### PR TITLE
Add function to get current snapshot ID.

### DIFF
--- a/iceberg_rust_ffi/Cargo.lock
+++ b/iceberg_rust_ffi/Cargo.lock
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg_rust_ffi"
-version = "0.7.17"
+version = "0.7.18"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceberg_rust_ffi"
-version = "0.7.17"
+version = "0.7.18"
 edition = "2021"
 
 [lib]

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -250,19 +250,21 @@ pub extern "C" fn iceberg_table_last_updated_ms(table: *mut IcebergTable) -> i64
 }
 
 /// Get the current snapshot ID of the table.
-/// Returns the snapshot ID (a non-zero i64) if the table has at least one committed snapshot,
-/// or 0 if the table has no snapshots yet.
+/// Returns the snapshot ID if the table has at least one committed snapshot,
+/// or -1 if the table has no snapshots yet.
+/// Note: -1 is safe as a sentinel because iceberg-rust maps the Iceberg spec's
+/// EMPTY_SNAPSHOT_ID (-1) to `None`, so `current_snapshot_id()` never returns `Some(-1)`.
 #[no_mangle]
 pub extern "C" fn iceberg_table_current_snapshot_id(table: *mut IcebergTable) -> i64 {
     if table.is_null() {
-        return 0;
+        return -1;
     }
     let table_ref = unsafe { &*table };
     table_ref
         .table
         .metadata()
         .current_snapshot_id()
-        .unwrap_or(0)
+        .unwrap_or(-1)
 }
 
 /// Get table current schema as JSON string

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -249,6 +249,18 @@ pub extern "C" fn iceberg_table_last_updated_ms(table: *mut IcebergTable) -> i64
     table_ref.table.metadata().last_updated_ms()
 }
 
+/// Get the current snapshot ID of the table.
+/// Returns the snapshot ID (a non-zero i64) if the table has at least one committed snapshot,
+/// or 0 if the table has no snapshots yet.
+#[no_mangle]
+pub extern "C" fn iceberg_table_current_snapshot_id(table: *mut IcebergTable) -> i64 {
+    if table.is_null() {
+        return 0;
+    }
+    let table_ref = unsafe { &*table };
+    table_ref.table.metadata().current_snapshot_id().unwrap_or(0)
+}
+
 /// Get table current schema as JSON string
 #[no_mangle]
 pub extern "C" fn iceberg_table_schema(table: *mut IcebergTable) -> *mut c_char {

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -258,7 +258,11 @@ pub extern "C" fn iceberg_table_current_snapshot_id(table: *mut IcebergTable) ->
         return 0;
     }
     let table_ref = unsafe { &*table };
-    table_ref.table.metadata().current_snapshot_id().unwrap_or(0)
+    table_ref
+        .table
+        .metadata()
+        .current_snapshot_id()
+        .unwrap_or(0)
 }
 
 /// Get table current schema as JSON string

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -499,7 +499,7 @@ if the table has no snapshots yet (e.g. immediately after creation, before any c
 """
 function table_current_snapshot_id(table::Table)::Union{Int64,Nothing}
     id = @ccall rust_lib.iceberg_table_current_snapshot_id(table::Table)::Int64
-    return id == 0 ? nothing : id
+    return id == -1 ? nothing : id
 end
 
 """

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -13,7 +13,7 @@ export init_runtime
 export IcebergException
 export new_incremental_scan, free_incremental_scan!
 export table_open, free_table, new_scan, free_scan!
-export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_schema
+export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_current_snapshot_id, table_schema
 export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
 export with_file_column!, with_pos_column!
 export scan!, next_batch, free_batch, free_stream
@@ -488,6 +488,18 @@ function table_last_updated_ms(table::Table)
         throw(IcebergException("Failed to get table last updated timestamp"))
     end
     return timestamp
+end
+
+"""
+    table_current_snapshot_id(table::Table)::Union{Int64,Nothing}
+
+Get the current snapshot ID of an Iceberg table.
+Returns the snapshot ID if the table has at least one committed snapshot, or `nothing`
+if the table has no snapshots yet (e.g. immediately after creation, before any commit).
+"""
+function table_current_snapshot_id(table::Table)::Union{Int64,Nothing}
+    id = @ccall rust_lib.iceberg_table_current_snapshot_id(table::Table)::Int64
+    return id == 0 ? nothing : id
 end
 
 """

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -1063,6 +1063,11 @@ end
         @test last_updated > 0
         println("✅ Table last updated (ms): $last_updated")
 
+        # A freshly created table has no snapshots yet
+        snapshot_id = RustyIceberg.table_current_snapshot_id(table_1)
+        @test isnothing(snapshot_id)
+        println("✅ Table current snapshot ID is nothing (no snapshots yet)")
+
         # Verify table schema
         schema_json = RustyIceberg.table_schema(table_1)
         @test !isempty(schema_json)

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -82,6 +82,28 @@ using Tables
         @test updated_table != C_NULL
         println("✅ Transaction committed successfully")
 
+        # Snapshot ID is a non-nothing Int64 after the first commit
+        snapshot_id_1 = RustyIceberg.table_current_snapshot_id(updated_table)
+        @test !isnothing(snapshot_id_1)
+        @test snapshot_id_1 isa Int64
+        println("✅ Snapshot ID after first commit: $snapshot_id_1")
+
+        # A second commit produces a different snapshot ID
+        data_files_2 = RustyIceberg.with_data_file_writer(updated_table; prefix="batch2") do writer
+            write(writer, (id = Int64[9], name = ["Ivy"], value = [9.9]))
+        end
+        updated_table_2 = RustyIceberg.with_transaction(updated_table, catalog) do tx
+            RustyIceberg.with_fast_append(tx) do action
+                RustyIceberg.add_data_files(action, data_files_2)
+            end
+        end
+        snapshot_id_2 = RustyIceberg.table_current_snapshot_id(updated_table_2)
+        @test !isnothing(snapshot_id_2)
+        @test snapshot_id_2 isa Int64
+        @test snapshot_id_2 != snapshot_id_1
+        println("✅ Snapshot ID after second commit: $snapshot_id_2 (differs from first)")
+        RustyIceberg.free_table(updated_table_2)
+
         # Test 6: Verify table exists in catalog by loading it fresh
         println("\nTest 6: Verifying table exists in catalog...")
         reloaded_table = RustyIceberg.load_table(catalog, test_namespace, table_name)


### PR DESCRIPTION
## Add `table_current_snapshot_id`

Adds a new accessor that returns the current snapshot ID of an Iceberg table after a commit.

**Rust** (`table.rs`): new `iceberg_table_current_snapshot_id` FFI function wrapping `table.metadata().current_snapshot_id()`, returning `0` when no snapshots exist.

**Julia** (`RustyIceberg.jl`): wrapper `table_current_snapshot_id(table) -> Union{Int64, Nothing}`, converting the sentinel `0` to `nothing`.

**Tests**: asserts `nothing` on a freshly created table (in `catalog_tests.jl`, alongside the existing metadata accessor tests), and asserts a non-`nothing` `Int64` that changes between successive commits (in `writer_tests.jl`).