### PR TITLE
Add table_file_row_counts API

### DIFF
--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -42,8 +42,8 @@ pub use catalog::{IcebergBoolResponse, IcebergCatalog, IcebergCatalogResponse};
 pub use full::IcebergScan;
 pub use incremental::{IcebergIncrementalScan, IcebergUnzippedStreamsResponse};
 pub use response::{
-    IcebergBoxedResponse, IcebergNestedStringListResponse, IcebergPropertyResponse,
-    IcebergStringListResponse,
+    IcebergBoxedResponse, IcebergFileRowCountResponse, IcebergNestedStringListResponse,
+    IcebergPropertyResponse, IcebergStringListResponse,
 };
 pub use table::{
     ArrowBatch, IcebergArrowStream, IcebergArrowStreamResponse, IcebergBatchResponse, IcebergTable,

--- a/iceberg_rust_ffi/src/response.rs
+++ b/iceberg_rust_ffi/src/response.rs
@@ -116,6 +116,63 @@ impl RawResponse for IcebergStringListResponse {
     }
 }
 
+/// Response type for file row count operations (parallel arrays of paths and counts)
+#[repr(C)]
+pub struct IcebergFileRowCountResponse {
+    pub result: CResult,
+    pub paths: *mut *mut c_char,
+    pub counts: *mut i64,
+    pub count: usize,
+    pub error_message: *mut c_char,
+    pub context: *const Context,
+}
+
+unsafe impl Send for IcebergFileRowCountResponse {}
+
+impl RawResponse for IcebergFileRowCountResponse {
+    type Payload = Vec<(String, i64)>;
+
+    fn result_mut(&mut self) -> &mut CResult {
+        &mut self.result
+    }
+
+    fn context_mut(&mut self) -> &mut *const Context {
+        &mut self.context
+    }
+
+    fn error_message_mut(&mut self) -> &mut *mut c_char {
+        &mut self.error_message
+    }
+
+    fn set_payload(&mut self, payload: Option<Self::Payload>) {
+        match payload {
+            Some(items) => {
+                let mut paths: Vec<*mut c_char> = Vec::with_capacity(items.len());
+                let mut counts: Vec<i64> = Vec::with_capacity(items.len());
+                for (path, count) in items {
+                    let c_string = std::ffi::CString::new(path).unwrap_or_default();
+                    paths.push(c_string.into_raw());
+                    counts.push(count);
+                }
+                self.count = paths.len();
+                // Use boxed slices so the pointer points directly to the array data,
+                // not to a Vec struct. This allows Julia to index the arrays directly.
+                let mut paths_slice = paths.into_boxed_slice();
+                let mut counts_slice = counts.into_boxed_slice();
+                self.paths = paths_slice.as_mut_ptr();
+                self.counts = counts_slice.as_mut_ptr();
+                std::mem::forget(paths_slice);
+                std::mem::forget(counts_slice);
+            }
+            None => {
+                self.paths = ptr::null_mut();
+                self.counts = ptr::null_mut();
+                self.count = 0;
+            }
+        }
+    }
+}
+
 /// Response type for nested string list operations (for namespace lists)
 #[repr(C)]
 pub struct IcebergNestedStringListResponse {

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -1,4 +1,4 @@
-use crate::response::IcebergBoxedResponse;
+use crate::response::{IcebergBoxedResponse, IcebergFileRowCountResponse};
 /// Table and streaming support for iceberg_rust_ffi
 use crate::{CResult, Context, RawResponse};
 use iceberg::io::{FileIOBuilder, OpenDalRoutingStorageFactory};
@@ -263,5 +263,52 @@ pub extern "C" fn iceberg_table_schema(table: *mut IcebergTable) -> *mut c_char 
             Err(_) => ptr::null_mut(),
         },
         Err(_) => ptr::null_mut(),
