### PR TITLE
Add schema_from_table

### DIFF
--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -22,6 +22,7 @@ export Catalog, catalog_create_rest, free_catalog
 export load_table, list_tables, list_namespaces, table_exists, create_table, drop_table, drop_namespace, create_namespace
 export Field, Schema, PartitionField, PartitionSpec, SortField, SortOrder
 export SchemaBuilder, add_field, with_identifier, build
+export schema_from_table
 export schema_to_json, partition_spec_to_json, sort_order_to_json
 export iceberg_type_to_arrow_type, arrow_type, arrow_types, iceberg_column_type
 # Iceberg type system

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -629,3 +629,39 @@ Build the final Schema from the builder.
 function build(builder::SchemaBuilder)::Schema
     Schema(builder.fields; identifier_field_ids=builder.identifier_field_ids)
 end
+
+function _schema_from_json(json::String)::Schema
+    parsed = JSON.parse(json)
+    fields = Field[
+        Field(
+            Int32(f["id"]),
+            String(f["name"]),
+            String(f["type"]);
+            required = get(f, "required", false),
+            doc = get(f, "doc", nothing),
+        )
+        for f in parsed["fields"]
+    ]
+    identifier_field_ids = Int32[Int32(id) for id in get(parsed, "identifier-field-ids", [])]
+    return Schema(fields; identifier_field_ids=identifier_field_ids)
+end
+
+"""
+    schema_from_table(table::Table)::Schema
+
+Get the current schema of an Iceberg table as a `Schema` object.
+
+Parses the table's JSON schema and constructs a `Schema` with typed `Field` objects.
+
+# Example
+```julia
+table = table_open("s3://bucket/path/metadata/metadata.json")
+schema = schema_from_table(table)
+for field in schema.fields
+    println(field.name, ": ", field.type)
+end
+```
+"""
+function schema_from_table(table::Table)::Schema
+    return _schema_from_json(table_schema(table))
+end

--- a/test/schema_tests.jl
+++ b/test/schema_tests.jl
@@ -348,4 +348,79 @@ end
     end
 end
 
+@testset "schema_from_table" begin
+    @testset "basic round-trip" begin
+        original = Schema([
+            Field(Int32(1), "id", IcebergLong(); required=true),
+            Field(Int32(2), "name", IcebergString()),
+            Field(Int32(3), "amount", IcebergDecimal(38, 18)),
+        ])
+        schema = RustyIceberg._schema_from_json(schema_to_json(original))
+        @test length(schema.fields) == 3
+        @test schema.fields[1].id == Int32(1)
+        @test schema.fields[1].name == "id"
+        @test schema.fields[1].type isa IcebergLong
+        @test schema.fields[1].required == true
+        @test schema.fields[2].name == "name"
+        @test schema.fields[2].type isa IcebergString
+        @test schema.fields[2].required == false
+        @test schema.fields[3].type isa IcebergDecimal
+        @test schema.fields[3].type.precision == 38
+        @test schema.fields[3].type.scale == 18
+    end
+
+    @testset "identifier field IDs preserved" begin
+        original = Schema(
+            [Field(Int32(1), "id", IcebergLong(); required=true)];
+            identifier_field_ids=Int32[1]
+        )
+        schema = RustyIceberg._schema_from_json(schema_to_json(original))
+        @test schema.identifier_field_ids == Int32[1]
+    end
+
+    @testset "no identifier field IDs" begin
+        original = Schema([Field(Int32(1), "x", IcebergInt())])
+        schema = RustyIceberg._schema_from_json(schema_to_json(original))
+        @test isempty(schema.identifier_field_ids)
+    end
+
+    @testset "doc field preserved" begin
+        original = Schema([
+            Field(Int32(1), "ts", IcebergTimestamp(); doc="creation time"),
+        ])
+        schema = RustyIceberg._schema_from_json(schema_to_json(original))
+        @test schema.fields[1].doc == "creation time"
+    end
+
+    @testset "all primitive types round-trip" begin
+        fields = [
+            Field(Int32(1),  "a", IcebergBoolean()),
+            Field(Int32(2),  "b", IcebergInt()),
+            Field(Int32(3),  "c", IcebergLong()),
+            Field(Int32(4),  "d", IcebergFloat()),
+            Field(Int32(5),  "e", IcebergDouble()),
+            Field(Int32(6),  "f", IcebergDate()),
+            Field(Int32(7),  "g", IcebergTime()),
+            Field(Int32(8),  "h", IcebergTimestamp()),
+            Field(Int32(9),  "i", IcebergTimestamptz()),
+            Field(Int32(10), "j", IcebergTimestampNs()),
+            Field(Int32(11), "k", IcebergTimestamptzNs()),
+            Field(Int32(12), "l", IcebergString()),
+            Field(Int32(13), "m", IcebergUuid()),
+            Field(Int32(14), "n", IcebergBinary()),
+            Field(Int32(15), "o", IcebergDecimal(10, 2)),
+        ]
+        schema = RustyIceberg._schema_from_json(schema_to_json(Schema(fields)))
+        expected_types = [
+            IcebergBoolean, IcebergInt, IcebergLong, IcebergFloat, IcebergDouble,
+            IcebergDate, IcebergTime, IcebergTimestamp, IcebergTimestamptz,
+            IcebergTimestampNs, IcebergTimestamptzNs, IcebergString, IcebergUuid,
+            IcebergBinary, IcebergDecimal,
+        ]
+        for (field, T) in zip(schema.fields, expected_types)
+            @test field.type isa T
+        end
+    end
+end
+
 println("All schema tests passed!")


### PR DESCRIPTION
## Summary

- Adds `schema_from_table(table::Table)::Schema` to get a typed `Schema` object directly from an open table, without having to manually parse the JSON returned by `table_schema`
- Extracts the JSON parsing logic into a private `_schema_from_json` helper to keep things testable
- Adds unit tests covering field attributes, identifier field IDs, doc strings, and all primitive type round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)