### PR TITLE
Make FFI compatible with rustc 1.87

### DIFF
--- a/iceberg_rust_ffi/Cargo.lock
+++ b/iceberg_rust_ffi/Cargo.lock
@@ -1374,11 +1374,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1578,6 +1578,7 @@ dependencies = [
  "arrow-array",
  "arrow-ipc",
  "futures",
+ "home",
  "iceberg",
  "libc",
  "object_store_ffi",

--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -23,6 +23,9 @@ arrow-ipc = "56.2.0"
 tracing-subscriber = "0.3"
 tracing = "0.1"
 once_cell = "1.19"
+# Pin home to 0.5.9 to support rustc < 1.88
+# (0.5.11+ requires rustc 1.88+)
+home = "=0.5.9"
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
Yggdrasil doesn't have newer Rust, so the easiest solution is to pin problematic package that requires 1.88