+    }
+}
+
+// Get per-file row counts for the current snapshot via plan_files()
+export_runtime_op!(
+    iceberg_table_file_row_counts,
+    IcebergFileRowCountResponse,
+    || {
+        let table_ref = unsafe { &*table };
+        let scan = table_ref.table.scan().build()?;
+        Ok(scan)
+    },
+    scan,
+    async {
+        use futures::TryStreamExt;
+        let mut stream = scan.plan_files().await?;
+        let mut result: Vec<(String, i64)> = Vec::new();
+        while let Some(task) = stream.try_next().await? {
+            let count = task.record_count.unwrap_or(0) as i64;
+            result.push((task.data_file_path().to_string(), count));
+        }
+        Ok::<Vec<(String, i64)>, anyhow::Error>(result)
+    },
+    table: *mut IcebergTable
+);
+
+/// Free the memory allocated by iceberg_table_file_row_counts
+#[no_mangle]
+pub extern "C" fn iceberg_file_row_counts_free(
+    paths: *mut *mut std::ffi::c_char,
+    counts: *mut i64,
+    count: usize,
+) {
+    if !paths.is_null() {
+        unsafe {
+            let paths_slice = Box::from_raw(std::slice::from_raw_parts_mut(paths, count));
+            for path in paths_slice.iter() {
+                if !path.is_null() {
+                    let _ = std::ffi::CString::from_raw(*path);
+                }
+            }
+        }
+    }
+    if !counts.is_null() {
+        unsafe {
+            let _ = Box::from_raw(std::slice::from_raw_parts_mut(counts, count));
+        }
     }
 }

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -13,7 +13,7 @@ export init_runtime
 export IcebergException
 export new_incremental_scan, free_incremental_scan!
 export table_open, free_table, new_scan, free_scan!
-export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_schema
+export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_schema, table_file_row_counts
 export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
 export with_file_column!, with_pos_column!
 export scan!, next_batch, free_batch, free_stream
@@ -503,6 +503,54 @@ function table_schema(table::Table)
     end
     result = unsafe_string(ptr)
     @ccall rust_lib.iceberg_destroy_cstring(ptr::Ptr{Cchar})::Cint
+    return result
+end
+
+mutable struct FileRowCountResponse
+    result::Cint
+    paths::Ptr{Ptr{Cchar}}
+    counts::Ptr{Int64}
+    count::Csize_t
+    error_message::Ptr{Cchar}
+    context::Ptr{Cvoid}
+
+    FileRowCountResponse() = new(-1, C_NULL, C_NULL, 0, C_NULL, C_NULL)
+end
+
+"""
+    table_file_row_counts(table::Table) -> Dict{String, Int64}
+
+Return the row count for each data file in the current snapshot of the table.
+
+The counts come from Iceberg manifest metadata and do not require reading any
+Parquet files.
+"""
+function table_file_row_counts(table::Table)
+    response = FileRowCountResponse()
+
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_table_file_row_counts(
+            table::Table,
+            response::Ref{FileRowCountResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+
+    @throw_on_error(response, "iceberg_table_file_row_counts", IcebergException)
+
+    result = Dict{String, Int64}()
+    for i in 1:response.count
+        path = unsafe_string(unsafe_load(response.paths, i))
+        count = unsafe_load(response.counts, i)
+        result[path] = count
+    end
+
+    @ccall rust_lib.iceberg_file_row_counts_free(
+        response.paths::Ptr{Ptr{Cchar}},
+        response.counts::Ptr{Int64},
+        response.count::Csize_t
+    )::Cvoid
+
     return result
 end
 

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -1223,3 +1223,24 @@ end
         end
     end
 end
+
+@testset "table_file_row_counts" begin
+    customer_path = "s3://warehouse/tpch.sf01/customer/metadata/00001-76f6e7e4-b34f-492f-b6a1-cc9f8c8f4975.metadata.json"
+
+    table = RustyIceberg.table_open(customer_path)
+    try
+        counts = RustyIceberg.table_file_row_counts(table)
+
+        # Should return a non-empty dict
+        @test counts isa Dict{String, Int64}
+
+        # Total row count should match known tpch sf01 customer table size (15000 rows). See
+        # assets/tpch/tpch.sf01/customer/metadata/01992e1d-25b3-7111-9dfc-38f55f99f91b-m0.avro
+        @test length(counts) == 1
+        @test collect(keys(counts)) == ["s3://warehouse/tpch.sf01/customer/data/data_customer-00000.parquet"]
+        @test collect(values(counts)) == [15000]
+
+    finally
+        RustyIceberg.free_table(table)
+    end
+end


### PR DESCRIPTION
## Summary

- Adds `iceberg_table_file_row_counts` FFI function that reads per-file row counts from Iceberg manifest metadata without reading any Parquet data files
- Adds Julia binding `table_file_row_counts(table) -> Dict{String, Int64}` mapping file paths to their row counts
- Uses boxed slices (not `Box<Vec>`) for the response arrays so Julia can index the data directly without indirecting through the Vec struct layout
- Adds a test verifying correctness against the known TPC-H SF0.1 customer table

## Test plan

- [ ] `make run-containers` to start MinIO + Polaris
- [ ] `make test-dev` — the new `table_file_row_counts` testset in `scan_tests.jl` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)