### PR TITLE
Add in-memory catalog with pluggable storage

### DIFF
--- a/iceberg_rust_ffi/Cargo.lock
+++ b/iceberg_rust_ffi/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg_rust_ffi"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceberg_rust_ffi"
-version = "0.7.15"
+version = "0.7.16"
 edition = "2021"
 
 [lib]

--- a/iceberg_rust_ffi/src/catalog.rs
+++ b/iceberg_rust_ffi/src/catalog.rs
@@ -7,8 +7,9 @@ use crate::IcebergTable;
 use anyhow::Result;
 use async_trait::async_trait;
 use iceberg::io::{
-    LocalFsStorageFactory, MemoryStorageFactory, OpenDalRoutingStorageFactory,
-    RefreshableStorageFactory, StorageCredential, StorageCredentialsLoader, StorageFactory,
+    LocalFsStorageFactory, MemoryStorageFactory, OpenDalStorageFactory,
+    OpenDalRoutingStorageFactory, RefreshableStorageFactory, StorageCredential,
+    StorageCredentialsLoader, StorageFactory,
 };
 use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
 use iceberg::{Catalog, CatalogBuilder, Error, ErrorKind, NamespaceIdent, TableIdent};
@@ -276,7 +277,15 @@ impl IcebergCatalog {
     ) -> Result<Self> {
         let factory: Arc<dyn StorageFactory> =
             if warehouse.starts_with("s3://") || warehouse.starts_with("s3a://") {
-                Arc::new(OpenDalRoutingStorageFactory)
+                // OpenDalRoutingStorageFactory requires PROP_METADATA_LOCATION in the
+                // StorageConfig at build() time, but MemoryCatalog builds its FileIO once
+                // at construction time (before any table exists). Use the pre-configured
+                // S3 variant instead, which reads credentials from catalog props directly.
+                let scheme = if warehouse.starts_with("s3a://") { "s3a" } else { "s3" };
+                Arc::new(OpenDalStorageFactory::S3 {
+                    configured_scheme: scheme.to_string(),
+                    customized_credential_load: None,
+                })
             } else if warehouse == "memory" {
                 Arc::new(MemoryStorageFactory)
             } else {

--- a/iceberg_rust_ffi/src/catalog.rs
+++ b/iceberg_rust_ffi/src/catalog.rs
@@ -174,6 +174,11 @@ impl StorageCredentialsLoader for RestCredentialsLoader {
 /// in the `Rest` arm lets us call REST-only methods (vended credentials, token
 /// invalidation) without a downcast while still exposing a `&dyn Catalog` for
 /// all generic operations.
+///
+/// Both arms wrap their catalog in an `Arc` so the value can be shared safely
+/// across async tasks spawned by the Tokio runtime (e.g. credential loaders
+/// that hold a `Weak<RestCatalog>`). Without `Arc` the catalog would need to
+/// be `'static` or cloned on every async boundary.
 enum CatalogKind {
     Rest(Arc<RestCatalog>),
     Memory(Arc<dyn Catalog>),
@@ -183,6 +188,11 @@ enum CatalogKind {
 /// Stores the catalog backend plus any pre-creation configuration (authenticator,
 /// credentials-loader flag).
 pub struct IcebergCatalog {
+    /// `None` while the catalog is being configured (before `create_rest` /
+    /// `create_memory` is called). Using `Option` here rather than adding an
+    /// `Uninitialized` variant to `CatalogKind` keeps the enum focused on
+    /// actual backends and lets the compiler enforce exhaustive matching on
+    /// only the meaningful states.
     kind: Option<CatalogKind>,
     /// Stores a pending authenticator to be applied before first use
     authenticator: Option<Arc<FFITokenAuthenticator>>,

--- a/iceberg_rust_ffi/src/catalog.rs
+++ b/iceberg_rust_ffi/src/catalog.rs
@@ -257,27 +257,38 @@ impl IcebergCatalog {
         Ok(self)
     }
 
-    /// Create and initialize a memory catalog backed by local-filesystem or
-    /// in-process memory storage.
+    /// Create and initialize a memory catalog with pluggable file storage.
     ///
-    /// `warehouse` is the root path / URI prefix used to derive table locations:
-    /// - For `use_local_fs = true`: a real filesystem path such as `/tmp/warehouse`.
-    ///   Table metadata and data files are written to disk.
-    /// - For `use_local_fs = false`: any string (e.g. `"memory"`). Everything is
-    ///   held in RAM and lost when the catalog is freed.
-    pub async fn create_memory(mut self, warehouse: String, use_local_fs: bool) -> Result<Self> {
-        let factory: Arc<dyn StorageFactory> = if use_local_fs {
-            Arc::new(LocalFsStorageFactory)
-        } else {
-            Arc::new(MemoryStorageFactory)
-        };
+    /// The storage backend is inferred from `warehouse`:
+    ///
+    /// - `"memory"` — everything (metadata + Parquet) lives in RAM.
+    ///   Lost when the catalog is freed. Good for unit tests.
+    /// - `"s3://…"` / `"s3a://…"` — table files are written to S3 (or any
+    ///   S3-compatible store). Credentials are passed in `props` using the
+    ///   standard keys (`s3.access-key-id`, `s3.region`, etc.).
+    ///   The catalog registry still lives in RAM.
+    /// - Any other string (local path) — table files are written to the
+    ///   local filesystem at that path. The catalog registry lives in RAM.
+    pub async fn create_memory(
+        mut self,
+        warehouse: String,
+        props: HashMap<String, String>,
+    ) -> Result<Self> {
+        let factory: Arc<dyn StorageFactory> =
+            if warehouse.starts_with("s3://") || warehouse.starts_with("s3a://") {
+                Arc::new(OpenDalRoutingStorageFactory)
+            } else if warehouse == "memory" {
+                Arc::new(MemoryStorageFactory)
+            } else {
+                Arc::new(LocalFsStorageFactory)
+            };
+
+        let mut catalog_props = props;
+        catalog_props.insert(MEMORY_CATALOG_WAREHOUSE.to_string(), warehouse);
 
         let catalog = MemoryCatalogBuilder::default()
             .with_storage_factory(factory)
-            .load(
-                "memory",
-                HashMap::from([(MEMORY_CATALOG_WAREHOUSE.to_string(), warehouse)]),
-            )
+            .load("memory", catalog_props)
             .await?;
 
         self.kind = Some(CatalogKind::Memory(Arc::new(catalog)));
@@ -878,7 +889,11 @@ export_runtime_op!(
     catalog: *mut IcebergCatalog
 );
 
-// Create a memory catalog (in-process state, local-fs or in-memory file storage)
+// Create a memory catalog.
+// Storage backend is inferred from warehouse_path:
+//   "memory"      → in-process HashMap (everything in RAM)
+//   "s3://…"      → S3-compatible object store (credentials via properties)
+//   anything else → local filesystem at that path
 export_runtime_op!(
     iceberg_memory_catalog_create,
     IcebergCatalogResponse,
@@ -889,16 +904,16 @@ export_runtime_op!(
         // SAFETY: catalog was checked to be non-null above and came from Box::into_raw
         let catalog = unsafe { Box::from_raw(catalog) };
         let warehouse = parse_c_string(warehouse_path, "warehouse_path")?;
-        let storage = parse_c_string(storage_type, "storage_type")?;
-        let use_local_fs = storage != "memory";
-        Ok((*catalog, warehouse, use_local_fs))
+        let props = parse_properties(properties, properties_len)?;
+        Ok((*catalog, warehouse, props))
     },
     args,
     async {
-        let (catalog, warehouse, use_local_fs) = args;
-        catalog.create_memory(warehouse, use_local_fs).await
+        let (catalog, warehouse, props) = args;
+        catalog.create_memory(warehouse, props).await
     },
     catalog: *mut IcebergCatalog,
     warehouse_path: *const c_char,
-    storage_type: *const c_char
+    properties: *const PropertyEntry,
+    properties_len: usize
 );

--- a/iceberg_rust_ffi/src/catalog.rs
+++ b/iceberg_rust_ffi/src/catalog.rs
@@ -7,9 +7,10 @@ use crate::IcebergTable;
 use anyhow::Result;
 use async_trait::async_trait;
 use iceberg::io::{
-    OpenDalRoutingStorageFactory, RefreshableStorageFactory, StorageCredential,
-    StorageCredentialsLoader, StorageFactory,
+    LocalFsStorageFactory, MemoryStorageFactory, OpenDalRoutingStorageFactory,
+    RefreshableStorageFactory, StorageCredential, StorageCredentialsLoader, StorageFactory,
 };
+use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
 use iceberg::{Catalog, CatalogBuilder, Error, ErrorKind, NamespaceIdent, TableIdent};
 use iceberg_catalog_rest::{CustomAuthenticator, RestCatalog, RestCatalogBuilder};
 use std::collections::HashMap;
@@ -168,11 +169,20 @@ impl StorageCredentialsLoader for RestCredentialsLoader {
     }
 }
 
-/// Opaque catalog handle for FFI
-/// Stores a RestCatalog instance wrapped in an Arc for safe memory management.
-/// Also stores the authenticator to allow setting it before catalog creation.
+/// Discriminates between catalog backends. Carrying the concrete `RestCatalog`
+/// in the `Rest` arm lets us call REST-only methods (vended credentials, token
+/// invalidation) without a downcast while still exposing a `&dyn Catalog` for
+/// all generic operations.
+enum CatalogKind {
+    Rest(Arc<RestCatalog>),
+    Memory(Arc<dyn Catalog>),
+}
+
+/// Opaque catalog handle for FFI.
+/// Stores the catalog backend plus any pre-creation configuration (authenticator,
+/// credentials-loader flag).
 pub struct IcebergCatalog {
-    catalog: Option<Arc<RestCatalog>>,
+    kind: Option<CatalogKind>,
     /// Stores a pending authenticator to be applied before first use
     authenticator: Option<Arc<FFITokenAuthenticator>>,
     /// Whether to attach a storage credentials loader after catalog creation
@@ -190,7 +200,7 @@ unsafe impl Sync for IcebergCatalog {}
 impl Default for IcebergCatalog {
     fn default() -> Self {
         IcebergCatalog {
-            catalog: None,
+            kind: None,
             authenticator: None,
             use_credentials_loader: false,
         }
@@ -242,8 +252,35 @@ impl IcebergCatalog {
             )
         };
 
-        self.catalog = Some(catalog_arc);
+        self.kind = Some(CatalogKind::Rest(catalog_arc));
 
+        Ok(self)
+    }
+
+    /// Create and initialize a memory catalog backed by local-filesystem or
+    /// in-process memory storage.
+    ///
+    /// `warehouse` is the root path / URI prefix used to derive table locations:
+    /// - For `use_local_fs = true`: a real filesystem path such as `/tmp/warehouse`.
+    ///   Table metadata and data files are written to disk.
+    /// - For `use_local_fs = false`: any string (e.g. `"memory"`). Everything is
+    ///   held in RAM and lost when the catalog is freed.
+    pub async fn create_memory(mut self, warehouse: String, use_local_fs: bool) -> Result<Self> {
+        let factory: Arc<dyn StorageFactory> = if use_local_fs {
+            Arc::new(LocalFsStorageFactory)
+        } else {
+            Arc::new(MemoryStorageFactory)
+        };
+
+        let catalog = MemoryCatalogBuilder::default()
+            .with_storage_factory(factory)
+            .load(
+                "memory",
+                HashMap::from([(MEMORY_CATALOG_WAREHOUSE.to_string(), warehouse)]),
+            )
+            .await?;
+
+        self.kind = Some(CatalogKind::Memory(Arc::new(catalog)));
         Ok(self)
     }
 
@@ -265,21 +302,31 @@ impl IcebergCatalog {
         Ok(())
     }
 
-    /// Get a reference to the underlying RestCatalog.
-    ///
-    /// Returns a reference to the catalog.
-    /// Panics if the catalog has not been initialized via create_rest.
-    fn as_ref(&self) -> &RestCatalog {
-        self.catalog
-            .as_ref()
-            .expect("catalog should be initialized")
+    /// Returns a `&dyn Catalog` for generic operations. Panics if not initialized.
+    fn as_ref(&self) -> &dyn Catalog {
+        match self.kind.as_ref().expect("catalog should be initialized") {
+            CatalogKind::Rest(c) => c.as_ref(),
+            CatalogKind::Memory(c) => c.as_ref(),
+        }
     }
 
-    /// Get a reference to the underlying RestCatalog for transaction commit.
-    ///
-    /// Returns Some(&RestCatalog) if initialized, None otherwise.
-    pub fn get_catalog(&self) -> Option<&RestCatalog> {
-        self.catalog.as_deref()
+    /// Returns `&RestCatalog` for REST-only operations. Errors for other backends.
+    fn as_rest_ref(&self) -> Result<&RestCatalog> {
+        match self.kind.as_ref() {
+            Some(CatalogKind::Rest(c)) => Ok(c.as_ref()),
+            Some(CatalogKind::Memory(_)) => Err(anyhow::anyhow!(
+                "This operation is only supported by REST catalogs"
+            )),
+            None => Err(anyhow::anyhow!("Catalog not initialized")),
+        }
+    }
+
+    /// Returns `&dyn Catalog` for use in transaction commits. None if not initialized.
+    pub fn get_catalog(&self) -> Option<&dyn Catalog> {
+        self.kind.as_ref().map(|k| match k {
+            CatalogKind::Rest(c) => c.as_ref() as &dyn Catalog,
+            CatalogKind::Memory(c) => c.as_ref(),
+        })
     }
 
     /// Load a table by namespace and name
@@ -304,7 +351,7 @@ impl IcebergCatalog {
         let namespace = NamespaceIdent::from_vec(namespace_parts)?;
         let table_ident = TableIdent::new(namespace, table_name);
         let table = self
-            .as_ref()
+            .as_rest_ref()?
             .load_table_with_credentials(&table_ident)
             .await?;
 
@@ -381,7 +428,7 @@ impl IcebergCatalog {
 
         // Call the appropriate catalog method based on load_credentials flag
         let table = if load_credentials {
-            self.as_ref()
+            self.as_rest_ref()?
                 .create_table_with_credentials(&namespace_ident, table_creation)
                 .await?
         } else {
@@ -823,10 +870,35 @@ export_runtime_op!(
     },
     catalog_ref,
     async {
-        if let Some(cat) = &catalog_ref.catalog {
+        if let Some(CatalogKind::Rest(cat)) = &catalog_ref.kind {
             cat.invalidate_token().await?;
         }
         Ok::<bool, anyhow::Error>(true)
     },
     catalog: *mut IcebergCatalog
+);
+
+// Create a memory catalog (in-process state, local-fs or in-memory file storage)
+export_runtime_op!(
+    iceberg_memory_catalog_create,
+    IcebergCatalogResponse,
+    || {
+        if catalog.is_null() {
+            return Err(anyhow::anyhow!("Null catalog pointer provided"));
+        }
+        // SAFETY: catalog was checked to be non-null above and came from Box::into_raw
+        let catalog = unsafe { Box::from_raw(catalog) };
+        let warehouse = parse_c_string(warehouse_path, "warehouse_path")?;
+        let storage = parse_c_string(storage_type, "storage_type")?;
+        let use_local_fs = storage != "memory";
+        Ok((*catalog, warehouse, use_local_fs))
+    },
+    args,
+    async {
+        let (catalog, warehouse, use_local_fs) = args;
+        catalog.create_memory(warehouse, use_local_fs).await
+    },
+    catalog: *mut IcebergCatalog,
+    warehouse_path: *const c_char,
+    storage_type: *const c_char
 );

--- a/iceberg_rust_ffi/src/catalog.rs
+++ b/iceberg_rust_ffi/src/catalog.rs
@@ -7,9 +7,9 @@ use crate::IcebergTable;
 use anyhow::Result;
 use async_trait::async_trait;
 use iceberg::io::{
-    LocalFsStorageFactory, MemoryStorageFactory, OpenDalStorageFactory,
-    OpenDalRoutingStorageFactory, RefreshableStorageFactory, StorageCredential,
-    StorageCredentialsLoader, StorageFactory,
+    LocalFsStorageFactory, MemoryStorageFactory, OpenDalRoutingStorageFactory,
+    OpenDalStorageFactory, RefreshableStorageFactory, StorageCredential, StorageCredentialsLoader,
+    StorageFactory,
 };
 use iceberg::memory::{MemoryCatalogBuilder, MEMORY_CATALOG_WAREHOUSE};
 use iceberg::{Catalog, CatalogBuilder, Error, ErrorKind, NamespaceIdent, TableIdent};
@@ -281,7 +281,11 @@ impl IcebergCatalog {
                 // StorageConfig at build() time, but MemoryCatalog builds its FileIO once
                 // at construction time (before any table exists). Use the pre-configured
                 // S3 variant instead, which reads credentials from catalog props directly.
-                let scheme = if warehouse.starts_with("s3a://") { "s3a" } else { "s3" };
+                let scheme = if warehouse.starts_with("s3a://") {
+                    "s3a"
+                } else {
+                    "s3"
+                };
                 Arc::new(OpenDalStorageFactory::S3 {
                     configured_scheme: scheme.to_string(),
                     customized_credential_load: None,

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -18,7 +18,7 @@ export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, wit
 export with_file_column!, with_pos_column!
 export scan!, next_batch, free_batch, free_stream
 export FILE_COLUMN, POS_COLUMN
-export Catalog, catalog_create_rest, free_catalog
+export Catalog, catalog_create_rest, catalog_create_memory, free_catalog!
 export load_table, list_tables, list_namespaces, table_exists, create_table, drop_table, drop_namespace, create_namespace
 export Field, Schema, PartitionField, PartitionSpec, SortField, SortOrder
 export SchemaBuilder, add_field, with_identifier, build

--- a/src/catalog.jl
+++ b/src/catalog.jl
@@ -1,8 +1,72 @@
-"""
-Catalog support for RustyIceberg.jl
-
-This module provides Julia wrappers for the REST catalog FFI functions.
-"""
+# Catalog support for RustyIceberg.jl
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Catalog modes and where files live
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Apache Iceberg separates two concerns:
+#
+#   • The *catalog registry* — the in-memory or server-side index that maps
+#     (namespace, table-name) → table metadata location.
+#
+#   • *Table files* — the actual data that makes up an Iceberg table:
+#       - Metadata files  (.metadata.json, snapshot manifests, manifest lists)
+#       - Data files      (Parquet files written by the writer)
+#
+# RustyIceberg.jl exposes three catalog constructors, each with different
+# durability characteristics:
+#
+# ┌──────────────────────────────┬─────────────────┬─────────────────────────┐
+# │ Constructor                  │ Registry lives  │ Table files live        │
+# ├──────────────────────────────┼─────────────────┼─────────────────────────┤
+# │ catalog_create_rest(uri)     │ REST server     │ object store (S3, ADLS, │
+# │                              │ (durable,       │ GCS, …) — durable,      │
+# │                              │ shareable)      │ shareable               │
+# ├──────────────────────────────┼─────────────────┼─────────────────────────┤
+# │ catalog_create_memory(path)  │ RAM (this       │ local filesystem —      │
+# │   where path is a local      │ process only,   │ durable within the host,│
+# │   filesystem path            │ lost on exit)   │ single-machine only     │
+# ├──────────────────────────────┼─────────────────┼─────────────────────────┤
+# │ catalog_create_memory("s3://…│ RAM (this       │ S3 (or compatible)  —   │
+# │   …bucket/prefix")           │ process only,   │ durable, shareable;     │
+# │                              │ lost on exit)   │ no catalog server needed│
+# ├──────────────────────────────┼─────────────────┼─────────────────────────┤
+# │ catalog_create_memory(       │ RAM             │ RAM — everything lost   │
+# │   "memory")                  │                 │ on process exit; good   │
+# │                              │                 │ for unit tests only     │
+# └──────────────────────────────┴─────────────────┴─────────────────────────┘
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Choosing a mode
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# REST catalog (catalog_create_rest)
+#   The production choice. The registry is held by a server (e.g. Polaris,
+#   Nessie, Unity) so multiple processes can share it and it survives restarts.
+#   Table files go to whatever object store the server is configured for.
+#   Requires a running catalog server.
+#
+# Memory catalog + local filesystem (catalog_create_memory("/some/path"))
+#   Useful for local development and integration tests that need real file I/O
+#   but don't want a server. The registry is lost when the catalog is freed, but
+#   the Parquet files and metadata JSON are persisted on disk. A table can be
+#   re-opened later via table_open(metadata_json_path) even after the catalog
+#   is gone.
+#
+# Memory catalog + S3 (catalog_create_memory("s3://bucket/prefix"))
+#   Fills the gap for jobs that need to write Iceberg tables to S3 without
+#   running a catalog server. The registry lives in RAM for the duration of
+#   the process, but all metadata and Parquet files are written to S3 and
+#   remain there after the process exits. Downstream consumers can read tables
+#   via table_open("s3://bucket/prefix/.../metadata.json"). S3 credentials are
+#   passed via the `properties` keyword argument using the same keys accepted
+#   by catalog_create_rest ("s3.access-key-id", "s3.region", etc.).
+#
+# Memory catalog + in-process memory (catalog_create_memory("memory"))
+#   Everything, including Parquet bytes, lives in a HashMap in RAM. Nothing
+#   survives process exit. Use this for fast, hermetic unit tests that do not
+#   need durable storage.
+#
 
 # Token callback function that can be exported as C-callable with token caching support
 # This is a static function (no closure) that takes auth_fn and extracts the authenticator
@@ -307,45 +371,68 @@ function catalog_create_rest(
 end
 
 """
-    catalog_create_memory(warehouse_path::String; storage::Symbol=:local)::Catalog
+    catalog_create_memory(
+        warehouse_path::String;
+        properties::Dict{String,String}=Dict{String,String}()
+    )::Catalog
 
 Create an in-memory Iceberg catalog.
 
-The catalog registry (which namespaces and tables exist) always lives in memory
-and is lost when the catalog is freed. What varies is where the actual table
-files (metadata JSON, Parquet) go:
+The catalog registry (which namespaces and tables exist) always lives in RAM
+and is lost when the catalog is freed. The storage backend for actual table
+files (metadata JSON, Parquet) is inferred from `warehouse_path`:
 
-- `storage=:local` (default): files are written to `warehouse_path` on the local
-  filesystem. They persist after the catalog is freed.
-- `storage=:memory`: files are stored in RAM alongside the registry. Everything
-  is lost when the catalog is freed. Useful for unit tests.
+- Local filesystem path (e.g. `"/tmp/warehouse"`): files are written to disk
+  and persist after the catalog is freed.
+- S3 URI (e.g. `"s3://bucket/prefix"`): files are written to S3 and persist
+  after the catalog is freed. Pass S3 credentials via `properties` using the
+  standard keys (`"s3.access-key-id"`, `"s3.secret-access-key"`, `"s3.region"`,
+  `"s3.endpoint"`, etc.). If omitted, credentials are read from the environment.
+- `"memory"`: files are stored in RAM alongside the registry. Everything is
+  lost when the catalog is freed. Useful for unit tests.
 
 # Example
 ```julia
-# Persist table files to disk
+# Persist table files to local disk
 catalog = catalog_create_memory("/tmp/my_warehouse")
 
-# Fully ephemeral — good for tests
-catalog = catalog_create_memory("memory"; storage=:memory)
+# Write table files to S3 (credentials from environment)
+catalog = catalog_create_memory("s3://my-bucket/warehouse")
+
+# Write table files to S3 with explicit credentials
+catalog = catalog_create_memory(
+    "s3://my-bucket/warehouse";
+    properties=Dict(
+        "s3.access-key-id"     => "...",
+        "s3.secret-access-key" => "...",
+        "s3.region"            => "us-east-1",
+    )
+)
+
+# Fully ephemeral — good for unit tests
+catalog = catalog_create_memory("memory")
 ```
 """
 function catalog_create_memory(
     warehouse_path::String;
-    storage::Symbol=:local,
+    properties::Dict{String,String}=Dict{String,String}(),
 )::Catalog
     catalog_ptr = @ccall rust_lib.iceberg_catalog_init()::Ptr{Cvoid}
     if catalog_ptr == C_NULL
         throw(IcebergException("Failed to create empty catalog"))
     end
 
-    storage_str = storage == :memory ? "memory" : "local"
+    property_entries = [PropertyEntry(pointer(k), pointer(v)) for (k, v) in properties]
+    properties_len = length(property_entries)
+
     response = CatalogResponse()
 
-    async_ccall(response) do handle
+    async_ccall(response, property_entries, properties) do handle
         @ccall rust_lib.iceberg_memory_catalog_create(
             catalog_ptr::Ptr{Cvoid},
             warehouse_path::Cstring,
-            storage_str::Cstring,
+            (properties_len > 0 ? pointer(property_entries) : C_NULL)::Ptr{PropertyEntry},
+            properties_len::Csize_t,
             response::Ref{CatalogResponse},
             handle::Ptr{Cvoid}
         )::Cint

--- a/src/catalog.jl
+++ b/src/catalog.jl
@@ -61,6 +61,9 @@
 #   via table_open("s3://bucket/prefix/.../metadata.json"). S3 credentials are
 #   passed via the `properties` keyword argument using the same keys accepted
 #   by catalog_create_rest ("s3.access-key-id", "s3.region", etc.).
+#   Note: uses a pre-configured S3 storage factory (not the routing factory),
+#   because MemoryCatalog builds its FileIO once at construction time — before
+#   any table location is known — so the routing factory cannot be used here.
 #
 # Memory catalog + in-process memory (catalog_create_memory("memory"))
 #   Everything, including Parquet bytes, lives in a HashMap in RAM. Nothing

--- a/src/catalog.jl
+++ b/src/catalog.jl
@@ -307,6 +307,55 @@ function catalog_create_rest(
 end
 
 """
+    catalog_create_memory(warehouse_path::String; storage::Symbol=:local)::Catalog
+
+Create an in-memory Iceberg catalog.
+
+The catalog registry (which namespaces and tables exist) always lives in memory
+and is lost when the catalog is freed. What varies is where the actual table
+files (metadata JSON, Parquet) go:
+
+- `storage=:local` (default): files are written to `warehouse_path` on the local
+  filesystem. They persist after the catalog is freed.
+- `storage=:memory`: files are stored in RAM alongside the registry. Everything
+  is lost when the catalog is freed. Useful for unit tests.
+
+# Example
+```julia
+# Persist table files to disk
+catalog = catalog_create_memory("/tmp/my_warehouse")
+
+# Fully ephemeral — good for tests
+catalog = catalog_create_memory("memory"; storage=:memory)
+```
+"""
+function catalog_create_memory(
+    warehouse_path::String;
+    storage::Symbol=:local,
+)::Catalog
+    catalog_ptr = @ccall rust_lib.iceberg_catalog_init()::Ptr{Cvoid}
+    if catalog_ptr == C_NULL
+        throw(IcebergException("Failed to create empty catalog"))
+    end
+
+    storage_str = storage == :memory ? "memory" : "local"
+    response = CatalogResponse()
+
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_memory_catalog_create(
+            catalog_ptr::Ptr{Cvoid},
+            warehouse_path::Cstring,
+            storage_str::Cstring,
+            response::Ref{CatalogResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+
+    @throw_on_error(response, "catalog_create_memory", IcebergException)
+    return Catalog(response.value, nothing)
+end
+
+"""
     free_catalog!(catalog::Catalog)
 
 Free the memory associated with a catalog.

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -72,7 +72,7 @@ end
     end
 
     @testset "memory storage" begin
-        cat = catalog_create_memory("memory"; storage=:memory)
+        cat = catalog_create_memory("memory")
         try
             @test cat isa Catalog
 
@@ -156,8 +156,72 @@ end
         end
     end
 
+    @testset "S3 storage write and read roundtrip" begin
+        without_aws_env() do
+            s3 = get_s3_config()
+            # Use a unique prefix per test run to avoid cross-test interference
+            warehouse = "s3://warehouse/memory-catalog-test-$(round(Int, time() * 1000))"
+            props = Dict(
+                "s3.endpoint"          => s3["endpoint"],
+                "s3.access-key-id"     => s3["access_key_id"],
+                "s3.secret-access-key" => s3["secret_access_key"],
+                "s3.region"            => s3["region"],
+                "s3.path-style-access" => "true",
+            )
+            cat = catalog_create_memory(warehouse; properties=props)
+            table = C_NULL
+            updated_table = C_NULL
+            data_files = nothing
+            try
+                @test cat isa Catalog
+
+                create_namespace(cat, ["ns"])
+                schema = Schema([
+                    Field(Int32(1), "id",    IcebergLong();   required=true),
+                    Field(Int32(2), "name",  IcebergString(); required=false),
+                    Field(Int32(3), "value", IcebergDouble(); required=false),
+                ])
+                table = create_table(cat, ["ns"], "s3_roundtrip", schema)
+                @test table != C_NULL
+
+                # Write data
+                data_files = RustyIceberg.with_data_file_writer(table) do writer
+                    write(writer, (
+                        id    = Int64[10, 20, 30],
+                        name  = ["x", "y", "z"],
+                        value = [1.5, 2.5, 3.5],
+                    ))
+                end
+                @test data_files !== nothing
+
+                updated_table = RustyIceberg.with_transaction(table, cat) do tx
+                    RustyIceberg.with_fast_append(tx) do action
+                        RustyIceberg.add_data_files(action, data_files)
+                    end
+                end
+
+                # Read back and verify
+                tbl = read_table_data(updated_table)
+                @test tbl !== nothing
+                sorted = sort(collect(zip(tbl.id, tbl.name, tbl.value)))
+                @test length(sorted) == 3
+                @test sorted[1] == (10, "x", 1.5)
+                @test sorted[2] == (20, "y", 2.5)
+                @test sorted[3] == (30, "z", 3.5)
+            finally
+                if updated_table != C_NULL
+                    free_table(updated_table)
+                end
+                if table != C_NULL
+                    free_table(table)
+                end
+                free_catalog!(cat)
+            end
+        end
+    end
+
     @testset "REST-only operations throw on memory catalog" begin
-        cat = catalog_create_memory("memory"; storage=:memory)
+        cat = catalog_create_memory("memory")
         try
             create_namespace(cat, ["ns"])
             create_table(cat, ["ns"], "t", _simple_schema())

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -7,6 +7,173 @@ using JSON
 using Base64
 using RustyIceberg: Field, Schema, PartitionSpec, SortOrder, PartitionField
 
+# ---------------------------------------------------------------------------
+# Memory catalog tests — run without Docker or S3
+# ---------------------------------------------------------------------------
+
+function _simple_schema()
+    Schema([
+        Field(Int32(1), "id",   IcebergLong();   required=true),
+        Field(Int32(2), "name", IcebergString(); required=false),
+    ])
+end
+
+@testset "Memory Catalog" begin
+    @testset "local-fs storage" begin
+        mktempdir() do warehouse
+            cat = catalog_create_memory(warehouse)
+            try
+                @test cat isa Catalog
+                @test cat.ptr != C_NULL
+
+                # Namespace operations
+                create_namespace(cat, ["ns1"])
+                ns = list_namespaces(cat)
+                @test [["ns1"]] == ns
+
+                # Table operations
+                schema = _simple_schema()
+                tbl = create_table(cat, ["ns1"], "events", schema)
+                @test tbl != C_NULL
+
+                @test list_tables(cat, ["ns1"]) == ["events"]
+                @test table_exists(cat, ["ns1"], "events") == true
+                @test table_exists(cat, ["ns1"], "nope")   == false
+
+                # Schema round-trip via schema_from_table
+                s = schema_from_table(tbl)
+                @test length(s.fields) == 2
+                @test s.fields[1].name == "id"
+                @test s.fields[1].type isa IcebergLong
+                @test s.fields[1].required == true
+                @test s.fields[2].name == "name"
+                @test s.fields[2].type isa IcebergString
+
+                # Load table from catalog
+                tbl2 = load_table(cat, ["ns1"], "events")
+                @test tbl2 != C_NULL
+
+                # Metadata files actually on disk
+                @test isdir(warehouse)
+                @test !isempty(readdir(warehouse))
+
+                # Drop table
+                drop_table(cat, ["ns1"], "events")
+                @test table_exists(cat, ["ns1"], "events") == false
+                @test list_tables(cat, ["ns1"]) == String[]
+
+                # Drop namespace
+                drop_namespace(cat, ["ns1"])
+                @test list_namespaces(cat) == Vector{String}[]
+            finally
+                free_catalog!(cat)
+            end
+        end
+    end
+
+    @testset "memory storage" begin
+        cat = catalog_create_memory("memory"; storage=:memory)
+        try
+            @test cat isa Catalog
+
+            create_namespace(cat, ["ns"])
+            create_table(cat, ["ns"], "t", _simple_schema())
+            @test table_exists(cat, ["ns"], "t") == true
+        finally
+            free_catalog!(cat)
+        end
+    end
+
+    @testset "multiple namespaces and tables" begin
+        mktempdir() do warehouse
+            cat = catalog_create_memory(warehouse)
+            try
+                create_namespace(cat, ["a"])
+                create_namespace(cat, ["b"])
+                @test sort(list_namespaces(cat)) == [["a"], ["b"]]
+
+                create_table(cat, ["a"], "t1", _simple_schema())
+                create_table(cat, ["a"], "t2", _simple_schema())
+                create_table(cat, ["b"], "t3", _simple_schema())
+
+                @test sort(list_tables(cat, ["a"])) == ["t1", "t2"]
+                @test list_tables(cat, ["b"])       == ["t3"]
+            finally
+                free_catalog!(cat)
+            end
+        end
+    end
+
+    @testset "write and read roundtrip" begin
+        mktempdir() do warehouse
+            cat = catalog_create_memory(warehouse)
+            table = C_NULL
+            updated_table = C_NULL
+            data_files = nothing
+            try
+                create_namespace(cat, ["ns"])
+                schema = Schema([
+                    Field(Int32(1), "id",    IcebergLong();   required=true),
+                    Field(Int32(2), "name",  IcebergString(); required=false),
+                    Field(Int32(3), "value", IcebergDouble(); required=false),
+                ])
+                table = create_table(cat, ["ns"], "roundtrip", schema)
+                @test table != C_NULL
+
+                # Write data
+                data_files = RustyIceberg.with_data_file_writer(table) do writer
+                    write(writer, (
+                        id    = Int64[1, 2, 3],
+                        name  = ["alice", "bob", "carol"],
+                        value = [1.1, 2.2, 3.3],
+                    ))
+                end
+                @test data_files !== nothing
+
+                updated_table = RustyIceberg.with_transaction(table, cat) do tx
+                    RustyIceberg.with_fast_append(tx) do action
+                        RustyIceberg.add_data_files(action, data_files)
+                    end
+                end
+
+                # Read back and verify
+                tbl = read_table_data(updated_table)
+                @test tbl !== nothing
+                sorted = sort(collect(zip(tbl.id, tbl.name, tbl.value)))
+                @test length(sorted) == 3
+                @test sorted[1] == (1, "alice", 1.1)
+                @test sorted[2] == (2, "bob",   2.2)
+                @test sorted[3] == (3, "carol",  3.3)
+            finally
+                if updated_table != C_NULL
+                    free_table(updated_table)
+                end
+                if table != C_NULL
+                    free_table(table)
+                end
+                free_catalog!(cat)
+            end
+        end
+    end
+
+    @testset "REST-only operations throw on memory catalog" begin
+        cat = catalog_create_memory("memory"; storage=:memory)
+        try
+            create_namespace(cat, ["ns"])
+            create_table(cat, ["ns"], "t", _simple_schema())
+
+            @test_throws RustyIceberg.IcebergException load_table(
+                cat, ["ns"], "t"; load_credentials=true
+            )
+            @test_throws RustyIceberg.IcebergException create_table(
+                cat, ["ns"], "t2", _simple_schema(); load_credentials=true
+            )
+        finally
+            free_catalog!(cat)
+        end
+    end
+end
+
 @testset "Catalog API" begin
     println("Testing catalog API...")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using RustyIceberg
 using DataFrames
 using Arrow
+using Tables
 using FunctionWrappers: FunctionWrapper
 using HTTP
 using JSON


### PR DESCRIPTION
## Summary

- Adds `catalog_create_memory(warehouse; properties=...)` to the Julia API, backed by iceberg-rust's `MemoryCatalog`
- Storage backend is inferred from the warehouse string — no separate `storage` kwarg needed:
  - `"memory"` → everything in RAM (good for unit tests)
  - `"s3://bucket/prefix"` → S3-backed files, registry in RAM (write to S3 without a catalog server)
  - local path → files on local disk, registry in RAM
- S3 credentials are passed via the `properties` kwarg using the same keys as `catalog_create_rest`
- REST-specific operations (`load_table` with `load_credentials=true`, etc.) return a clear error on memory catalogs
- Introduces `CatalogKind` enum in the FFI to cleanly handle polymorphic catalog dispatch without redundant `Arc` storage
- Fixes `free_catalog!` export (was mistakenly exported as `free_catalog`)
- Adds extensive module-level comment to `catalog.jl` documenting all catalog modes, registry vs file durability, and when to use each
- Adds tests: basic CRUD, multiple namespaces, REST-only guard, local write+read roundtrip, S3 write+read roundtrip (against MinIO)
- Bumps FFI version to 0.7.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)