### PR TITLE
Collapse scan parameters into constructors, remove with_* functions

### DIFF
--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -189,7 +189,7 @@ export_runtime_op!(
 impl_scan_free!(iceberg_scan_free, IcebergScan);
 
 // ---------------------------------------------------------------------------
-// Split-scan API: plan_files → create_reader → next_file_scan → read_file_scan
+// Split-scan API: plan_files → create_reader → next_file → read_file_scan
 // ---------------------------------------------------------------------------
 
 // Async: plan which files to read. Returns a concurrent-safe task stream.

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -9,13 +9,14 @@ use iceberg::scan::TableScan;
 use object_store_ffi::{
     export_runtime_op, with_cancellation, CResult, NotifyGuard, ResponseGuard, RT,
 };
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
 
 use crate::scan_common::*;
 use crate::{
     IcebergArrowReaderContext, IcebergArrowStream, IcebergArrowStreamResponse, IcebergFileScanTask,
     IcebergFileScanTaskStream, IcebergFileScanTaskStreamResponse, IcebergNextFileScanTaskResponse,
-    IcebergTable,
+    IcebergNextWarmFileScanResponse, IcebergTable, IcebergWarmFileScan, IcebergWarmFileScanStream,
+    IcebergWarmFileScanStreamResponse,
 };
 
 const SNAPSHOT_ID_NONE: i64 = -1;
@@ -404,5 +405,124 @@ pub extern "C" fn iceberg_file_scan_task_file_path(
     match std::ffi::CString::new(task_ref.task.data_file_path.as_str()) {
         Ok(s) => s.into_raw(),
         Err(_) => std::ptr::null_mut(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Warm file stream API: plan_files_warm → next_warm_file → read_warm_file
+// ---------------------------------------------------------------------------
+
+// Async: plan files and start batch-prefetch streams concurrently.
+// Returns a stream of IcebergWarmFileScan items in manifest order,
+// each with its batch channel already running.
+export_runtime_op!(
+    iceberg_plan_files_warm,
+    IcebergWarmFileScanStreamResponse,
+    || {
+        if scan.is_null() {
+            return Err(anyhow::anyhow!("Null scan pointer"));
+        }
+        if reader_ctx.is_null() {
+            return Err(anyhow::anyhow!("Null reader context pointer"));
+        }
+        let scan_ptr = unsafe { &*scan };
+        let ctx = unsafe { &*reader_ctx };
+        let task_prefetch_depth = if scan_ptr.task_prefetch_depth == 0 {
+            crate::table::DEFAULT_TASK_PREFETCH_DEPTH
+        } else {
+            scan_ptr.task_prefetch_depth
+        };
+        let reader = ctx.reader.clone();
+        let batch_prefetch_depth = ctx.batch_prefetch_depth;
+        Ok((&scan_ptr.scan, task_prefetch_depth, reader, batch_prefetch_depth))
+    },
+    result_tuple,
+    async {
+        let (scan_ref, task_prefetch_depth, reader, batch_prefetch_depth) = result_tuple;
+        let task_stream = scan_ref.plan_files().await?;
+        let (outer_tx, outer_rx) =
+            mpsc::channel::<Result<IcebergWarmFileScan, anyhow::Error>>(task_prefetch_depth);
+        let handle = tokio::spawn(crate::warm_file_stream::run_warm(
+            task_stream,
+            reader,
+            task_prefetch_depth,
+            batch_prefetch_depth,
+            outer_tx,
+        ));
+        Ok::<IcebergWarmFileScanStream, anyhow::Error>(IcebergWarmFileScanStream {
+            receiver: tokio::sync::Mutex::new(outer_rx),
+            producer_handle: tokio::sync::Mutex::new(Some(handle)),
+        })
+    },
+    scan: *mut IcebergScan,
+    reader_ctx: *mut IcebergArrowReaderContext
+);
+
+// Async: pull the next warm file. Returns null value at end-of-stream.
+export_runtime_op!(
+    iceberg_next_warm_file,
+    IcebergNextWarmFileScanResponse,
+    || {
+        if stream.is_null() {
+            return Err(anyhow::anyhow!("Null warm file stream pointer"));
+        }
+        let stream_ref = unsafe { &*stream };
+        Ok(stream_ref)
+    },
+    stream_ref,
+    async { stream_ref.next().await },
+    stream: *mut IcebergWarmFileScanStream
+);
+
+/// Extract (and take ownership of) the Arrow stream from a warm file handle.
+/// Consumes the stream slot — caller must NOT call this twice on the same handle.
+#[no_mangle]
+pub extern "C" fn iceberg_warm_file_take_stream(
+    file: *mut IcebergWarmFileScan,
+) -> *mut crate::table::IcebergArrowStream {
+    if file.is_null() {
+        return ptr::null_mut();
+    }
+    let file_ref = unsafe { &mut *file };
+    let empty = IcebergArrowStream {
+        stream: tokio::sync::Mutex::new(futures::stream::empty().boxed()),
+    };
+    let stream = std::mem::replace(&mut file_ref.stream, empty);
+    Box::into_raw(Box::new(stream))
+}
+
+/// Record count for a warm file handle. Returns -1 if not available.
+#[no_mangle]
+pub extern "C" fn iceberg_warm_file_record_count(file: *const IcebergWarmFileScan) -> i64 {
+    if file.is_null() {
+        return -1;
+    }
+    unsafe { &*file }.record_count.map_or(-1, |n| n as i64)
+}
+
+/// File path for a warm file handle. Caller must free with `iceberg_destroy_cstring`.
+#[no_mangle]
+pub extern "C" fn iceberg_warm_file_path(
+    file: *const IcebergWarmFileScan,
+) -> *mut std::ffi::c_char {
+    if file.is_null() {
+        return ptr::null_mut();
+    }
+    unsafe { &*file }.file_path.clone().into_raw()
+}
+
+/// Free a warm file handle.
+#[no_mangle]
+pub extern "C" fn iceberg_warm_file_free(file: *mut IcebergWarmFileScan) {
+    if !file.is_null() {
+        drop(unsafe { Box::from_raw(file) });
+    }
+}
+
+/// Free a warm file stream.
+#[no_mangle]
+pub extern "C" fn iceberg_warm_file_stream_free(stream: *mut IcebergWarmFileScanStream) {
+    if !stream.is_null() {
+        drop(unsafe { Box::from_raw(stream) });
     }
 }

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -4,7 +4,7 @@ use std::ptr;
 use futures::{stream, StreamExt};
 use iceberg::arrow::ArrowReaderBuilder;
 use iceberg::io::FileIO;
-use iceberg::scan::{TableScan, TableScanBuilder};
+use iceberg::scan::TableScan;
 use object_store_ffi::{
     export_runtime_op, with_cancellation, CResult, NotifyGuard, ResponseGuard, RT,
 };
@@ -17,12 +17,13 @@ use crate::{
     IcebergFileScanTaskStreamResponse, IcebergNextFileScanTaskResponse, IcebergTable,
 };
 
-/// Struct for regular (full) scan builder and scan
+const SNAPSHOT_ID_NONE: i64 = -1;
+
+/// Struct for a built full table scan.
 #[repr(C)]
 pub struct IcebergScan {
-    pub builder: Option<TableScanBuilder<'static>>,
-    pub scan: Option<TableScan>,
-    pub file_io: Option<FileIO>,
+    pub scan: TableScan,
+    pub file_io: FileIO,
     /// 0 = auto-detect (num_cpus)
     pub serialization_concurrency: usize,
     /// stored separately so create_reader can use it; 0 = use reader default
@@ -35,110 +36,87 @@ pub struct IcebergScan {
 
 unsafe impl Send for IcebergScan {}
 
-/// Create a new scan builder
+/// Create and build a new scan.
+///
+/// Numeric parameters use -1 as "not set / use default" sentinel.
+/// Returns NULL on any error (invalid table, failed build, bad column names, etc.)
 #[no_mangle]
-pub extern "C" fn iceberg_new_scan(table: *mut IcebergTable) -> *mut IcebergScan {
+pub extern "C" fn iceberg_new_scan(
+    table: *mut IcebergTable,
+    column_names: *const *const c_char, // NULL = all columns
+    column_names_len: usize,
+    data_file_concurrency_limit: i64,    // -1 = use reader default
+    manifest_file_concurrency_limit: i64, // -1 = don't set
+    manifest_entry_concurrency_limit: i64, // -1 = don't set
+    batch_size: i64,                     // -1 = no override
+    file_column: u8,                     // 0 = no, non-zero = yes
+    pos_column: u8,
+    serialization_concurrency: i64,      // -1 = auto-detect
+    snapshot_id: i64,                    // -1 = current (SNAPSHOT_ID_NONE)
+    task_prefetch_depth: i64,            // -1 = use DEFAULT_TASK_PREFETCH_DEPTH
+) -> *mut IcebergScan {
     if table.is_null() {
         return ptr::null_mut();
     }
     let table_ref = unsafe { &*table };
     let file_io = table_ref.table.file_io().clone();
-    let scan_builder = table_ref.table.scan();
+    let mut builder = table_ref.table.scan();
+
+    // Apply column selection
+    if !column_names.is_null() && column_names_len > 0 {
+        let mut columns = Vec::new();
+        for i in 0..column_names_len {
+            let col_ptr = unsafe { *column_names.add(i) };
+            if col_ptr.is_null() {
+                return ptr::null_mut();
+            }
+            let col_str = unsafe {
+                match CStr::from_ptr(col_ptr).to_str() {
+                    Ok(s) => s,
+                    Err(_) => return ptr::null_mut(),
+                }
+            };
+            columns.push(col_str.to_string());
+        }
+        builder = builder.select(columns);
+    }
+
+    // Apply builder methods
+    if manifest_file_concurrency_limit >= 0 {
+        builder = builder.with_manifest_file_concurrency_limit(manifest_file_concurrency_limit as usize);
+    }
+    if manifest_entry_concurrency_limit >= 0 {
+        builder = builder.with_manifest_entry_concurrency_limit(manifest_entry_concurrency_limit as usize);
+    }
+    if batch_size >= 0 {
+        builder = builder.with_batch_size(Some(batch_size as usize));
+    }
+    if file_column != 0 {
+        builder = builder.with_file_column();
+    }
+    if pos_column != 0 {
+        builder = builder.with_pos_column();
+    }
+    if snapshot_id != SNAPSHOT_ID_NONE {
+        builder = builder.snapshot_id(snapshot_id);
+    }
+    if data_file_concurrency_limit >= 0 {
+        builder = builder.with_data_file_concurrency_limit(data_file_concurrency_limit as usize);
+    }
+
+    let scan = match builder.build() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+
     Box::into_raw(Box::new(IcebergScan {
-        builder: Some(scan_builder),
-        scan: None,
-        file_io: Some(file_io),
-        serialization_concurrency: 1,
-        data_file_concurrency_limit: 0,
-        batch_size: 0,
-        task_prefetch_depth: 0,
+        scan,
+        file_io,
+        serialization_concurrency: if serialization_concurrency < 0 { 0 } else { serialization_concurrency as usize },
+        data_file_concurrency_limit: if data_file_concurrency_limit < 0 { 0 } else { data_file_concurrency_limit as usize },
+        batch_size: if batch_size < 0 { 0 } else { batch_size as usize },
+        task_prefetch_depth: if task_prefetch_depth < 0 { 0 } else { task_prefetch_depth as usize },
     }))
-}
-
-// Use macros from scan_common for shared functionality
-impl_select_columns!(iceberg_select_columns, IcebergScan);
-
-/// Sets data file concurrency on the builder and stores the value for create_reader.
-#[no_mangle]
-pub extern "C" fn iceberg_scan_with_data_file_concurrency_limit(
-    scan: &mut *mut IcebergScan,
-    n: usize,
-) -> CResult {
-    if scan.is_null() || (*scan).is_null() {
-        return CResult::Error;
-    }
-    let scan_ref = unsafe { &mut **scan };
-    let builder = scan_ref.builder.take();
-    if builder.is_none() {
-        return CResult::Error;
-    }
-    scan_ref.builder = builder.map(|b| b.with_data_file_concurrency_limit(n));
-    scan_ref.data_file_concurrency_limit = n;
-    CResult::Ok
-}
-
-impl_scan_builder_method!(
-    iceberg_scan_with_manifest_file_concurrency_limit,
-    IcebergScan,
-    with_manifest_file_concurrency_limit,
-    n: usize
-);
-
-impl_scan_builder_method!(
-    iceberg_scan_with_manifest_entry_concurrency_limit,
-    IcebergScan,
-    with_manifest_entry_concurrency_limit,
-    n: usize
-);
-
-/// Sets batch size on the builder and stores the value for create_reader.
-#[no_mangle]
-pub extern "C" fn iceberg_scan_with_batch_size(
-    scan: &mut *mut IcebergScan,
-    n: usize,
-) -> CResult {
-    if scan.is_null() || (*scan).is_null() {
-        return CResult::Error;
-    }
-    let scan_ref = unsafe { &mut **scan };
-    if scan_ref.builder.is_none() {
-        return CResult::Error;
-    }
-    let builder = scan_ref.builder.take();
-    scan_ref.builder = builder.map(|b| b.with_batch_size(Some(n)));
-    scan_ref.batch_size = n;
-    CResult::Ok
-}
-
-impl_scan_builder_method!(iceberg_scan_with_file_column, IcebergScan, with_file_column);
-
-impl_scan_builder_method!(iceberg_scan_with_pos_column, IcebergScan, with_pos_column);
-
-impl_scan_build!(iceberg_scan_build, IcebergScan);
-
-impl_with_serialization_concurrency_limit!(
-    iceberg_scan_with_serialization_concurrency_limit,
-    IcebergScan
-);
-
-impl_scan_builder_method!(
-    iceberg_scan_with_snapshot_id,
-    IcebergScan,
-    snapshot_id,
-    snapshot_id: i64
-);
-
-/// Sets the file scan task prefetch depth (tasks buffered ahead of consumer).
-#[no_mangle]
-pub extern "C" fn iceberg_scan_with_task_prefetch_depth(
-    scan: &mut *mut IcebergScan,
-    n: usize,
-) -> CResult {
-    if scan.is_null() || (*scan).is_null() {
-        return CResult::Error;
-    }
-    unsafe { (*(*scan)).task_prefetch_depth = n };
-    CResult::Ok
 }
 
 // Async: get a single Arrow stream for the entire scan (non-split API)
@@ -150,10 +128,6 @@ export_runtime_op!(
             return Err(anyhow::anyhow!("Null scan pointer provided"));
         }
         let scan_ptr = unsafe { &*scan };
-        let scan_ref = &scan_ptr.scan;
-        if scan_ref.is_none() {
-            return Err(anyhow::anyhow!("Scan not initialized"));
-        }
 
         // Determine concurrency (0 = auto-detect)
         let serialization_concurrency = scan_ptr.serialization_concurrency;
@@ -165,7 +139,7 @@ export_runtime_op!(
             serialization_concurrency
         };
 
-        Ok((scan_ref.as_ref().unwrap(), serialization_concurrency))
+        Ok((&scan_ptr.scan, serialization_concurrency))
     },
     result_tuple,
     async {
@@ -201,14 +175,12 @@ export_runtime_op!(
             return Err(anyhow::anyhow!("Null scan pointer provided"));
         }
         let scan_ptr = unsafe { &*scan };
-        let scan_ref = scan_ptr.scan.as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Scan not built — call build! first"))?;
         let task_prefetch_depth = if scan_ptr.task_prefetch_depth == 0 {
             crate::table::DEFAULT_TASK_PREFETCH_DEPTH
         } else {
             scan_ptr.task_prefetch_depth
         };
-        Ok((scan_ref, task_prefetch_depth))
+        Ok((&scan_ptr.scan, task_prefetch_depth))
     },
     result_tuple,
     async {
@@ -233,11 +205,8 @@ pub extern "C" fn iceberg_create_reader(
         return ptr::null_mut();
     }
     let scan_ptr = unsafe { &*scan };
-    let Some(file_io) = scan_ptr.file_io.as_ref() else {
-        return ptr::null_mut();
-    };
 
-    let mut builder = ArrowReaderBuilder::new(file_io.clone())
+    let mut builder = ArrowReaderBuilder::new(scan_ptr.file_io.clone())
         .with_row_group_filtering_enabled(true)
         .with_row_selection_enabled(false);
 
@@ -247,7 +216,7 @@ pub extern "C" fn iceberg_create_reader(
         scan_ptr.data_file_concurrency_limit
     };
     if data_file_concurrency > 0 {
-    builder = builder.with_data_file_concurrency_limit(data_file_concurrency);
+        builder = builder.with_data_file_concurrency_limit(data_file_concurrency);
     }
     if scan_ptr.batch_size > 0 {
         builder = builder.with_batch_size(scan_ptr.batch_size);

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -1,6 +1,9 @@
 use std::ffi::{c_char, c_void, CStr};
 use std::ptr;
 
+use futures::{stream, StreamExt};
+use iceberg::arrow::ArrowReaderBuilder;
+use iceberg::io::FileIO;
 use iceberg::scan::{TableScan, TableScanBuilder};
 use object_store_ffi::{
     export_runtime_op, with_cancellation, CResult, NotifyGuard, ResponseGuard, RT,
@@ -8,15 +11,26 @@ use object_store_ffi::{
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::scan_common::*;
-use crate::{IcebergArrowStream, IcebergArrowStreamResponse, IcebergTable};
+use crate::{
+    IcebergArrowReaderContext, IcebergArrowStream,
+    IcebergArrowStreamResponse, IcebergFileScanTask, IcebergFileScanTaskStream,
+    IcebergFileScanTaskStreamResponse, IcebergNextFileScanTaskResponse, IcebergTable,
+};
 
 /// Struct for regular (full) scan builder and scan
 #[repr(C)]
 pub struct IcebergScan {
     pub builder: Option<TableScanBuilder<'static>>,
     pub scan: Option<TableScan>,
+    pub file_io: Option<FileIO>,
     /// 0 = auto-detect (num_cpus)
     pub serialization_concurrency: usize,
+    /// stored separately so create_reader can use it; 0 = use reader default
+    pub data_file_concurrency_limit: usize,
+    /// stored separately so create_reader can use it; 0 = no override
+    pub batch_size: usize,
+    /// File scan task prefetch depth for plan_files; 0 = DEFAULT_TASK_PREFETCH_DEPTH
+    pub task_prefetch_depth: usize,
 }
 
 unsafe impl Send for IcebergScan {}
@@ -28,23 +42,40 @@ pub extern "C" fn iceberg_new_scan(table: *mut IcebergTable) -> *mut IcebergScan
         return ptr::null_mut();
     }
     let table_ref = unsafe { &*table };
+    let file_io = table_ref.table.file_io().clone();
     let scan_builder = table_ref.table.scan();
     Box::into_raw(Box::new(IcebergScan {
         builder: Some(scan_builder),
         scan: None,
-        serialization_concurrency: 0,
+        file_io: Some(file_io),
+        serialization_concurrency: 1,
+        data_file_concurrency_limit: 0,
+        batch_size: 0,
+        task_prefetch_depth: 0,
     }))
 }
 
 // Use macros from scan_common for shared functionality
 impl_select_columns!(iceberg_select_columns, IcebergScan);
 
-impl_scan_builder_method!(
-    iceberg_scan_with_data_file_concurrency_limit,
-    IcebergScan,
-    with_data_file_concurrency_limit,
-    n: usize
-);
+/// Sets data file concurrency on the builder and stores the value for create_reader.
+#[no_mangle]
+pub extern "C" fn iceberg_scan_with_data_file_concurrency_limit(
+    scan: &mut *mut IcebergScan,
+    n: usize,
+) -> CResult {
+    if scan.is_null() || (*scan).is_null() {
+        return CResult::Error;
+    }
+    let scan_ref = unsafe { &mut **scan };
+    let builder = scan_ref.builder.take();
+    if builder.is_none() {
+        return CResult::Error;
+    }
+    scan_ref.builder = builder.map(|b| b.with_data_file_concurrency_limit(n));
+    scan_ref.data_file_concurrency_limit = n;
+    CResult::Ok
+}
 
 impl_scan_builder_method!(
     iceberg_scan_with_manifest_file_concurrency_limit,
@@ -60,7 +91,24 @@ impl_scan_builder_method!(
     n: usize
 );
 
-impl_with_batch_size!(iceberg_scan_with_batch_size, IcebergScan);
+/// Sets batch size on the builder and stores the value for create_reader.
+#[no_mangle]
+pub extern "C" fn iceberg_scan_with_batch_size(
+    scan: &mut *mut IcebergScan,
+    n: usize,
+) -> CResult {
+    if scan.is_null() || (*scan).is_null() {
+        return CResult::Error;
+    }
+    let scan_ref = unsafe { &mut **scan };
+    if scan_ref.builder.is_none() {
+        return CResult::Error;
+    }
+    let builder = scan_ref.builder.take();
+    scan_ref.builder = builder.map(|b| b.with_batch_size(Some(n)));
+    scan_ref.batch_size = n;
+    CResult::Ok
+}
 
 impl_scan_builder_method!(iceberg_scan_with_file_column, IcebergScan, with_file_column);
 
@@ -80,7 +128,20 @@ impl_scan_builder_method!(
     snapshot_id: i64
 );
 
-// Async function to initialize stream from a table scan
+/// Sets the file scan task prefetch depth (tasks buffered ahead of consumer).
+#[no_mangle]
+pub extern "C" fn iceberg_scan_with_task_prefetch_depth(
+    scan: &mut *mut IcebergScan,
+    n: usize,
+) -> CResult {
+    if scan.is_null() || (*scan).is_null() {
+        return CResult::Error;
+    }
+    unsafe { (*(*scan)).task_prefetch_depth = n };
+    CResult::Ok
+}
+
+// Async: get a single Arrow stream for the entire scan (non-split API)
 export_runtime_op!(
     iceberg_arrow_stream,
     IcebergArrowStreamResponse,
@@ -126,3 +187,152 @@ export_runtime_op!(
 );
 
 impl_scan_free!(iceberg_scan_free, IcebergScan);
+
+// ---------------------------------------------------------------------------
+// Split-scan API: plan_files → create_reader → next_file_scan → read_file_scan
+// ---------------------------------------------------------------------------
+
+// Async: plan which files to read. Returns a concurrent-safe task stream.
+export_runtime_op!(
+    iceberg_plan_files,
+    IcebergFileScanTaskStreamResponse,
+    || {
+        if scan.is_null() {
+            return Err(anyhow::anyhow!("Null scan pointer provided"));
+        }
+        let scan_ptr = unsafe { &*scan };
+        let scan_ref = scan_ptr.scan.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Scan not built — call build! first"))?;
+        let task_prefetch_depth = if scan_ptr.task_prefetch_depth == 0 {
+            crate::table::DEFAULT_TASK_PREFETCH_DEPTH
+        } else {
+            scan_ptr.task_prefetch_depth
+        };
+        Ok((scan_ref, task_prefetch_depth))
+    },
+    result_tuple,
+    async {
+        let (scan_ref, task_prefetch_depth) = result_tuple;
+        let stream = scan_ref.plan_files().await?;
+        Ok::<IcebergFileScanTaskStream, anyhow::Error>(
+            IcebergFileScanTaskStream::new(stream, task_prefetch_depth)
+        )
+    },
+    scan: *mut IcebergScan
+);
+
+/// Sync: create a shared ArrowReader context from the scan's configuration.
+/// Pass the returned context to every read_file_scan call.
+/// `reader_concurrency` overrides the scan-level data_file_concurrency_limit when > 0.
+#[no_mangle]
+pub extern "C" fn iceberg_create_reader(
+    scan: *mut IcebergScan,
+    reader_concurrency: usize,
+) -> *mut IcebergArrowReaderContext {
+    if scan.is_null() {
+        return ptr::null_mut();
+    }
+    let scan_ptr = unsafe { &*scan };
+    let Some(file_io) = scan_ptr.file_io.as_ref() else {
+        return ptr::null_mut();
+    };
+
+    let mut builder = ArrowReaderBuilder::new(file_io.clone())
+        .with_row_group_filtering_enabled(true)
+        .with_row_selection_enabled(false);
+
+    let data_file_concurrency = if reader_concurrency > 0 {
+        reader_concurrency
+    } else {
+        scan_ptr.data_file_concurrency_limit
+    };
+    if data_file_concurrency > 0 {
+    builder = builder.with_data_file_concurrency_limit(data_file_concurrency);
+    }
+    if scan_ptr.batch_size > 0 {
+        builder = builder.with_batch_size(scan_ptr.batch_size);
+    }
+
+    let serialization_concurrency = if scan_ptr.serialization_concurrency == 0 {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+    } else {
+        scan_ptr.serialization_concurrency
+    };
+
+    Box::into_raw(Box::new(IcebergArrowReaderContext {
+        reader: builder.build(),
+        serialization_concurrency,
+    }))
+}
+
+// Async: pull the next file scan task. Returns null payload at end-of-stream.
+export_runtime_op!(
+    iceberg_next_file_scan_task,
+    IcebergNextFileScanTaskResponse,
+    || {
+        if task_stream.is_null() {
+            return Err(anyhow::anyhow!("Null task stream pointer"));
+        }
+        let stream_ref = unsafe { &*task_stream };
+        Ok(stream_ref)
+    },
+    stream_ref,
+    async {
+        stream_ref.next().await
+    },
+    task_stream: *mut IcebergFileScanTaskStream
+);
+
+// Async: read a single file scan task into an Arrow stream.
+// Clones the ArrowReader (cheap — shares delete-file cache via Arc).
+// Consumes the task — caller must NOT call free_file_scan after this.
+export_runtime_op!(
+    iceberg_read_file_scan_task,
+    IcebergArrowStreamResponse,
+    || {
+        if reader_ctx.is_null() {
+            return Err(anyhow::anyhow!("Null reader context pointer"));
+        }
+        if task.is_null() {
+            return Err(anyhow::anyhow!("Null task pointer"));
+        }
+        let ctx = unsafe { &*reader_ctx };
+        let reader = ctx.reader.clone();
+        let serialization_concurrency = ctx.serialization_concurrency;
+        let task_ref = unsafe { Box::from_raw(task) };
+        let file_scan_task = task_ref.task;
+        Ok((reader, serialization_concurrency, file_scan_task))
+    },
+    result_tuple,
+    async {
+        let (reader, serialization_concurrency, file_scan_task) = result_tuple;
+
+        // Wrap the single task in a stream for the reader API, which expects a stream
+        // of tasks
+        let task_stream = stream::once(async { Ok(file_scan_task) }).boxed();
+        let record_batch_stream = reader.read(task_stream)?;
+        let serialized_stream = crate::transform_stream_with_parallel_serialization(
+            record_batch_stream,
+            serialization_concurrency,
+        );
+        Ok::<IcebergArrowStream, anyhow::Error>(IcebergArrowStream {
+            stream: AsyncMutex::new(serialized_stream),
+        })
+    },
+    reader_ctx: *mut IcebergArrowReaderContext,
+    task: *mut IcebergFileScanTask
+);
+
+/// Returns the record count for a file scan task, or -1 if not available.
+#[no_mangle]
+pub extern "C" fn iceberg_file_scan_task_record_count(
+    task: *const IcebergFileScanTask,
+) -> i64 {
+    if task.is_null() {
+        return -1;
+    }
+    let task_ref = unsafe { &*task };
+    task_ref.task.record_count.map_or(-1, |n| n as i64)
+}

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -1,5 +1,6 @@
 use std::ffi::{c_char, c_void, CStr};
 use std::ptr;
+use std::time::Instant;
 
 use futures::{stream, StreamExt};
 use iceberg::arrow::ArrowReaderBuilder;
@@ -239,7 +240,7 @@ pub extern "C" fn iceberg_create_reader(
     let scan_ptr = unsafe { &*scan };
 
     let mut builder = ArrowReaderBuilder::new(scan_ptr.file_io.clone())
-        .with_row_group_filtering_enabled(true)
+        .with_row_group_filtering_enabled(false)
         .with_row_selection_enabled(false);
 
     let data_file_concurrency = if reader_concurrency > 0 {
@@ -268,7 +269,11 @@ pub extern "C" fn iceberg_create_reader(
         None
     };
 
-    let batch_prefetch_depth = if batch_prefetch_depth == 0 { 4 } else { batch_prefetch_depth };
+    let batch_prefetch_depth = if batch_prefetch_depth == 0 {
+        4
+    } else {
+        batch_prefetch_depth
+    };
     Box::into_raw(Box::new(IcebergArrowReaderContext {
         reader: builder.build(),
         serialization_concurrency,
@@ -331,13 +336,37 @@ export_runtime_op!(
         // Eagerly drain into a bounded channel so batches are prefetched while
         // Julia processes the previous one. The background task runs independently
         // of Julia's next_batch calls.
+        crate::table::SPLIT_SCAN_STATS
+            .files_opened
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let (tx, rx) = tokio::sync::mpsc::channel(batch_prefetch_depth);
         tokio::spawn(async move {
             futures::pin_mut!(serialized_stream);
+            let mut fetch_start = Instant::now();
             while let Some(item) = serialized_stream.next().await {
+                let fetch_ns = fetch_start.elapsed().as_nanos() as u64;
+                crate::table::SPLIT_SCAN_STATS
+                    .fetch_serialize_ns
+                    .fetch_add(fetch_ns, std::sync::atomic::Ordering::Relaxed);
+
+                if let Ok(ref batch) = item {
+                    crate::table::SPLIT_SCAN_STATS
+                        .batches_produced
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    crate::table::SPLIT_SCAN_STATS
+                        .bytes_produced
+                        .fetch_add(batch.length as u64, std::sync::atomic::Ordering::Relaxed);
+                }
+
+                let send_start = Instant::now();
                 if tx.send(item).await.is_err() {
                     break; // Julia dropped the stream
                 }
+                crate::table::SPLIT_SCAN_STATS
+                    .channel_backpressure_ns
+                    .fetch_add(send_start.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+
+                fetch_start = Instant::now();
             }
         });
         let stream = futures::stream::unfold(rx, |mut rx| async move {

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -12,9 +12,9 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::scan_common::*;
 use crate::{
-    IcebergArrowReaderContext, IcebergArrowStream,
-    IcebergArrowStreamResponse, IcebergFileScanTask, IcebergFileScanTaskStream,
-    IcebergFileScanTaskStreamResponse, IcebergNextFileScanTaskResponse, IcebergTable,
+    IcebergArrowReaderContext, IcebergArrowStream, IcebergArrowStreamResponse, IcebergFileScanTask,
+    IcebergFileScanTaskStream, IcebergFileScanTaskStreamResponse, IcebergNextFileScanTaskResponse,
+    IcebergTable,
 };
 
 const SNAPSHOT_ID_NONE: i64 = -1;
@@ -45,15 +45,15 @@ pub extern "C" fn iceberg_new_scan(
     table: *mut IcebergTable,
     column_names: *const *const c_char, // NULL = all columns
     column_names_len: usize,
-    data_file_concurrency_limit: i64,    // -1 = use reader default
-    manifest_file_concurrency_limit: i64, // -1 = don't set
+    data_file_concurrency_limit: i64,      // -1 = use reader default
+    manifest_file_concurrency_limit: i64,  // -1 = don't set
     manifest_entry_concurrency_limit: i64, // -1 = don't set
-    batch_size: i64,                     // -1 = no override
-    file_column: u8,                     // 0 = no, non-zero = yes
+    batch_size: i64,                       // -1 = no override
+    file_column: u8,                       // 0 = no, non-zero = yes
     pos_column: u8,
-    serialization_concurrency: i64,      // -1 = auto-detect
-    snapshot_id: i64,                    // -1 = current (SNAPSHOT_ID_NONE)
-    task_prefetch_depth: i64,            // -1 = use DEFAULT_TASK_PREFETCH_DEPTH
+    serialization_concurrency: i64, // -1 = auto-detect
+    snapshot_id: i64,               // -1 = current (SNAPSHOT_ID_NONE)
+    task_prefetch_depth: i64,       // -1 = use DEFAULT_TASK_PREFETCH_DEPTH
 ) -> *mut IcebergScan {
     if table.is_null() {
         return ptr::null_mut();
@@ -83,10 +83,12 @@ pub extern "C" fn iceberg_new_scan(
 
     // Apply builder methods
     if manifest_file_concurrency_limit >= 0 {
-        builder = builder.with_manifest_file_concurrency_limit(manifest_file_concurrency_limit as usize);
+        builder =
+            builder.with_manifest_file_concurrency_limit(manifest_file_concurrency_limit as usize);
     }
     if manifest_entry_concurrency_limit >= 0 {
-        builder = builder.with_manifest_entry_concurrency_limit(manifest_entry_concurrency_limit as usize);
+        builder = builder
+            .with_manifest_entry_concurrency_limit(manifest_entry_concurrency_limit as usize);
     }
     if batch_size >= 0 {
         builder = builder.with_batch_size(Some(batch_size as usize));
@@ -109,13 +111,42 @@ pub extern "C" fn iceberg_new_scan(
         Err(_) => return ptr::null_mut(),
     };
 
+    let resolved_serialization_concurrency = if serialization_concurrency < 0 {
+        0
+    } else {
+        serialization_concurrency as usize
+    };
+    let resolved_data_file_concurrency = if data_file_concurrency_limit < 0 {
+        0
+    } else {
+        data_file_concurrency_limit as usize
+    };
+    let resolved_batch_size = if batch_size < 0 {
+        0
+    } else {
+        batch_size as usize
+    };
+    let resolved_task_prefetch_depth = if task_prefetch_depth < 0 {
+        0
+    } else {
+        task_prefetch_depth as usize
+    };
+    tracing::info!(
+        data_file_concurrency = resolved_data_file_concurrency,
+        manifest_file_concurrency = manifest_file_concurrency_limit,
+        manifest_entry_concurrency = manifest_entry_concurrency_limit,
+        batch_size = resolved_batch_size,
+        serialization_concurrency = resolved_serialization_concurrency,
+        task_prefetch_depth = resolved_task_prefetch_depth,
+        "iceberg_new_scan"
+    );
     Box::into_raw(Box::new(IcebergScan {
         scan,
         file_io,
-        serialization_concurrency: if serialization_concurrency < 0 { 0 } else { serialization_concurrency as usize },
-        data_file_concurrency_limit: if data_file_concurrency_limit < 0 { 0 } else { data_file_concurrency_limit as usize },
-        batch_size: if batch_size < 0 { 0 } else { batch_size as usize },
-        task_prefetch_depth: if task_prefetch_depth < 0 { 0 } else { task_prefetch_depth as usize },
+        serialization_concurrency: resolved_serialization_concurrency,
+        data_file_concurrency_limit: resolved_data_file_concurrency,
+        batch_size: resolved_batch_size,
+        task_prefetch_depth: resolved_task_prefetch_depth,
     }))
 }
 
@@ -230,7 +261,11 @@ pub extern "C" fn iceberg_create_reader(
         scan_ptr.serialization_concurrency
     };
 
-    let batch_size = if scan_ptr.batch_size > 0 { Some(scan_ptr.batch_size) } else { None };
+    let batch_size = if scan_ptr.batch_size > 0 {
+        Some(scan_ptr.batch_size)
+    } else {
+        None
+    };
 
     Box::into_raw(Box::new(IcebergArrowReaderContext {
         reader: builder.build(),
@@ -281,8 +316,7 @@ export_runtime_op!(
     async {
         let (reader, serialization_concurrency, file_scan_task) = result_tuple;
 
-        // Wrap the single task in a stream for the reader API, which expects a stream
-        // of tasks
+        // Wrap the single task in a one-element stream, as reader.read() takes a FileScanTaskStream as input
         let task_stream = stream::once(async { Ok(file_scan_task) }).boxed();
         let record_batch_stream = reader.read(task_stream)?;
         let serialized_stream = crate::transform_stream_with_parallel_serialization(
@@ -299,9 +333,7 @@ export_runtime_op!(
 
 /// Returns the record count for a file scan task, or -1 if not available.
 #[no_mangle]
-pub extern "C" fn iceberg_file_scan_task_record_count(
-    task: *const IcebergFileScanTask,
-) -> i64 {
+pub extern "C" fn iceberg_file_scan_task_record_count(task: *const IcebergFileScanTask) -> i64 {
     if task.is_null() {
         return -1;
     }

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -261,9 +261,12 @@ pub extern "C" fn iceberg_create_reader(
         scan_ptr.serialization_concurrency
     };
 
+    let batch_size = if scan_ptr.batch_size > 0 { Some(scan_ptr.batch_size) } else { None };
+
     Box::into_raw(Box::new(IcebergArrowReaderContext {
         reader: builder.build(),
         serialization_concurrency,
+        batch_size,
     }))
 }
 

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -231,6 +231,7 @@ export_runtime_op!(
 pub extern "C" fn iceberg_create_reader(
     scan: *mut IcebergScan,
     reader_concurrency: usize,
+    batch_prefetch_depth: usize,
 ) -> *mut IcebergArrowReaderContext {
     if scan.is_null() {
         return ptr::null_mut();
@@ -267,10 +268,12 @@ pub extern "C" fn iceberg_create_reader(
         None
     };
 
+    let batch_prefetch_depth = if batch_prefetch_depth == 0 { 4 } else { batch_prefetch_depth };
     Box::into_raw(Box::new(IcebergArrowReaderContext {
         reader: builder.build(),
         serialization_concurrency,
         batch_size,
+        batch_prefetch_depth,
     }))
 }
 
@@ -308,13 +311,14 @@ export_runtime_op!(
         let ctx = unsafe { &*reader_ctx };
         let reader = ctx.reader.clone();
         let serialization_concurrency = ctx.serialization_concurrency;
+        let batch_prefetch_depth = ctx.batch_prefetch_depth;
         let task_ref = unsafe { Box::from_raw(task) };
         let file_scan_task = task_ref.task;
-        Ok((reader, serialization_concurrency, file_scan_task))
+        Ok((reader, serialization_concurrency, batch_prefetch_depth, file_scan_task))
     },
     result_tuple,
     async {
-        let (reader, serialization_concurrency, file_scan_task) = result_tuple;
+        let (reader, serialization_concurrency, batch_prefetch_depth, file_scan_task) = result_tuple;
 
         // Wrap the single task in a one-element stream, as reader.read() takes a FileScanTaskStream as input
         let task_stream = stream::once(async { Ok(file_scan_task) }).boxed();
@@ -323,8 +327,25 @@ export_runtime_op!(
             record_batch_stream,
             serialization_concurrency,
         );
+
+        // Eagerly drain into a bounded channel so batches are prefetched while
+        // Julia processes the previous one. The background task runs independently
+        // of Julia's next_batch calls.
+        let (tx, rx) = tokio::sync::mpsc::channel(batch_prefetch_depth);
+        tokio::spawn(async move {
+            futures::pin_mut!(serialized_stream);
+            while let Some(item) = serialized_stream.next().await {
+                if tx.send(item).await.is_err() {
+                    break; // Julia dropped the stream
+                }
+            }
+        });
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|item| (item, rx))
+        })
+        .boxed();
         Ok::<IcebergArrowStream, anyhow::Error>(IcebergArrowStream {
-            stream: AsyncMutex::new(serialized_stream),
+            stream: AsyncMutex::new(stream),
         })
     },
     reader_ctx: *mut IcebergArrowReaderContext,

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -339,3 +339,19 @@ pub extern "C" fn iceberg_file_scan_task_record_count(
     let task_ref = unsafe { &*task };
     task_ref.task.record_count.map_or(-1, |n| n as i64)
 }
+
+/// Returns the data file path for a file scan task as an allocated C string.
+/// Caller must free with `iceberg_destroy_cstring`.
+#[no_mangle]
+pub extern "C" fn iceberg_file_scan_task_file_path(
+    task: *const IcebergFileScanTask,
+) -> *mut std::ffi::c_char {
+    if task.is_null() {
+        return std::ptr::null_mut();
+    }
+    let task_ref = unsafe { &*task };
+    match std::ffi::CString::new(task_ref.task.data_file_path.as_str()) {
+        Ok(s) => s.into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -16,6 +16,10 @@ use crate::table::{
     IcebergIncrementalAppendFileStream, IcebergIncrementalPosDeleteFile,
     IcebergIncrementalPosDeleteFileStream, DEFAULT_DELETE_BATCH_SIZE, DEFAULT_TASK_PREFETCH_DEPTH,
 };
+use crate::warm_file_stream::{
+    IcebergWarmFileScanStream, IcebergWarmFileScanStreamResponse,
+    IcebergWarmIncrementalStreamsResponse,
+};
 use crate::{IcebergArrowStream, IcebergArrowStreamResponse, IcebergTable};
 
 /// Sentinel value for optional snapshot IDs in the C API.
@@ -603,3 +607,60 @@ pub extern "C" fn iceberg_incremental_pos_delete_file_path(
         Err(_) => ptr::null_mut(),
     }
 }
+
+// Async: plan incremental files once, return warm append stream + delete stream.
+// Calls plan_files() exactly once to avoid double planning.
+export_runtime_op!(
+    iceberg_plan_incremental_warm,
+    IcebergWarmIncrementalStreamsResponse,
+    || {
+        if scan.is_null() {
+            return Err(anyhow::anyhow!("Null scan pointer"));
+        }
+        if reader_ctx.is_null() {
+            return Err(anyhow::anyhow!("Null reader context pointer"));
+        }
+        let scan_ptr = unsafe { &*scan };
+        let ctx = unsafe { &*reader_ctx };
+        let task_prefetch_depth = if scan_ptr.task_prefetch_depth == 0 {
+            DEFAULT_TASK_PREFETCH_DEPTH
+        } else {
+            scan_ptr.task_prefetch_depth
+        };
+        let reader = ctx.reader.clone();
+        let batch_prefetch_depth = ctx.batch_prefetch_depth;
+        Ok((&scan_ptr.scan, task_prefetch_depth, reader, batch_prefetch_depth))
+    },
+    result_tuple,
+    async {
+        let (scan_ref, task_prefetch_depth, reader, batch_prefetch_depth) = result_tuple;
+        let (append_stream, delete_stream) = scan_ref.plan_files().await?;
+
+        // Warm stream for append files.
+        let (outer_tx, outer_rx) =
+            tokio::sync::mpsc::channel::<Result<crate::IcebergWarmFileScan, anyhow::Error>>(
+                task_prefetch_depth,
+            );
+        let handle = tokio::spawn(crate::warm_file_stream::run_warm_append(
+            append_stream,
+            reader,
+            task_prefetch_depth,
+            batch_prefetch_depth,
+            outer_tx,
+        ));
+        let append_warm = IcebergWarmFileScanStream {
+            receiver: tokio::sync::Mutex::new(outer_rx),
+            producer_handle: tokio::sync::Mutex::new(Some(handle)),
+        };
+
+        // Standard prefetch stream for delete files (in-memory, no S3 reads).
+        let delete = IcebergIncrementalPosDeleteFileStream::new(delete_stream, task_prefetch_depth);
+
+        Ok::<(IcebergWarmFileScanStream, IcebergIncrementalPosDeleteFileStream), anyhow::Error>((
+            append_warm,
+            delete,
+        ))
+    },
+    scan: *mut IcebergIncrementalScan,
+    reader_ctx: *mut IcebergArrowReaderContext
+);

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -1,6 +1,8 @@
 use std::ffi::{c_char, c_void, CStr};
 use std::ptr;
 
+use iceberg::arrow::ArrowReaderBuilder;
+use iceberg::io::FileIO;
 use iceberg::scan::incremental::{IncrementalTableScan, IncrementalTableScanBuilder};
 use object_store_ffi::{
     export_runtime_op, with_cancellation, CResult, Context, NotifyGuard, RawResponse,
@@ -9,7 +11,13 @@ use object_store_ffi::{
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::scan_common::*;
-use crate::{IcebergArrowStream, IcebergTable};
+use crate::table::{
+    read_incremental_append_task, IcebergArrowReaderContext,
+    IcebergIncrementalAppendTask, IcebergIncrementalAppendTaskStream,
+    IcebergIncrementalPosDeleteTask, IcebergIncrementalPosDeleteTaskStream,
+    DEFAULT_DELETE_BATCH_SIZE, DEFAULT_TASK_PREFETCH_DEPTH,
+};
+use crate::{IcebergArrowStream, IcebergArrowStreamResponse, IcebergTable};
 
 /// Sentinel value for optional snapshot IDs in the C API.
 /// When -1 is passed as from_snapshot_id or to_snapshot_id, it means None (use default).
@@ -22,6 +30,14 @@ pub struct IcebergIncrementalScan {
     pub scan: Option<IncrementalTableScan>,
     /// 0 = auto-detect (num_cpus)
     pub serialization_concurrency: usize,
+    /// Stored for create_reader; set at scan creation from table.file_io()
+    pub file_io: Option<FileIO>,
+    /// 0 = use reader default
+    pub data_file_concurrency_limit: usize,
+    /// 0 = no override
+    pub batch_size: usize,
+    /// 0 = DEFAULT_TASK_PREFETCH_DEPTH
+    pub task_prefetch_depth: usize,
 }
 
 unsafe impl Send for IcebergIncrementalScan {}
@@ -97,11 +113,16 @@ pub extern "C" fn iceberg_new_incremental_scan(
         Some(to_snapshot_id)
     };
 
+    let file_io = table_ref.table.file_io().clone();
     let scan_builder = table_ref.table.incremental_scan(from_id, to_id);
     Box::into_raw(Box::new(IcebergIncrementalScan {
         builder: Some(scan_builder),
         scan: None,
         serialization_concurrency: 0,
+        file_io: Some(file_io),
+        data_file_concurrency_limit: 0,
+        batch_size: 0,
+        task_prefetch_depth: 0,
     }))
 }
 
@@ -115,12 +136,24 @@ impl_scan_builder_method!(
     n: usize
 );
 
-impl_scan_builder_method!(
-    iceberg_incremental_scan_with_data_file_concurrency_limit,
-    IcebergIncrementalScan,
-    with_data_file_concurrency_limit,
-    n: usize
-);
+/// Sets data file concurrency and stores the value for create_reader.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_scan_with_data_file_concurrency_limit(
+    scan: &mut *mut IcebergIncrementalScan,
+    n: usize,
+) -> CResult {
+    if scan.is_null() || (*scan).is_null() {
+        return CResult::Error;
+    }
+    let scan_ref = unsafe { &mut **scan };
+    let builder = scan_ref.builder.take();
+    if builder.is_none() {
+        return CResult::Error;
+    }
+    scan_ref.builder = builder.map(|b| b.with_data_file_concurrency_limit(n));
+    scan_ref.data_file_concurrency_limit = n;
+    CResult::Ok
+}
 
 impl_scan_builder_method!(
     iceberg_incremental_scan_with_manifest_entry_concurrency_limit,
@@ -129,10 +162,24 @@ impl_scan_builder_method!(
     n: usize
 );
 
-impl_with_batch_size!(
-    iceberg_incremental_scan_with_batch_size,
-    IcebergIncrementalScan
-);
+/// Sets batch size on the builder and stores the value for create_reader.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_scan_with_batch_size(
+    scan: &mut *mut IcebergIncrementalScan,
+    n: usize,
+) -> CResult {
+    if scan.is_null() || (*scan).is_null() {
+        return CResult::Error;
+    }
+    let scan_ref = unsafe { &mut **scan };
+    if scan_ref.builder.is_none() {
+        return CResult::Error;
+    }
+    let builder = scan_ref.builder.take();
+    scan_ref.builder = builder.map(|b| b.with_batch_size(Some(n)));
+    scan_ref.batch_size = n;
+    CResult::Ok
+}
 
 impl_scan_builder_method!(
     iceberg_incremental_scan_with_file_column,
@@ -208,3 +255,277 @@ export_runtime_op!(
 );
 
 impl_scan_free!(iceberg_free_incremental_scan, IcebergIncrementalScan);
+
+// ---------------------------------------------------------------------------
+// Incremental split-scan API
+// ---------------------------------------------------------------------------
+
+/// Response for plan_files: returns pointers to two separate task streams.
+#[repr(C)]
+pub struct IcebergIncrementalTaskStreamsResponse {
+    result: CResult,
+    append_stream: *mut IcebergIncrementalAppendTaskStream,
+    delete_stream: *mut IcebergIncrementalPosDeleteTaskStream,
+    error_message: *mut c_char,
+    context: *const Context,
+}
+
+unsafe impl Send for IcebergIncrementalTaskStreamsResponse {}
+
+impl RawResponse for IcebergIncrementalTaskStreamsResponse {
+    type Payload = (IcebergIncrementalAppendTaskStream, IcebergIncrementalPosDeleteTaskStream);
+
+    fn result_mut(&mut self) -> &mut CResult { &mut self.result }
+    fn context_mut(&mut self) -> &mut *const Context { &mut self.context }
+    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.error_message }
+
+    fn set_payload(&mut self, payload: Option<Self::Payload>) {
+        match payload {
+            Some((appends, deletes)) => {
+                self.append_stream = Box::into_raw(Box::new(appends));
+                self.delete_stream = Box::into_raw(Box::new(deletes));
+            }
+            None => {
+                self.append_stream = ptr::null_mut();
+                self.delete_stream = ptr::null_mut();
+            }
+        }
+    }
+}
+
+/// Response for next_append_task/next_pos_delete_task — null value = end-of-stream.
+#[repr(transparent)]
+pub struct IcebergIncrementalNextAppendTaskResponse(
+    pub crate::response::IcebergBoxedResponse<IcebergIncrementalAppendTask>,
+);
+
+unsafe impl Send for IcebergIncrementalNextAppendTaskResponse {}
+
+impl RawResponse for IcebergIncrementalNextAppendTaskResponse {
+    type Payload = Option<IcebergIncrementalAppendTask>;
+    fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
+    fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
+    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
+    fn set_payload(&mut self, payload: Option<Self::Payload>) {
+        match payload.flatten() {
+            Some(task) => self.0.value = Box::into_raw(Box::new(task)),
+            None => self.0.value = ptr::null_mut(),
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct IcebergIncrementalNextPosDeleteTaskResponse(
+    pub crate::response::IcebergBoxedResponse<IcebergIncrementalPosDeleteTask>,
+);
+
+unsafe impl Send for IcebergIncrementalNextPosDeleteTaskResponse {}
+
+impl RawResponse for IcebergIncrementalNextPosDeleteTaskResponse {
+    type Payload = Option<IcebergIncrementalPosDeleteTask>;
+    fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
+    fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
+    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
+    fn set_payload(&mut self, payload: Option<Self::Payload>) {
+        match payload.flatten() {
+            Some(task) => self.0.value = Box::into_raw(Box::new(task)),
+            None => self.0.value = ptr::null_mut(),
+        }
+    }
+}
+
+// Async: plan which files to read for an incremental scan.
+// Returns two task streams: one for append tasks, one for positional-delete tasks.
+export_runtime_op!(
+    iceberg_incremental_plan_files,
+    IcebergIncrementalTaskStreamsResponse,
+    || {
+        if scan.is_null() {
+            return Err(anyhow::anyhow!("Null scan pointer provided"));
+        }
+        let scan_ptr = unsafe { &*scan };
+        let scan_ref = scan_ptr.scan.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Incremental scan not built — call build! first"))?;
+        let task_prefetch_depth = if scan_ptr.task_prefetch_depth == 0 {
+            DEFAULT_TASK_PREFETCH_DEPTH
+        } else {
+            scan_ptr.task_prefetch_depth
+        };
+        Ok((scan_ref, task_prefetch_depth))
+    },
+    result_tuple,
+    async {
+        let (scan_ref, task_prefetch_depth) = result_tuple;
+        let (append_stream, delete_stream) = scan_ref.plan_files().await?;
+        Ok::<(IcebergIncrementalAppendTaskStream, IcebergIncrementalPosDeleteTaskStream), anyhow::Error>((
+            IcebergIncrementalAppendTaskStream::new(append_stream, task_prefetch_depth),
+            IcebergIncrementalPosDeleteTaskStream::new(delete_stream, task_prefetch_depth),
+        ))
+    },
+    scan: *mut IcebergIncrementalScan
+);
+
+/// Sync: create a shared ArrowReader context from the incremental scan's configuration.
+/// Pass the returned context to every read_append_task and read_pos_delete_task call.
+/// `reader_concurrency` overrides data_file_concurrency_limit when > 0.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_create_reader(
+    scan: *const IcebergIncrementalScan,
+    reader_concurrency: usize,
+) -> *mut IcebergArrowReaderContext {
+    if scan.is_null() {
+        return ptr::null_mut();
+    }
+    let scan_ptr = unsafe { &*scan };
+    let file_io = match scan_ptr.file_io.as_ref() {
+        Some(f) => f.clone(),
+        None => return ptr::null_mut(),
+    };
+
+    let mut builder = ArrowReaderBuilder::new(file_io);
+
+    let concurrency = if reader_concurrency > 0 {
+        reader_concurrency
+    } else {
+        scan_ptr.data_file_concurrency_limit
+    };
+    if concurrency > 0 {
+        builder = builder.with_data_file_concurrency_limit(concurrency);
+    }
+
+    let batch_size = if scan_ptr.batch_size > 0 { Some(scan_ptr.batch_size) } else { None };
+    if let Some(n) = batch_size {
+        builder = builder.with_batch_size(n);
+    }
+
+    let serialization_concurrency = if scan_ptr.serialization_concurrency == 0 {
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
+    } else {
+        scan_ptr.serialization_concurrency
+    };
+
+    Box::into_raw(Box::new(IcebergArrowReaderContext {
+        reader: builder.build(),
+        serialization_concurrency,
+        batch_size,
+    }))
+}
+
+// Async: pull the next append task. Returns null payload at end-of-stream.
+export_runtime_op!(
+    iceberg_incremental_next_append_task,
+    IcebergIncrementalNextAppendTaskResponse,
+    || {
+        if stream.is_null() {
+            return Err(anyhow::anyhow!("Null append task stream pointer"));
+        }
+        Ok(unsafe { &*stream })
+    },
+    stream_ref,
+    async {
+        stream_ref.next().await
+    },
+    stream: *mut IcebergIncrementalAppendTaskStream
+);
+
+// Async: pull the next positional-delete task. Returns null payload at end-of-stream.
+export_runtime_op!(
+    iceberg_incremental_next_pos_delete_task,
+    IcebergIncrementalNextPosDeleteTaskResponse,
+    || {
+        if stream.is_null() {
+            return Err(anyhow::anyhow!("Null pos-delete task stream pointer"));
+        }
+        Ok(unsafe { &*stream })
+    },
+    stream_ref,
+    async {
+        stream_ref.next().await
+    },
+    stream: *mut IcebergIncrementalPosDeleteTaskStream
+);
+
+// Async: read a single append task into an Arrow stream. Consumes the task.
+export_runtime_op!(
+    iceberg_incremental_read_append_task,
+    IcebergArrowStreamResponse,
+    || {
+        if reader_ctx.is_null() {
+            return Err(anyhow::anyhow!("Null reader context pointer"));
+        }
+        if task.is_null() {
+            return Err(anyhow::anyhow!("Null append task pointer"));
+        }
+        let ctx = unsafe { &*reader_ctx };
+        let reader = ctx.reader.clone();
+        let serialization_concurrency = ctx.serialization_concurrency;
+        let task_ref = unsafe { Box::from_raw(task) };
+        let append_task = task_ref.task;
+        Ok((reader, serialization_concurrency, append_task))
+    },
+    result_tuple,
+    async {
+        let (reader, serialization_concurrency, append_task) = result_tuple;
+        let arrow_stream = read_incremental_append_task(reader, append_task)
+            .map_err(|e| anyhow::anyhow!("Failed to read append task: {}", e))?;
+        let serialized = crate::transform_stream_with_parallel_serialization(
+            arrow_stream,
+            serialization_concurrency,
+        );
+        Ok::<IcebergArrowStream, anyhow::Error>(IcebergArrowStream {
+            stream: AsyncMutex::new(serialized),
+        })
+    },
+    reader_ctx: *mut IcebergArrowReaderContext,
+    task: *mut IcebergIncrementalAppendTask
+);
+
+// Async: convert a positional-delete task into an Arrow stream of (file_path, pos) pairs.
+// Consumes the task.
+export_runtime_op!(
+    iceberg_incremental_read_pos_delete_task,
+    IcebergArrowStreamResponse,
+    || {
+        if reader_ctx.is_null() {
+            return Err(anyhow::anyhow!("Null reader context pointer"));
+        }
+        if task.is_null() {
+            return Err(anyhow::anyhow!("Null pos-delete task pointer"));
+        }
+        let ctx = unsafe { &*reader_ctx };
+        let serialization_concurrency = ctx.serialization_concurrency;
+        let batch_size = ctx.batch_size.unwrap_or(DEFAULT_DELETE_BATCH_SIZE);
+        let task_ref = unsafe { Box::from_raw(task) };
+        Ok((serialization_concurrency, batch_size, task_ref.file_path, task_ref.positions))
+    },
+    result_tuple,
+    async {
+        let (serialization_concurrency, batch_size, file_path, positions) = result_tuple;
+        let arrow_stream = crate::pos_delete_positions_to_arrow_stream(
+            file_path,
+            positions,
+            batch_size,
+        )?;
+        let serialized = crate::transform_stream_with_parallel_serialization(
+            arrow_stream,
+            serialization_concurrency,
+        );
+        Ok::<IcebergArrowStream, anyhow::Error>(IcebergArrowStream {
+            stream: AsyncMutex::new(serialized),
+        })
+    },
+    reader_ctx: *mut IcebergArrowReaderContext,
+    task: *mut IcebergIncrementalPosDeleteTask
+);
+
+/// Returns the record count for an append task, or -1 if not available.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_append_task_record_count(
+    task: *const IcebergIncrementalAppendTask,
+) -> i64 {
+    if task.is_null() {
+        return -1;
+    }
+    let task_ref = unsafe { &*task };
+    task_ref.task.base.record_count.map_or(-1, |n| n as i64)
+}

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -437,6 +437,7 @@ pub extern "C" fn iceberg_incremental_create_reader(
         reader: builder.build(),
         serialization_concurrency,
         batch_size,
+        batch_prefetch_depth: 4,
     }))
 }
 

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 use iceberg::arrow::ArrowReaderBuilder;
 use iceberg::io::FileIO;
-use iceberg::scan::incremental::{IncrementalTableScan, IncrementalTableScanBuilder};
+use iceberg::scan::incremental::IncrementalTableScan;
 use object_store_ffi::{
     export_runtime_op, with_cancellation, CResult, Context, NotifyGuard, RawResponse,
     ResponseGuard, RT,
@@ -23,15 +23,14 @@ use crate::{IcebergArrowStream, IcebergArrowStreamResponse, IcebergTable};
 /// When -1 is passed as from_snapshot_id or to_snapshot_id, it means None (use default).
 const SNAPSHOT_ID_NONE: i64 = -1;
 
-/// Struct for incremental scan builder and scan
+/// Struct for a built incremental table scan.
 #[repr(C)]
 pub struct IcebergIncrementalScan {
-    pub builder: Option<IncrementalTableScanBuilder<'static>>,
-    pub scan: Option<IncrementalTableScan>,
+    pub scan: IncrementalTableScan,
     /// 0 = auto-detect (num_cpus)
     pub serialization_concurrency: usize,
     /// Stored for create_reader; set at scan creation from table.file_io()
-    pub file_io: Option<FileIO>,
+    pub file_io: FileIO,
     /// 0 = use reader default
     pub data_file_concurrency_limit: usize,
     /// 0 = no override
@@ -83,122 +82,95 @@ impl RawResponse for IcebergUnzippedStreamsResponse {
     }
 }
 
-/// Create a new incremental scan builder
+/// Create a new incremental scan builder with all parameters.
+///
+/// Numeric parameters use -1 as "not set / use default" sentinel.
 ///
 /// # Arguments
 /// * `table` - The table to scan
-/// * `from_snapshot_id` - Starting snapshot ID, or `SNAPSHOT_ID_NONE` (-1) to scan from the root (oldest) snapshot
-/// * `to_snapshot_id` - Ending snapshot ID, or `SNAPSHOT_ID_NONE` (-1) to scan to the current (latest) snapshot
+/// * `from_snapshot_id` - Starting snapshot ID, or -1 (SNAPSHOT_ID_NONE) for oldest
+/// * `to_snapshot_id` - Ending snapshot ID, or -1 (SNAPSHOT_ID_NONE) for current
+/// * All remaining parameters use -1 to mean "not set / use default"
 #[no_mangle]
 pub extern "C" fn iceberg_new_incremental_scan(
     table: *mut IcebergTable,
     from_snapshot_id: i64,
     to_snapshot_id: i64,
+    column_names: *const *const c_char, // NULL = all columns
+    column_names_len: usize,
+    data_file_concurrency_limit: i64,    // -1 = use reader default
+    manifest_file_concurrency_limit: i64, // -1 = don't set
+    manifest_entry_concurrency_limit: i64, // -1 = don't set
+    batch_size: i64,                     // -1 = no override
+    file_column: u8,                     // 0 = no, non-zero = yes
+    pos_column: u8,
+    serialization_concurrency: i64,      // -1 = auto-detect
+    task_prefetch_depth: i64,            // -1 = use DEFAULT_TASK_PREFETCH_DEPTH
 ) -> *mut IcebergIncrementalScan {
     if table.is_null() {
         return ptr::null_mut();
     }
     let table_ref = unsafe { &*table };
 
-    // Convert SNAPSHOT_ID_NONE to None for optional snapshot IDs
-    let from_id = if from_snapshot_id == SNAPSHOT_ID_NONE {
-        None
-    } else {
-        Some(from_snapshot_id)
-    };
-
-    let to_id = if to_snapshot_id == SNAPSHOT_ID_NONE {
-        None
-    } else {
-        Some(to_snapshot_id)
-    };
+    let from_id = if from_snapshot_id == SNAPSHOT_ID_NONE { None } else { Some(from_snapshot_id) };
+    let to_id = if to_snapshot_id == SNAPSHOT_ID_NONE { None } else { Some(to_snapshot_id) };
 
     let file_io = table_ref.table.file_io().clone();
-    let scan_builder = table_ref.table.incremental_scan(from_id, to_id);
+    let mut builder = table_ref.table.incremental_scan(from_id, to_id);
+
+    // Apply column selection
+    if !column_names.is_null() && column_names_len > 0 {
+        let mut columns = Vec::new();
+        for i in 0..column_names_len {
+            let col_ptr = unsafe { *column_names.add(i) };
+            if col_ptr.is_null() {
+                return ptr::null_mut();
+            }
+            let col_str = unsafe {
+                match CStr::from_ptr(col_ptr).to_str() {
+                    Ok(s) => s,
+                    Err(_) => return ptr::null_mut(),
+                }
+            };
+            columns.push(col_str.to_string());
+        }
+        builder = builder.select(columns);
+    }
+
+    // Apply builder methods
+    if manifest_file_concurrency_limit >= 0 {
+        builder = builder.with_manifest_file_concurrency_limit(manifest_file_concurrency_limit as usize);
+    }
+    if manifest_entry_concurrency_limit >= 0 {
+        builder = builder.with_manifest_entry_concurrency_limit(manifest_entry_concurrency_limit as usize);
+    }
+    if batch_size >= 0 {
+        builder = builder.with_batch_size(Some(batch_size as usize));
+    }
+    if file_column != 0 {
+        builder = builder.with_file_column();
+    }
+    if pos_column != 0 {
+        builder = builder.with_pos_column();
+    }
+    if data_file_concurrency_limit >= 0 {
+        builder = builder.with_data_file_concurrency_limit(data_file_concurrency_limit as usize);
+    }
+
+    let scan = match builder.build() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+
     Box::into_raw(Box::new(IcebergIncrementalScan {
-        builder: Some(scan_builder),
-        scan: None,
-        serialization_concurrency: 0,
-        file_io: Some(file_io),
-        data_file_concurrency_limit: 0,
-        batch_size: 0,
-        task_prefetch_depth: 0,
+        scan,
+        serialization_concurrency: if serialization_concurrency < 0 { 0 } else { serialization_concurrency as usize },
+        file_io,
+        data_file_concurrency_limit: if data_file_concurrency_limit < 0 { 0 } else { data_file_concurrency_limit as usize },
+        batch_size: if batch_size < 0 { 0 } else { batch_size as usize },
+        task_prefetch_depth: if task_prefetch_depth < 0 { 0 } else { task_prefetch_depth as usize },
     }))
 }
-
-// Use macros from scan_common for shared functionality
-impl_select_columns!(iceberg_incremental_select_columns, IcebergIncrementalScan);
-
-impl_scan_builder_method!(
-    iceberg_incremental_scan_with_manifest_file_concurrency_limit,
-    IcebergIncrementalScan,
-    with_manifest_file_concurrency_limit,
-    n: usize
-);
-
-/// Sets data file concurrency and stores the value for create_reader.
-#[no_mangle]
-pub extern "C" fn iceberg_incremental_scan_with_data_file_concurrency_limit(
-    scan: &mut *mut IcebergIncrementalScan,
-    n: usize,
-) -> CResult {
-    if scan.is_null() || (*scan).is_null() {
-        return CResult::Error;
-    }
-    let scan_ref = unsafe { &mut **scan };
-    let builder = scan_ref.builder.take();
-    if builder.is_none() {
-        return CResult::Error;
-    }
-    scan_ref.builder = builder.map(|b| b.with_data_file_concurrency_limit(n));
-    scan_ref.data_file_concurrency_limit = n;
-    CResult::Ok
-}
-
-impl_scan_builder_method!(
-    iceberg_incremental_scan_with_manifest_entry_concurrency_limit,
-    IcebergIncrementalScan,
-    with_manifest_entry_concurrency_limit,
-    n: usize
-);
-
-/// Sets batch size on the builder and stores the value for create_reader.
-#[no_mangle]
-pub extern "C" fn iceberg_incremental_scan_with_batch_size(
-    scan: &mut *mut IcebergIncrementalScan,
-    n: usize,
-) -> CResult {
-    if scan.is_null() || (*scan).is_null() {
-        return CResult::Error;
-    }
-    let scan_ref = unsafe { &mut **scan };
-    if scan_ref.builder.is_none() {
-        return CResult::Error;
-    }
-    let builder = scan_ref.builder.take();
-    scan_ref.builder = builder.map(|b| b.with_batch_size(Some(n)));
-    scan_ref.batch_size = n;
-    CResult::Ok
-}
-
-impl_scan_builder_method!(
-    iceberg_incremental_scan_with_file_column,
-    IcebergIncrementalScan,
-    with_file_column
-);
-
-impl_scan_builder_method!(
-    iceberg_incremental_scan_with_pos_column,
-    IcebergIncrementalScan,
-    with_pos_column
-);
-
-impl_scan_build!(iceberg_incremental_scan_build, IcebergIncrementalScan);
-
-impl_with_serialization_concurrency_limit!(
-    iceberg_incremental_scan_with_serialization_concurrency_limit,
-    IcebergIncrementalScan
-);
 
 // Get unzipped Arrow streams from incremental scan (async)
 // Returns two separate streams: one for inserts, one for deletes
@@ -210,10 +182,6 @@ export_runtime_op!(
             return Err(anyhow::anyhow!("Null scan pointer provided"));
         }
         let scan_ptr = unsafe { &*scan };
-        let scan_ref = &scan_ptr.scan;
-        if scan_ref.is_none() {
-            return Err(anyhow::anyhow!("Incremental scan not initialized"));
-        }
 
         // Determine concurrency (0 = auto-detect)
         let serialization_concurrency = scan_ptr.serialization_concurrency;
@@ -225,7 +193,7 @@ export_runtime_op!(
             serialization_concurrency
         };
 
-        Ok((scan_ref.as_ref().unwrap(), serialization_concurrency))
+        Ok((&scan_ptr.scan, serialization_concurrency))
     },
     result_tuple,
     async {
@@ -344,8 +312,7 @@ export_runtime_op!(
             return Err(anyhow::anyhow!("Null scan pointer provided"));
         }
         let scan_ptr = unsafe { &*scan };
-        let scan_ref = scan_ptr.scan.as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Incremental scan not built — call build! first"))?;
+        let scan_ref = &scan_ptr.scan;
         let task_prefetch_depth = if scan_ptr.task_prefetch_depth == 0 {
             DEFAULT_TASK_PREFETCH_DEPTH
         } else {
@@ -377,10 +344,7 @@ pub extern "C" fn iceberg_incremental_create_reader(
         return ptr::null_mut();
     }
     let scan_ptr = unsafe { &*scan };
-    let file_io = match scan_ptr.file_io.as_ref() {
-        Some(f) => f.clone(),
-        None => return ptr::null_mut(),
-    };
+    let file_io = scan_ptr.file_io.clone();
 
     let mut builder = ArrowReaderBuilder::new(file_io);
 

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -12,9 +12,9 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::scan_common::*;
 use crate::table::{
-    read_incremental_append_task, IcebergArrowReaderContext,
-    IcebergIncrementalAppendTask, IcebergIncrementalAppendTaskStream,
-    IcebergIncrementalPosDeleteTask, IcebergIncrementalPosDeleteTaskStream,
+    read_incremental_append_file, IcebergArrowReaderContext,
+    IcebergIncrementalAppendFile, IcebergIncrementalAppendFileStream,
+    IcebergIncrementalPosDeleteFile, IcebergIncrementalPosDeleteFileStream,
     DEFAULT_DELETE_BATCH_SIZE, DEFAULT_TASK_PREFETCH_DEPTH,
 };
 use crate::{IcebergArrowStream, IcebergArrowStreamResponse, IcebergTable};
@@ -264,8 +264,8 @@ impl_scan_free!(iceberg_free_incremental_scan, IcebergIncrementalScan);
 #[repr(C)]
 pub struct IcebergIncrementalTaskStreamsResponse {
     result: CResult,
-    append_stream: *mut IcebergIncrementalAppendTaskStream,
-    delete_stream: *mut IcebergIncrementalPosDeleteTaskStream,
+    append_stream: *mut IcebergIncrementalAppendFileStream,
+    delete_stream: *mut IcebergIncrementalPosDeleteFileStream,
     error_message: *mut c_char,
     context: *const Context,
 }
@@ -273,7 +273,7 @@ pub struct IcebergIncrementalTaskStreamsResponse {
 unsafe impl Send for IcebergIncrementalTaskStreamsResponse {}
 
 impl RawResponse for IcebergIncrementalTaskStreamsResponse {
-    type Payload = (IcebergIncrementalAppendTaskStream, IcebergIncrementalPosDeleteTaskStream);
+    type Payload = (IcebergIncrementalAppendFileStream, IcebergIncrementalPosDeleteFileStream);
 
     fn result_mut(&mut self) -> &mut CResult { &mut self.result }
     fn context_mut(&mut self) -> &mut *const Context { &mut self.context }
@@ -293,16 +293,16 @@ impl RawResponse for IcebergIncrementalTaskStreamsResponse {
     }
 }
 
-/// Response for next_append_task/next_pos_delete_task — null value = end-of-stream.
+/// Response for next_append_file/next_pos_delete_file — null value = end-of-stream.
 #[repr(transparent)]
-pub struct IcebergIncrementalNextAppendTaskResponse(
-    pub crate::response::IcebergBoxedResponse<IcebergIncrementalAppendTask>,
+pub struct IcebergIncrementalNextAppendFileResponse(
+    pub crate::response::IcebergBoxedResponse<IcebergIncrementalAppendFile>,
 );
 
-unsafe impl Send for IcebergIncrementalNextAppendTaskResponse {}
+unsafe impl Send for IcebergIncrementalNextAppendFileResponse {}
 
-impl RawResponse for IcebergIncrementalNextAppendTaskResponse {
-    type Payload = Option<IcebergIncrementalAppendTask>;
+impl RawResponse for IcebergIncrementalNextAppendFileResponse {
+    type Payload = Option<IcebergIncrementalAppendFile>;
     fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
     fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
     fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
@@ -315,14 +315,14 @@ impl RawResponse for IcebergIncrementalNextAppendTaskResponse {
 }
 
 #[repr(transparent)]
-pub struct IcebergIncrementalNextPosDeleteTaskResponse(
-    pub crate::response::IcebergBoxedResponse<IcebergIncrementalPosDeleteTask>,
+pub struct IcebergIncrementalNextPosDeleteFileResponse(
+    pub crate::response::IcebergBoxedResponse<IcebergIncrementalPosDeleteFile>,
 );
 
-unsafe impl Send for IcebergIncrementalNextPosDeleteTaskResponse {}
+unsafe impl Send for IcebergIncrementalNextPosDeleteFileResponse {}
 
-impl RawResponse for IcebergIncrementalNextPosDeleteTaskResponse {
-    type Payload = Option<IcebergIncrementalPosDeleteTask>;
+impl RawResponse for IcebergIncrementalNextPosDeleteFileResponse {
+    type Payload = Option<IcebergIncrementalPosDeleteFile>;
     fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
     fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
     fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
@@ -357,16 +357,16 @@ export_runtime_op!(
     async {
         let (scan_ref, task_prefetch_depth) = result_tuple;
         let (append_stream, delete_stream) = scan_ref.plan_files().await?;
-        Ok::<(IcebergIncrementalAppendTaskStream, IcebergIncrementalPosDeleteTaskStream), anyhow::Error>((
-            IcebergIncrementalAppendTaskStream::new(append_stream, task_prefetch_depth),
-            IcebergIncrementalPosDeleteTaskStream::new(delete_stream, task_prefetch_depth),
+        Ok::<(IcebergIncrementalAppendFileStream, IcebergIncrementalPosDeleteFileStream), anyhow::Error>((
+            IcebergIncrementalAppendFileStream::new(append_stream, task_prefetch_depth),
+            IcebergIncrementalPosDeleteFileStream::new(delete_stream, task_prefetch_depth),
         ))
     },
     scan: *mut IcebergIncrementalScan
 );
 
 /// Sync: create a shared ArrowReader context from the incremental scan's configuration.
-/// Pass the returned context to every read_append_task and read_pos_delete_task call.
+/// Pass the returned context to every read_append_file and read_pos_delete_file call.
 /// `reader_concurrency` overrides data_file_concurrency_limit when > 0.
 #[no_mangle]
 pub extern "C" fn iceberg_incremental_create_reader(
@@ -413,8 +413,8 @@ pub extern "C" fn iceberg_incremental_create_reader(
 
 // Async: pull the next append task. Returns null payload at end-of-stream.
 export_runtime_op!(
-    iceberg_incremental_next_append_task,
-    IcebergIncrementalNextAppendTaskResponse,
+    iceberg_incremental_next_append_file,
+    IcebergIncrementalNextAppendFileResponse,
     || {
         if stream.is_null() {
             return Err(anyhow::anyhow!("Null append task stream pointer"));
@@ -425,13 +425,13 @@ export_runtime_op!(
     async {
         stream_ref.next().await
     },
-    stream: *mut IcebergIncrementalAppendTaskStream
+    stream: *mut IcebergIncrementalAppendFileStream
 );
 
 // Async: pull the next positional-delete task. Returns null payload at end-of-stream.
 export_runtime_op!(
-    iceberg_incremental_next_pos_delete_task,
-    IcebergIncrementalNextPosDeleteTaskResponse,
+    iceberg_incremental_next_pos_delete_file,
+    IcebergIncrementalNextPosDeleteFileResponse,
     || {
         if stream.is_null() {
             return Err(anyhow::anyhow!("Null pos-delete task stream pointer"));
@@ -442,12 +442,12 @@ export_runtime_op!(
     async {
         stream_ref.next().await
     },
-    stream: *mut IcebergIncrementalPosDeleteTaskStream
+    stream: *mut IcebergIncrementalPosDeleteFileStream
 );
 
 // Async: read a single append task into an Arrow stream. Consumes the task.
 export_runtime_op!(
-    iceberg_incremental_read_append_task,
+    iceberg_incremental_read_append_file,
     IcebergArrowStreamResponse,
     || {
         if reader_ctx.is_null() {
@@ -466,7 +466,7 @@ export_runtime_op!(
     result_tuple,
     async {
         let (reader, serialization_concurrency, append_task) = result_tuple;
-        let arrow_stream = read_incremental_append_task(reader, append_task)
+        let arrow_stream = read_incremental_append_file(reader, append_task)
             .map_err(|e| anyhow::anyhow!("Failed to read append task: {}", e))?;
         let serialized = crate::transform_stream_with_parallel_serialization(
             arrow_stream,
@@ -477,13 +477,13 @@ export_runtime_op!(
         })
     },
     reader_ctx: *mut IcebergArrowReaderContext,
-    task: *mut IcebergIncrementalAppendTask
+    task: *mut IcebergIncrementalAppendFile
 );
 
 // Async: convert a positional-delete task into an Arrow stream of (file_path, pos) pairs.
 // Consumes the task.
 export_runtime_op!(
-    iceberg_incremental_read_pos_delete_task,
+    iceberg_incremental_read_pos_delete_file,
     IcebergArrowStreamResponse,
     || {
         if reader_ctx.is_null() {
@@ -515,17 +515,49 @@ export_runtime_op!(
         })
     },
     reader_ctx: *mut IcebergArrowReaderContext,
-    task: *mut IcebergIncrementalPosDeleteTask
+    task: *mut IcebergIncrementalPosDeleteFile
 );
 
 /// Returns the record count for an append task, or -1 if not available.
 #[no_mangle]
-pub extern "C" fn iceberg_incremental_append_task_record_count(
-    task: *const IcebergIncrementalAppendTask,
+pub extern "C" fn iceberg_incremental_append_file_record_count(
+    task: *const IcebergIncrementalAppendFile,
 ) -> i64 {
     if task.is_null() {
         return -1;
     }
     let task_ref = unsafe { &*task };
     task_ref.task.base.record_count.map_or(-1, |n| n as i64)
+}
+
+/// Returns the data file path for an incremental append file as an allocated C string.
+/// Caller must free with `iceberg_destroy_cstring`.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_append_file_path(
+    task: *const IcebergIncrementalAppendFile,
+) -> *mut std::ffi::c_char {
+    if task.is_null() {
+        return ptr::null_mut();
+    }
+    let task_ref = unsafe { &*task };
+    match std::ffi::CString::new(task_ref.task.base.data_file_path.as_str()) {
+        Ok(s) => s.into_raw(),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Returns the data file path for a positional-delete file as an allocated C string.
+/// Caller must free with `iceberg_destroy_cstring`.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_pos_delete_file_path(
+    task: *const IcebergIncrementalPosDeleteFile,
+) -> *mut std::ffi::c_char {
+    if task.is_null() {
+        return ptr::null_mut();
+    }
+    let task_ref = unsafe { &*task };
+    match std::ffi::CString::new(task_ref.file_path.as_str()) {
+        Ok(s) => s.into_raw(),
+        Err(_) => ptr::null_mut(),
+    }
 }

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -12,10 +12,9 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::scan_common::*;
 use crate::table::{
-    read_incremental_append_file, IcebergArrowReaderContext,
-    IcebergIncrementalAppendFile, IcebergIncrementalAppendFileStream,
-    IcebergIncrementalPosDeleteFile, IcebergIncrementalPosDeleteFileStream,
-    DEFAULT_DELETE_BATCH_SIZE, DEFAULT_TASK_PREFETCH_DEPTH,
+    read_incremental_append_file, IcebergArrowReaderContext, IcebergIncrementalAppendFile,
+    IcebergIncrementalAppendFileStream, IcebergIncrementalPosDeleteFile,
+    IcebergIncrementalPosDeleteFileStream, DEFAULT_DELETE_BATCH_SIZE, DEFAULT_TASK_PREFETCH_DEPTH,
 };
 use crate::{IcebergArrowStream, IcebergArrowStreamResponse, IcebergTable};
 
@@ -98,22 +97,30 @@ pub extern "C" fn iceberg_new_incremental_scan(
     to_snapshot_id: i64,
     column_names: *const *const c_char, // NULL = all columns
     column_names_len: usize,
-    data_file_concurrency_limit: i64,    // -1 = use reader default
-    manifest_file_concurrency_limit: i64, // -1 = don't set
+    data_file_concurrency_limit: i64,      // -1 = use reader default
+    manifest_file_concurrency_limit: i64,  // -1 = don't set
     manifest_entry_concurrency_limit: i64, // -1 = don't set
-    batch_size: i64,                     // -1 = no override
-    file_column: u8,                     // 0 = no, non-zero = yes
+    batch_size: i64,                       // -1 = no override
+    file_column: u8,                       // 0 = no, non-zero = yes
     pos_column: u8,
-    serialization_concurrency: i64,      // -1 = auto-detect
-    task_prefetch_depth: i64,            // -1 = use DEFAULT_TASK_PREFETCH_DEPTH
+    serialization_concurrency: i64, // -1 = auto-detect
+    task_prefetch_depth: i64,       // -1 = use DEFAULT_TASK_PREFETCH_DEPTH
 ) -> *mut IcebergIncrementalScan {
     if table.is_null() {
         return ptr::null_mut();
     }
     let table_ref = unsafe { &*table };
 
-    let from_id = if from_snapshot_id == SNAPSHOT_ID_NONE { None } else { Some(from_snapshot_id) };
-    let to_id = if to_snapshot_id == SNAPSHOT_ID_NONE { None } else { Some(to_snapshot_id) };
+    let from_id = if from_snapshot_id == SNAPSHOT_ID_NONE {
+        None
+    } else {
+        Some(from_snapshot_id)
+    };
+    let to_id = if to_snapshot_id == SNAPSHOT_ID_NONE {
+        None
+    } else {
+        Some(to_snapshot_id)
+    };
 
     let file_io = table_ref.table.file_io().clone();
     let mut builder = table_ref.table.incremental_scan(from_id, to_id);
@@ -139,10 +146,12 @@ pub extern "C" fn iceberg_new_incremental_scan(
 
     // Apply builder methods
     if manifest_file_concurrency_limit >= 0 {
-        builder = builder.with_manifest_file_concurrency_limit(manifest_file_concurrency_limit as usize);
+        builder =
+            builder.with_manifest_file_concurrency_limit(manifest_file_concurrency_limit as usize);
     }
     if manifest_entry_concurrency_limit >= 0 {
-        builder = builder.with_manifest_entry_concurrency_limit(manifest_entry_concurrency_limit as usize);
+        builder = builder
+            .with_manifest_entry_concurrency_limit(manifest_entry_concurrency_limit as usize);
     }
     if batch_size >= 0 {
         builder = builder.with_batch_size(Some(batch_size as usize));
@@ -162,13 +171,42 @@ pub extern "C" fn iceberg_new_incremental_scan(
         Err(_) => return ptr::null_mut(),
     };
 
+    let resolved_serialization_concurrency = if serialization_concurrency < 0 {
+        0
+    } else {
+        serialization_concurrency as usize
+    };
+    let resolved_data_file_concurrency = if data_file_concurrency_limit < 0 {
+        0
+    } else {
+        data_file_concurrency_limit as usize
+    };
+    let resolved_batch_size = if batch_size < 0 {
+        0
+    } else {
+        batch_size as usize
+    };
+    let resolved_task_prefetch_depth = if task_prefetch_depth < 0 {
+        0
+    } else {
+        task_prefetch_depth as usize
+    };
+    tracing::info!(
+        data_file_concurrency = resolved_data_file_concurrency,
+        manifest_file_concurrency = manifest_file_concurrency_limit,
+        manifest_entry_concurrency = manifest_entry_concurrency_limit,
+        batch_size = resolved_batch_size,
+        serialization_concurrency = resolved_serialization_concurrency,
+        task_prefetch_depth = resolved_task_prefetch_depth,
+        "iceberg_new_incremental_scan"
+    );
     Box::into_raw(Box::new(IcebergIncrementalScan {
         scan,
-        serialization_concurrency: if serialization_concurrency < 0 { 0 } else { serialization_concurrency as usize },
+        serialization_concurrency: resolved_serialization_concurrency,
         file_io,
-        data_file_concurrency_limit: if data_file_concurrency_limit < 0 { 0 } else { data_file_concurrency_limit as usize },
-        batch_size: if batch_size < 0 { 0 } else { batch_size as usize },
-        task_prefetch_depth: if task_prefetch_depth < 0 { 0 } else { task_prefetch_depth as usize },
+        data_file_concurrency_limit: resolved_data_file_concurrency,
+        batch_size: resolved_batch_size,
+        task_prefetch_depth: resolved_task_prefetch_depth,
     }))
 }
 
@@ -241,11 +279,20 @@ pub struct IcebergIncrementalTaskStreamsResponse {
 unsafe impl Send for IcebergIncrementalTaskStreamsResponse {}
 
 impl RawResponse for IcebergIncrementalTaskStreamsResponse {
-    type Payload = (IcebergIncrementalAppendFileStream, IcebergIncrementalPosDeleteFileStream);
+    type Payload = (
+        IcebergIncrementalAppendFileStream,
+        IcebergIncrementalPosDeleteFileStream,
+    );
 
-    fn result_mut(&mut self) -> &mut CResult { &mut self.result }
-    fn context_mut(&mut self) -> &mut *const Context { &mut self.context }
-    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.error_message }
+    fn result_mut(&mut self) -> &mut CResult {
+        &mut self.result
+    }
+    fn context_mut(&mut self) -> &mut *const Context {
+        &mut self.context
+    }
+    fn error_message_mut(&mut self) -> &mut *mut c_char {
+        &mut self.error_message
+    }
 
     fn set_payload(&mut self, payload: Option<Self::Payload>) {
         match payload {
@@ -271,9 +318,15 @@ unsafe impl Send for IcebergIncrementalNextAppendFileResponse {}
 
 impl RawResponse for IcebergIncrementalNextAppendFileResponse {
     type Payload = Option<IcebergIncrementalAppendFile>;
-    fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
-    fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
-    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
+    fn result_mut(&mut self) -> &mut CResult {
+        &mut self.0.result
+    }
+    fn context_mut(&mut self) -> &mut *const Context {
+        &mut self.0.context
+    }
+    fn error_message_mut(&mut self) -> &mut *mut c_char {
+        &mut self.0.error_message
+    }
     fn set_payload(&mut self, payload: Option<Self::Payload>) {
         match payload.flatten() {
             Some(task) => self.0.value = Box::into_raw(Box::new(task)),
@@ -291,9 +344,15 @@ unsafe impl Send for IcebergIncrementalNextPosDeleteFileResponse {}
 
 impl RawResponse for IcebergIncrementalNextPosDeleteFileResponse {
     type Payload = Option<IcebergIncrementalPosDeleteFile>;
-    fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
-    fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
-    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
+    fn result_mut(&mut self) -> &mut CResult {
+        &mut self.0.result
+    }
+    fn context_mut(&mut self) -> &mut *const Context {
+        &mut self.0.context
+    }
+    fn error_message_mut(&mut self) -> &mut *mut c_char {
+        &mut self.0.error_message
+    }
     fn set_payload(&mut self, payload: Option<Self::Payload>) {
         match payload.flatten() {
             Some(task) => self.0.value = Box::into_raw(Box::new(task)),
@@ -357,13 +416,19 @@ pub extern "C" fn iceberg_incremental_create_reader(
         builder = builder.with_data_file_concurrency_limit(concurrency);
     }
 
-    let batch_size = if scan_ptr.batch_size > 0 { Some(scan_ptr.batch_size) } else { None };
+    let batch_size = if scan_ptr.batch_size > 0 {
+        Some(scan_ptr.batch_size)
+    } else {
+        None
+    };
     if let Some(n) = batch_size {
         builder = builder.with_batch_size(n);
     }
 
     let serialization_concurrency = if scan_ptr.serialization_concurrency == 0 {
-        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
     } else {
         scan_ptr.serialization_concurrency
     };

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -530,6 +530,18 @@ pub extern "C" fn iceberg_incremental_append_file_record_count(
     task_ref.task.base.record_count.map_or(-1, |n| n as i64)
 }
 
+/// Returns the number of deleted row positions in a positional-delete file.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_pos_delete_file_record_count(
+    task: *const IcebergIncrementalPosDeleteFile,
+) -> i64 {
+    if task.is_null() {
+        return -1;
+    }
+    let task_ref = unsafe { &*task };
+    task_ref.positions.len() as i64
+}
+
 /// Returns the data file path for an incremental append file as an allocated C string.
 /// Caller must free with `iceberg_destroy_cstring`.
 #[no_mangle]

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -60,7 +60,7 @@ pub use table::{
 pub use transaction::{IcebergDataFiles, IcebergTransaction, IcebergTransactionResponse};
 pub use warm_file_stream::{
     IcebergNextWarmFileScanResponse, IcebergWarmFileScan, IcebergWarmFileScanStream,
-    IcebergWarmFileScanStreamResponse,
+    IcebergWarmFileScanStreamResponse, IcebergWarmIncrementalStreamsResponse,
 };
 pub use writer::{
     IcebergDataFileWriter, IcebergDataFileWriterResponse, IcebergWriterCloseResponse,

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -40,7 +40,10 @@ mod util;
 // Re-export types and functions from submodules
 pub use catalog::{IcebergBoolResponse, IcebergCatalog, IcebergCatalogResponse};
 pub use full::IcebergScan;
-pub use incremental::{IcebergIncrementalScan, IcebergUnzippedStreamsResponse};
+pub use incremental::{
+    IcebergIncrementalScan, IcebergIncrementalTaskStreamsResponse,
+    IcebergUnzippedStreamsResponse,
+};
 pub use response::{
     IcebergBoxedResponse, IcebergNestedStringListResponse, IcebergPropertyResponse,
     IcebergStringListResponse,
@@ -49,6 +52,9 @@ pub use table::{
     ArrowBatch, IcebergArrowReaderContext, IcebergArrowReaderContextResponse, IcebergArrowStream,
     IcebergArrowStreamResponse, IcebergBatchResponse, IcebergFileScanTask,
     IcebergFileScanTaskResponse, IcebergFileScanTaskStream, IcebergFileScanTaskStreamResponse,
+    IcebergIncrementalAppendTask, IcebergIncrementalAppendTaskResponse,
+    IcebergIncrementalAppendTaskStream, IcebergIncrementalPosDeleteTask,
+    IcebergIncrementalPosDeleteTaskResponse, IcebergIncrementalPosDeleteTaskStream,
     IcebergNextFileScanTaskResponse, IcebergTable, IcebergTableResponse,
 };
 pub use transaction::{IcebergDataFiles, IcebergTransaction, IcebergTransactionResponse};
@@ -178,6 +184,42 @@ pub(crate) fn transform_stream_with_parallel_serialization(
         })
         .buffer_unordered(concurrency)
         .boxed()
+}
+
+/// Build an Arrow record-batch stream from a list of deleted row positions.
+/// Schema: [file_path: Utf8, pos: Int64]. Used by `iceberg_incremental_read_pos_delete_task`.
+pub(crate) fn pos_delete_positions_to_arrow_stream(
+    file_path: String,
+    positions: Vec<u64>,
+    batch_size: usize,
+) -> Result<futures::stream::BoxStream<'static, Result<RecordBatch, iceberg::Error>>> {
+    use std::sync::Arc;
+    use arrow_array::{Int64Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("file_path", DataType::Utf8, false),
+        Field::new("pos", DataType::Int64, false),
+    ]));
+
+    let stream = futures::stream::iter(
+        positions
+            .chunks(batch_size)
+            .map(|chunk| {
+                let n = chunk.len();
+                let file_array = StringArray::from(vec![file_path.as_str(); n]);
+                let pos_array = Int64Array::from_iter(chunk.iter().map(|&p| Some(p as i64)));
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![Arc::new(file_array), Arc::new(pos_array)],
+                )
+                .map_err(|e| iceberg::Error::new(iceberg::ErrorKind::Unexpected, e.to_string()))
+            })
+            .collect::<Vec<_>>(),
+    )
+    .boxed();
+
+    Ok(stream)
 }
 
 // Initialize runtime - configure RT and RESULT_CB directly

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -15,6 +15,7 @@ use object_store_ffi::{
 mod full;
 mod incremental;
 mod scan_common;
+mod warm_file_stream;
 
 // Catalog module
 mod catalog;
@@ -41,8 +42,7 @@ mod util;
 pub use catalog::{IcebergBoolResponse, IcebergCatalog, IcebergCatalogResponse};
 pub use full::IcebergScan;
 pub use incremental::{
-    IcebergIncrementalScan, IcebergIncrementalTaskStreamsResponse,
-    IcebergUnzippedStreamsResponse,
+    IcebergIncrementalScan, IcebergIncrementalTaskStreamsResponse, IcebergUnzippedStreamsResponse,
 };
 pub use response::{
     IcebergBoxedResponse, IcebergNestedStringListResponse, IcebergPropertyResponse,
@@ -58,6 +58,10 @@ pub use table::{
     IcebergNextFileScanTaskResponse, IcebergTable, IcebergTableResponse,
 };
 pub use transaction::{IcebergDataFiles, IcebergTransaction, IcebergTransactionResponse};
+pub use warm_file_stream::{
+    IcebergNextWarmFileScanResponse, IcebergWarmFileScan, IcebergWarmFileScanStream,
+    IcebergWarmFileScanStreamResponse,
+};
 pub use writer::{
     IcebergDataFileWriter, IcebergDataFileWriterResponse, IcebergWriterCloseResponse,
 };
@@ -193,9 +197,9 @@ pub(crate) fn pos_delete_positions_to_arrow_stream(
     positions: Vec<u64>,
     batch_size: usize,
 ) -> Result<futures::stream::BoxStream<'static, Result<RecordBatch, iceberg::Error>>> {
-    use std::sync::Arc;
     use arrow_array::{Int64Array, StringArray};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+    use std::sync::Arc;
 
     let schema = Arc::new(ArrowSchema::new(vec![
         Field::new("file_path", DataType::Utf8, false),

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -182,7 +182,7 @@ pub(crate) fn transform_stream_with_parallel_serialization(
                 )),
             }
         })
-        .buffer_unordered(concurrency)
+        .buffered(concurrency)
         .boxed()
 }
 

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -52,9 +52,9 @@ pub use table::{
     ArrowBatch, IcebergArrowReaderContext, IcebergArrowReaderContextResponse, IcebergArrowStream,
     IcebergArrowStreamResponse, IcebergBatchResponse, IcebergFileScanTask,
     IcebergFileScanTaskResponse, IcebergFileScanTaskStream, IcebergFileScanTaskStreamResponse,
-    IcebergIncrementalAppendTask, IcebergIncrementalAppendTaskResponse,
-    IcebergIncrementalAppendTaskStream, IcebergIncrementalPosDeleteTask,
-    IcebergIncrementalPosDeleteTaskResponse, IcebergIncrementalPosDeleteTaskStream,
+    IcebergIncrementalAppendFile, IcebergIncrementalAppendFileResponse,
+    IcebergIncrementalAppendFileStream, IcebergIncrementalPosDeleteFile,
+    IcebergIncrementalPosDeleteFileResponse, IcebergIncrementalPosDeleteFileStream,
     IcebergNextFileScanTaskResponse, IcebergTable, IcebergTableResponse,
 };
 pub use transaction::{IcebergDataFiles, IcebergTransaction, IcebergTransactionResponse};
@@ -187,7 +187,7 @@ pub(crate) fn transform_stream_with_parallel_serialization(
 }
 
 /// Build an Arrow record-batch stream from a list of deleted row positions.
-/// Schema: [file_path: Utf8, pos: Int64]. Used by `iceberg_incremental_read_pos_delete_task`.
+/// Schema: [file_path: Utf8, pos: Int64]. Used by `iceberg_incremental_read_pos_delete_file`.
 pub(crate) fn pos_delete_positions_to_arrow_stream(
     file_path: String,
     positions: Vec<u64>,

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -46,8 +46,10 @@ pub use response::{
     IcebergStringListResponse,
 };
 pub use table::{
-    ArrowBatch, IcebergArrowStream, IcebergArrowStreamResponse, IcebergBatchResponse, IcebergTable,
-    IcebergTableResponse,
+    ArrowBatch, IcebergArrowReaderContext, IcebergArrowReaderContextResponse, IcebergArrowStream,
+    IcebergArrowStreamResponse, IcebergBatchResponse, IcebergFileScanTask,
+    IcebergFileScanTaskResponse, IcebergFileScanTaskStream, IcebergFileScanTaskStreamResponse,
+    IcebergNextFileScanTaskResponse, IcebergTable, IcebergTableResponse,
 };
 pub use transaction::{IcebergDataFiles, IcebergTransaction, IcebergTransactionResponse};
 pub use writer::{

--- a/iceberg_rust_ffi/src/scan_common.rs
+++ b/iceberg_rust_ffi/src/scan_common.rs
@@ -1,92 +1,5 @@
 /// Common macros for scan builder methods shared between regular and incremental scans
 
-/// Macro to generate select_columns function for any scan type.
-/// Uses in-place mutation so it works regardless of how many fields the scan struct has.
-macro_rules! impl_select_columns {
-    ($fn_name:ident, $scan_type:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(
-            scan: &mut *mut $scan_type,
-            column_names: *const *const c_char,
-            num_columns: usize,
-        ) -> CResult {
-            if scan.is_null() || (*scan).is_null() || column_names.is_null() {
-                return CResult::Error;
-            }
-
-            let mut columns = Vec::new();
-
-            for i in 0..num_columns {
-                let col_ptr = unsafe { *column_names.add(i) };
-                if col_ptr.is_null() {
-                    return CResult::Error;
-                }
-
-                let col_str = unsafe {
-                    match CStr::from_ptr(col_ptr).to_str() {
-                        Ok(s) => s,
-                        Err(_) => return CResult::Error,
-                    }
-                };
-                columns.push(col_str.to_string());
-            }
-
-            let scan_ref = unsafe { &mut **scan };
-            let builder = scan_ref.builder.take();
-            if builder.is_none() {
-                return CResult::Error;
-            }
-            scan_ref.builder = builder.map(|b| b.select(columns));
-            CResult::Ok
-        }
-    };
-}
-
-/// Macro to generate scan builder methods with zero or more parameters.
-/// Uses in-place mutation so it works with any struct that has `builder` and `scan` fields.
-macro_rules! impl_scan_builder_method {
-    ($fn_name:ident, $scan_type:ident, $builder_method:ident $(, $param:ident: $param_type:ty)*) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(scan: &mut *mut $scan_type $(, $param: $param_type)*) -> CResult {
-            if scan.is_null() || (*scan).is_null() {
-                return CResult::Error;
-            }
-            let scan_ref = unsafe { &mut **scan };
-            let builder = scan_ref.builder.take();
-            if builder.is_none() {
-                return CResult::Error;
-            }
-            scan_ref.builder = builder.map(|b| b.$builder_method($($param),*));
-            CResult::Ok
-        }
-    };
-}
-
-
-/// Macro to generate build function for any scan type
-macro_rules! impl_scan_build {
-    ($fn_name:ident, $scan_type:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(scan: &mut *mut $scan_type) -> CResult {
-            if scan.is_null() || (*scan).is_null() {
-                return CResult::Error;
-            }
-            let scan_ref = unsafe { &mut **scan };
-            let builder = scan_ref.builder.take();
-            if builder.is_none() {
-                return CResult::Error;
-            }
-            match builder.unwrap().build() {
-                Ok(built_scan) => {
-                    scan_ref.scan = Some(built_scan);
-                    CResult::Ok
-                }
-                Err(_) => CResult::Error,
-            }
-        }
-    };
-}
-
 /// Macro to generate scan_free function for any scan type
 macro_rules! impl_scan_free {
     ($fn_name:ident, $scan_type:ident) => {
@@ -102,24 +15,5 @@ macro_rules! impl_scan_free {
     };
 }
 
-/// Macro to generate with_serialization_concurrency_limit function for any scan type
-macro_rules! impl_with_serialization_concurrency_limit {
-    ($fn_name:ident, $scan_type:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(scan: &mut *mut $scan_type, n: usize) -> CResult {
-            if scan.is_null() || (*scan).is_null() {
-                return CResult::Error;
-            }
-            let scan_ref = unsafe { &mut **scan };
-            scan_ref.serialization_concurrency = n;
-            CResult::Ok
-        }
-    };
-}
-
-// Re-export macros for use in other modules
-pub(crate) use impl_scan_build;
-pub(crate) use impl_scan_builder_method;
+// Re-export macro for use in other modules
 pub(crate) use impl_scan_free;
-pub(crate) use impl_select_columns;
-pub(crate) use impl_with_serialization_concurrency_limit;

--- a/iceberg_rust_ffi/src/scan_common.rs
+++ b/iceberg_rust_ffi/src/scan_common.rs
@@ -62,27 +62,6 @@ macro_rules! impl_scan_builder_method {
     };
 }
 
-/// Macro to generate with_batch_size function for any scan type.
-/// Only updates the builder; does NOT store the batch size in the scan struct.
-/// For IcebergScan, use the custom iceberg_scan_with_batch_size function instead,
-/// which also stores the value for create_reader.
-macro_rules! impl_with_batch_size {
-    ($fn_name:ident, $scan_type:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(scan: &mut *mut $scan_type, n: usize) -> CResult {
-            if scan.is_null() || (*scan).is_null() {
-                return CResult::Error;
-            }
-            let scan_ref = unsafe { &mut **scan };
-            if scan_ref.builder.is_none() {
-                return CResult::Error;
-            }
-            let builder = scan_ref.builder.take();
-            scan_ref.builder = builder.map(|b| b.with_batch_size(Some(n)));
-            CResult::Ok
-        }
-    };
-}
 
 /// Macro to generate build function for any scan type
 macro_rules! impl_scan_build {
@@ -143,5 +122,4 @@ pub(crate) use impl_scan_build;
 pub(crate) use impl_scan_builder_method;
 pub(crate) use impl_scan_free;
 pub(crate) use impl_select_columns;
-pub(crate) use impl_with_batch_size;
 pub(crate) use impl_with_serialization_concurrency_limit;

--- a/iceberg_rust_ffi/src/scan_common.rs
+++ b/iceberg_rust_ffi/src/scan_common.rs
@@ -1,5 +1,7 @@
 /// Common macros for scan builder methods shared between regular and incremental scans
-/// Macro to generate select_columns function for any scan type
+
+/// Macro to generate select_columns function for any scan type.
+/// Uses in-place mutation so it works regardless of how many fields the scan struct has.
 macro_rules! impl_select_columns {
     ($fn_name:ident, $scan_type:ident) => {
         #[no_mangle]
@@ -29,44 +31,19 @@ macro_rules! impl_select_columns {
                 columns.push(col_str.to_string());
             }
 
-            let scan_ref = unsafe { Box::from_raw(*scan) };
-
-            if scan_ref.builder.is_none() {
+            let scan_ref = unsafe { &mut **scan };
+            let builder = scan_ref.builder.take();
+            if builder.is_none() {
                 return CResult::Error;
             }
-            *scan = Box::into_raw(Box::new($scan_type {
-                builder: scan_ref.builder.map(|b| b.select(columns)),
-                scan: scan_ref.scan,
-                serialization_concurrency: scan_ref.serialization_concurrency,
-            }));
-
+            scan_ref.builder = builder.map(|b| b.select(columns));
             CResult::Ok
         }
     };
 }
 
-/// Macro to generate scan builder methods with zero or more parameters
-///
-/// # Examples
-///
-/// With single parameter:
-/// ```ignore
-/// impl_scan_builder_method!(
-///     iceberg_scan_with_data_file_concurrency_limit,
-///     IcebergScan,
-///     with_data_file_concurrency_limit,
-///     n: usize
-/// );
-/// ```
-///
-/// Without parameters:
-/// ```ignore
-/// impl_scan_builder_method!(
-///     iceberg_scan_with_file_column,
-///     IcebergScan,
-///     with_file_column
-/// );
-/// ```
+/// Macro to generate scan builder methods with zero or more parameters.
+/// Uses in-place mutation so it works with any struct that has `builder` and `scan` fields.
 macro_rules! impl_scan_builder_method {
     ($fn_name:ident, $scan_type:ident, $builder_method:ident $(, $param:ident: $param_type:ty)*) => {
         #[no_mangle]
@@ -74,24 +51,21 @@ macro_rules! impl_scan_builder_method {
             if scan.is_null() || (*scan).is_null() {
                 return CResult::Error;
             }
-            let scan_ref = unsafe { Box::from_raw(*scan) };
-
-            if scan_ref.builder.is_none() {
+            let scan_ref = unsafe { &mut **scan };
+            let builder = scan_ref.builder.take();
+            if builder.is_none() {
                 return CResult::Error;
             }
-
-            *scan = Box::into_raw(Box::new($scan_type {
-                builder: scan_ref.builder.map(|b| b.$builder_method($($param),*)),
-                scan: scan_ref.scan,
-                serialization_concurrency: scan_ref.serialization_concurrency,
-            }));
-
+            scan_ref.builder = builder.map(|b| b.$builder_method($($param),*));
             CResult::Ok
         }
     };
 }
 
-/// Macro to generate with_batch_size function for any scan type
+/// Macro to generate with_batch_size function for any scan type.
+/// Only updates the builder; does NOT store the batch size in the scan struct.
+/// For IcebergScan, use the custom iceberg_scan_with_batch_size function instead,
+/// which also stores the value for create_reader.
 macro_rules! impl_with_batch_size {
     ($fn_name:ident, $scan_type:ident) => {
         #[no_mangle]
@@ -99,20 +73,12 @@ macro_rules! impl_with_batch_size {
             if scan.is_null() || (*scan).is_null() {
                 return CResult::Error;
             }
-            let scan_ref = unsafe { Box::from_raw(*scan) };
-
+            let scan_ref = unsafe { &mut **scan };
             if scan_ref.builder.is_none() {
                 return CResult::Error;
             }
-
-            assert!(scan_ref.scan.is_none());
-
-            *scan = Box::into_raw(Box::new($scan_type {
-                builder: scan_ref.builder.map(|b| b.with_batch_size(Some(n))),
-                scan: None,
-                serialization_concurrency: scan_ref.serialization_concurrency,
-            }));
-
+            let builder = scan_ref.builder.take();
+            scan_ref.builder = builder.map(|b| b.with_batch_size(Some(n)));
             CResult::Ok
         }
     };
@@ -126,19 +92,14 @@ macro_rules! impl_scan_build {
             if scan.is_null() || (*scan).is_null() {
                 return CResult::Error;
             }
-            let scan_ref = unsafe { Box::from_raw(*scan) };
-            if scan_ref.builder.is_none() {
+            let scan_ref = unsafe { &mut **scan };
+            let builder = scan_ref.builder.take();
+            if builder.is_none() {
                 return CResult::Error;
             }
-            let builder = scan_ref.builder.unwrap();
-
-            match builder.build() {
+            match builder.unwrap().build() {
                 Ok(built_scan) => {
-                    *scan = Box::into_raw(Box::new($scan_type {
-                        builder: None,
-                        scan: Some(built_scan),
-                        serialization_concurrency: scan_ref.serialization_concurrency,
-                    }));
+                    scan_ref.scan = Some(built_scan);
                     CResult::Ok
                 }
                 Err(_) => CResult::Error,
@@ -170,9 +131,8 @@ macro_rules! impl_with_serialization_concurrency_limit {
             if scan.is_null() || (*scan).is_null() {
                 return CResult::Error;
             }
-            let mut scan_ref = unsafe { Box::from_raw(*scan) };
+            let scan_ref = unsafe { &mut **scan };
             scan_ref.serialization_concurrency = n;
-            *scan = Box::into_raw(scan_ref);
             CResult::Ok
         }
     };

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -1,7 +1,9 @@
 use crate::response::IcebergBoxedResponse;
 /// Table and streaming support for iceberg_rust_ffi
 use crate::{CResult, Context, RawResponse};
+use iceberg::arrow::ArrowReader;
 use iceberg::io::{FileIOBuilder, OpenDalRoutingStorageFactory};
+use iceberg::scan::{FileScanTask, FileScanTaskStream};
 use iceberg::table::StaticTable;
 use iceberg::table::Table;
 use iceberg::TableIdent;
@@ -44,9 +46,107 @@ pub struct ArrowBatch {
 // making it safe to send between threads.
 unsafe impl Send for ArrowBatch {}
 
+/// Default task prefetch depth for IcebergFileScanTaskStream producers.
+pub(crate) const DEFAULT_TASK_PREFETCH_DEPTH: usize = 4;
+
+// ---------------------------------------------------------------------------
+// Split-scan API types
+// ---------------------------------------------------------------------------
+
+/// Shared ArrowReader context — created once via `create_reader`, then passed
+/// to every `read_file_scan` call. Cloning the reader is cheap: the internal
+/// CachingDeleteFileLoader is shared via Arc.
+pub struct IcebergArrowReaderContext {
+    pub reader: ArrowReader,
+    pub serialization_concurrency: usize,
+}
+
+unsafe impl Send for IcebergArrowReaderContext {}
+
+/// A single file scan task (byte range of a Parquet file) returned by next_file_scan.
+pub struct IcebergFileScanTask {
+    pub task: FileScanTask,
+}
+
+unsafe impl Send for IcebergFileScanTask {}
+
+/// Stream of file scan tasks produced by plan_files. Eagerly drains the
+/// planning stream into a bounded channel so task planning runs ahead of
+/// Julia's consumption.
+pub struct IcebergFileScanTaskStream {
+    receiver: AsyncMutex<tokio::sync::mpsc::Receiver<Result<FileScanTask, iceberg::Error>>>,
+    producer_handle: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+unsafe impl Send for IcebergFileScanTaskStream {}
+
+impl IcebergFileScanTaskStream {
+    pub fn new(stream: FileScanTaskStream, prefetch_depth: usize) -> Self {
+        use futures::StreamExt;
+        let (tx, rx) = tokio::sync::mpsc::channel(prefetch_depth);
+        let handle = tokio::spawn(async move {
+            futures::pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                let is_err = item.is_err();
+                if tx.send(item).await.is_err() {
+                    break;
+                }
+                if is_err {
+                    break;
+                }
+            }
+        });
+        Self {
+            receiver: AsyncMutex::new(rx),
+            producer_handle: AsyncMutex::new(Some(handle)),
+        }
+    }
+
+    pub async fn next(&self) -> Result<Option<IcebergFileScanTask>, anyhow::Error> {
+        let mut rx = self.receiver.lock().await;
+        match rx.recv().await {
+            Some(Ok(task)) => Ok(Some(IcebergFileScanTask { task })),
+            Some(Err(e)) => Err(anyhow::anyhow!("Task planning error: {}", e)),
+            None => {
+                let mut handle_guard = self.producer_handle.lock().await;
+                if let Some(handle) = handle_guard.take() {
+                    match handle.await {
+                        Ok(()) => Ok(None),
+                        Err(e) => Err(anyhow::anyhow!("Task planner panicked: {}", e)),
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
 /// Type aliases for response types
 pub type IcebergTableResponse = IcebergBoxedResponse<IcebergTable>;
 pub type IcebergArrowStreamResponse = IcebergBoxedResponse<IcebergArrowStream>;
+pub type IcebergArrowReaderContextResponse = IcebergBoxedResponse<IcebergArrowReaderContext>;
+pub type IcebergFileScanTaskStreamResponse = IcebergBoxedResponse<IcebergFileScanTaskStream>;
+pub type IcebergFileScanTaskResponse = IcebergBoxedResponse<IcebergFileScanTask>;
+
+/// Response for next_file_scan — null value pointer means end-of-stream.
+#[repr(transparent)]
+pub struct IcebergNextFileScanTaskResponse(pub IcebergBoxedResponse<IcebergFileScanTask>);
+
+unsafe impl Send for IcebergNextFileScanTaskResponse {}
+
+impl RawResponse for IcebergNextFileScanTaskResponse {
+    type Payload = Option<IcebergFileScanTask>;
+    fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
+    fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
+    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
+    fn set_payload(&mut self, payload: Option<Self::Payload>) {
+        match payload.flatten() {
+            Some(task) => self.0.value = Box::into_raw(Box::new(task)),
+            None => self.0.value = ptr::null_mut(),
+        }
+    }
+}
 
 /// Batch response - same memory layout as IcebergBoxedResponse<ArrowBatch>
 /// but with Option<ArrowBatch> payload to handle end-of-stream (None) case.
@@ -111,6 +211,28 @@ pub extern "C" fn iceberg_arrow_stream_free(stream: *mut IcebergArrowStream) {
         unsafe {
             let _ = Box::from_raw(stream);
         }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_arrow_reader_context_free(ctx: *mut IcebergArrowReaderContext) {
+    if !ctx.is_null() {
+        unsafe { let _ = Box::from_raw(ctx); }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_file_scan_task_stream_free(stream: *mut IcebergFileScanTaskStream) {
+    if !stream.is_null() {
+        unsafe { let _ = Box::from_raw(stream); }
+    }
+}
+
+/// Free a file scan task. Do NOT call after passing it to read_file_scan — that consumes it.
+#[no_mangle]
+pub extern "C" fn iceberg_file_scan_task_free(task: *mut IcebergFileScanTask) {
+    if !task.is_null() {
+        unsafe { let _ = Box::from_raw(task); }
     }
 }
 

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -10,6 +10,7 @@ use iceberg::table::Table;
 use iceberg::TableIdent;
 use std::ffi::{c_char, c_void};
 use std::ptr;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use tokio::sync::Mutex as AsyncMutex;
 
 // FFI exports
@@ -18,6 +19,103 @@ use object_store_ffi::{export_runtime_op, with_cancellation, NotifyGuard, Respon
 // Utility imports
 use crate::util::{parse_c_string, parse_properties};
 use crate::PropertyEntry;
+
+// ===========================================================================
+// Split-scan performance monitoring
+// ===========================================================================
+
+pub(crate) struct SplitScanStats {
+    pub(crate) files_opened: AtomicUsize,
+    pub(crate) batches_produced: AtomicUsize,
+    pub(crate) bytes_produced: AtomicU64,
+    /// Time inside serialized_stream.next() per batch: fetch + decode + serialize.
+    pub(crate) fetch_serialize_ns: AtomicU64,
+    /// Time background task is blocked on tx.send() (channel full = Julia slow).
+    pub(crate) channel_backpressure_ns: AtomicU64,
+    /// Time Julia waits in iceberg_next_batch for the next batch (rx.recv() latency).
+    pub(crate) next_batch_wait_ns: AtomicU64,
+}
+
+impl SplitScanStats {
+    const fn new() -> Self {
+        Self {
+            files_opened: AtomicUsize::new(0),
+            batches_produced: AtomicUsize::new(0),
+            bytes_produced: AtomicU64::new(0),
+            fetch_serialize_ns: AtomicU64::new(0),
+            channel_backpressure_ns: AtomicU64::new(0),
+            next_batch_wait_ns: AtomicU64::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.files_opened.store(0, Ordering::Relaxed);
+        self.batches_produced.store(0, Ordering::Relaxed);
+        self.bytes_produced.store(0, Ordering::Relaxed);
+        self.fetch_serialize_ns.store(0, Ordering::Relaxed);
+        self.channel_backpressure_ns.store(0, Ordering::Relaxed);
+        self.next_batch_wait_ns.store(0, Ordering::Relaxed);
+    }
+
+    fn print_summary(&self) {
+        let files = self.files_opened.load(Ordering::Relaxed);
+        let batches = self.batches_produced.load(Ordering::Relaxed);
+        let bytes = self.bytes_produced.load(Ordering::Relaxed);
+        let fetch_ms = self.fetch_serialize_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let bp_ms = self.channel_backpressure_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let wait_ms = self.next_batch_wait_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let bytes_mb = bytes as f64 / (1024.0 * 1024.0);
+
+        const BOX: usize = 68;
+        let row = |content: &str| {
+            let pad = (BOX - 6).saturating_sub(content.len());
+            println!("│  {}{:pad$}  │", content, "", pad = pad);
+        };
+        let dashes = |n: usize| -> String { "─".repeat(n) };
+        let sep = |label: &str| {
+            let fill = (BOX - 10).saturating_sub(label.len());
+            println!("│  {} {} {}  │", dashes(2), label, dashes(fill));
+        };
+        let border = |left: char, right: char| {
+            println!("{}{}{}", left, dashes(BOX - 2), right);
+        };
+
+        border('┌', '┐');
+        row("Split-Scan Stats");
+        row("");
+        row(&format!("files opened:    {:>9}", files));
+        row(&format!(
+            "batches:         {:>9}       serialized: {:.1} MB",
+            batches, bytes_mb
+        ));
+        sep("per-batch timings (sum across all files)");
+        row(&format!(
+            "fetch+serialize: {:>9.1} ms    (I/O + decode + IPC)",
+            fetch_ms
+        ));
+        row(&format!(
+            "channel wait:    {:>9.1} ms    (backpressure — Julia slow)",
+            bp_ms
+        ));
+        row(&format!(
+            "next_batch wait: {:>9.1} ms    (Julia waiting for prefetch)",
+            wait_ms
+        ));
+        border('└', '┘');
+    }
+}
+
+pub(crate) static SPLIT_SCAN_STATS: SplitScanStats = SplitScanStats::new();
+
+#[no_mangle]
+pub extern "C" fn iceberg_print_split_scan_stats() {
+    SPLIT_SCAN_STATS.print_summary();
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_reset_split_scan_stats() {
+    SPLIT_SCAN_STATS.reset();
+}
 
 /// Direct table structure - no opaque wrapper
 #[repr(C)]
@@ -183,9 +281,7 @@ impl IcebergIncrementalAppendFileStream {
         }
     }
 
-    pub async fn next(
-        &self,
-    ) -> Result<Option<IcebergIncrementalAppendFile>, anyhow::Error> {
+    pub async fn next(&self) -> Result<Option<IcebergIncrementalAppendFile>, anyhow::Error> {
         let mut rx = self.receiver.lock().await;
         match rx.recv().await {
             Some(Ok(task)) => Ok(Some(IcebergIncrementalAppendFile { task })),
@@ -193,7 +289,9 @@ impl IcebergIncrementalAppendFileStream {
             None => {
                 let mut h = self.producer_handle.lock().await;
                 if let Some(handle) = h.take() {
-                    handle.await.map_err(|e| anyhow::anyhow!("Planner panicked: {}", e))?;
+                    handle
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Planner panicked: {}", e))?;
                 }
                 Ok(None)
             }
@@ -225,15 +323,19 @@ impl IcebergIncrementalPosDeleteFileStream {
                 match item {
                     Ok(DeleteScanTask::PositionalDeletes(file_path, dv)) => {
                         let positions: Vec<u64> = dv.iter().collect();
-                        let task =
-                            IcebergIncrementalPosDeleteFile { file_path, positions };
+                        let task = IcebergIncrementalPosDeleteFile {
+                            file_path,
+                            positions,
+                        };
                         if tx.send(Ok(task)).await.is_err() {
                             break;
                         }
                     }
                     Ok(_) => {} // skip DeletedFile and EqualityDeletes
                     Err(e) => {
-                        let _ = tx.send(Err(anyhow::anyhow!("Delete task error: {}", e))).await;
+                        let _ = tx
+                            .send(Err(anyhow::anyhow!("Delete task error: {}", e)))
+                            .await;
                         break;
                     }
                 }
@@ -245,9 +347,7 @@ impl IcebergIncrementalPosDeleteFileStream {
         }
     }
 
-    pub async fn next(
-        &self,
-    ) -> Result<Option<IcebergIncrementalPosDeleteFile>, anyhow::Error> {
+    pub async fn next(&self) -> Result<Option<IcebergIncrementalPosDeleteFile>, anyhow::Error> {
         let mut rx = self.receiver.lock().await;
         match rx.recv().await {
             Some(Ok(task)) => Ok(Some(task)),
@@ -255,7 +355,9 @@ impl IcebergIncrementalPosDeleteFileStream {
             None => {
                 let mut h = self.producer_handle.lock().await;
                 if let Some(handle) = h.take() {
-                    handle.await.map_err(|e| anyhow::anyhow!("Planner panicked: {}", e))?;
+                    handle
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Planner panicked: {}", e))?;
                 }
                 Ok(None)
             }
@@ -270,8 +372,7 @@ pub(crate) fn read_incremental_append_file(
     task: AppendedFileScanTask,
 ) -> iceberg::Result<iceberg::scan::ArrowRecordBatchStream> {
     use futures::{stream, StreamExt};
-    let append_stream =
-        stream::once(async { Ok(task) }).boxed();
+    let append_stream = stream::once(async { Ok(task) }).boxed();
     let delete_stream = stream::empty::<Result<DeleteScanTask, iceberg::Error>>().boxed();
     let streams = (append_stream, delete_stream);
     let (arrow_stream, _): UnzippedIncrementalBatchRecordStream =
@@ -285,8 +386,7 @@ pub type IcebergArrowStreamResponse = IcebergBoxedResponse<IcebergArrowStream>;
 pub type IcebergArrowReaderContextResponse = IcebergBoxedResponse<IcebergArrowReaderContext>;
 pub type IcebergFileScanTaskStreamResponse = IcebergBoxedResponse<IcebergFileScanTaskStream>;
 pub type IcebergFileScanTaskResponse = IcebergBoxedResponse<IcebergFileScanTask>;
-pub type IcebergIncrementalAppendFileResponse =
-    IcebergBoxedResponse<IcebergIncrementalAppendFile>;
+pub type IcebergIncrementalAppendFileResponse = IcebergBoxedResponse<IcebergIncrementalAppendFile>;
 pub type IcebergIncrementalPosDeleteFileResponse =
     IcebergBoxedResponse<IcebergIncrementalPosDeleteFile>;
 
@@ -298,9 +398,15 @@ unsafe impl Send for IcebergNextFileScanTaskResponse {}
 
 impl RawResponse for IcebergNextFileScanTaskResponse {
     type Payload = Option<IcebergFileScanTask>;
-    fn result_mut(&mut self) -> &mut CResult { &mut self.0.result }
-    fn context_mut(&mut self) -> &mut *const Context { &mut self.0.context }
-    fn error_message_mut(&mut self) -> &mut *mut c_char { &mut self.0.error_message }
+    fn result_mut(&mut self) -> &mut CResult {
+        &mut self.0.result
+    }
+    fn context_mut(&mut self) -> &mut *const Context {
+        &mut self.0.context
+    }
+    fn error_message_mut(&mut self) -> &mut *mut c_char {
+        &mut self.0.error_message
+    }
     fn set_payload(&mut self, payload: Option<Self::Payload>) {
         match payload.flatten() {
             Some(task) => self.0.value = Box::into_raw(Box::new(task)),
@@ -378,14 +484,18 @@ pub extern "C" fn iceberg_arrow_stream_free(stream: *mut IcebergArrowStream) {
 #[no_mangle]
 pub extern "C" fn iceberg_arrow_reader_context_free(ctx: *mut IcebergArrowReaderContext) {
     if !ctx.is_null() {
-        unsafe { let _ = Box::from_raw(ctx); }
+        unsafe {
+            let _ = Box::from_raw(ctx);
+        }
     }
 }
 
 #[no_mangle]
 pub extern "C" fn iceberg_file_scan_task_stream_free(stream: *mut IcebergFileScanTaskStream) {
     if !stream.is_null() {
-        unsafe { let _ = Box::from_raw(stream); }
+        unsafe {
+            let _ = Box::from_raw(stream);
+        }
     }
 }
 
@@ -393,7 +503,9 @@ pub extern "C" fn iceberg_file_scan_task_stream_free(stream: *mut IcebergFileSca
 #[no_mangle]
 pub extern "C" fn iceberg_file_scan_task_free(task: *mut IcebergFileScanTask) {
     if !task.is_null() {
-        unsafe { let _ = Box::from_raw(task); }
+        unsafe {
+            let _ = Box::from_raw(task);
+        }
     }
 }
 
@@ -402,7 +514,9 @@ pub extern "C" fn iceberg_incremental_append_file_stream_free(
     stream: *mut IcebergIncrementalAppendFileStream,
 ) {
     if !stream.is_null() {
-        unsafe { let _ = Box::from_raw(stream); }
+        unsafe {
+            let _ = Box::from_raw(stream);
+        }
     }
 }
 
@@ -411,17 +525,19 @@ pub extern "C" fn iceberg_incremental_pos_delete_file_stream_free(
     stream: *mut IcebergIncrementalPosDeleteFileStream,
 ) {
     if !stream.is_null() {
-        unsafe { let _ = Box::from_raw(stream); }
+        unsafe {
+            let _ = Box::from_raw(stream);
+        }
     }
 }
 
 /// Free an append file. Do NOT call after passing it to read_append_file — that consumes it.
 #[no_mangle]
-pub extern "C" fn iceberg_incremental_append_file_free(
-    task: *mut IcebergIncrementalAppendFile,
-) {
+pub extern "C" fn iceberg_incremental_append_file_free(task: *mut IcebergIncrementalAppendFile) {
     if !task.is_null() {
-        unsafe { let _ = Box::from_raw(task); }
+        unsafe {
+            let _ = Box::from_raw(task);
+        }
     }
 }
 
@@ -431,7 +547,9 @@ pub extern "C" fn iceberg_incremental_pos_delete_file_free(
     task: *mut IcebergIncrementalPosDeleteFile,
 ) {
     if !task.is_null() {
-        unsafe { let _ = Box::from_raw(task); }
+        unsafe {
+            let _ = Box::from_raw(task);
+        }
     }
 }
 
@@ -489,14 +607,18 @@ export_runtime_op!(
     stream_ref,
     async {
         use futures::TryStreamExt;
+        use std::time::Instant;
         let mut stream_guard = stream_ref.stream.lock().await;
 
-        match stream_guard.try_next().await {
-            Ok(Some(record_batch)) => {
-                Ok(Some(record_batch))
-            }
+        let t = Instant::now();
+        let result = stream_guard.try_next().await;
+        SPLIT_SCAN_STATS
+            .next_batch_wait_ns
+            .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+
+        match result {
+            Ok(Some(record_batch)) => Ok(Some(record_batch)),
             Ok(None) => {
-                // End of stream
                 tracing::debug!("End of stream reached");
                 Ok(None)
             }

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -1,8 +1,9 @@
 use crate::response::IcebergBoxedResponse;
 /// Table and streaming support for iceberg_rust_ffi
 use crate::{CResult, Context, RawResponse};
-use iceberg::arrow::ArrowReader;
+use iceberg::arrow::{ArrowReader, StreamsInto, UnzippedIncrementalBatchRecordStream};
 use iceberg::io::{FileIOBuilder, OpenDalRoutingStorageFactory};
+use iceberg::scan::incremental::{AppendedFileScanTask, DeleteScanTask};
 use iceberg::scan::{FileScanTask, FileScanTaskStream};
 use iceberg::table::StaticTable;
 use iceberg::table::Table;
@@ -59,7 +60,11 @@ pub(crate) const DEFAULT_TASK_PREFETCH_DEPTH: usize = 4;
 pub struct IcebergArrowReaderContext {
     pub reader: ArrowReader,
     pub serialization_concurrency: usize,
+    /// Batch size used for positional-delete Arrow conversion; None = use DEFAULT_DELETE_BATCH_SIZE.
+    pub batch_size: Option<usize>,
 }
+
+pub(crate) const DEFAULT_DELETE_BATCH_SIZE: usize = 1024;
 
 unsafe impl Send for IcebergArrowReaderContext {}
 
@@ -122,12 +127,166 @@ impl IcebergFileScanTaskStream {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Incremental split-scan API types
+// ---------------------------------------------------------------------------
+
+/// A single appended file scan task returned by `iceberg_incremental_next_append_task`.
+pub struct IcebergIncrementalAppendTask {
+    pub task: AppendedFileScanTask,
+}
+
+unsafe impl Send for IcebergIncrementalAppendTask {}
+
+/// A single positional-delete task: a set of deleted row positions within one data file.
+/// Produced by `iceberg_incremental_next_pos_delete_task`; skips DeletedFile/EqualityDeletes.
+pub struct IcebergIncrementalPosDeleteTask {
+    pub file_path: String,
+    pub positions: Vec<u64>,
+}
+
+unsafe impl Send for IcebergIncrementalPosDeleteTask {}
+
+/// Buffered stream of `AppendedFileScanTask` items produced by incremental `plan_files`.
+pub struct IcebergIncrementalAppendTaskStream {
+    pub(crate) receiver:
+        AsyncMutex<tokio::sync::mpsc::Receiver<Result<AppendedFileScanTask, iceberg::Error>>>,
+    pub(crate) producer_handle: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+unsafe impl Send for IcebergIncrementalAppendTaskStream {}
+
+impl IcebergIncrementalAppendTaskStream {
+    pub fn new(
+        stream: futures::stream::BoxStream<'static, Result<AppendedFileScanTask, iceberg::Error>>,
+        prefetch_depth: usize,
+    ) -> Self {
+        use futures::StreamExt;
+        let (tx, rx) = tokio::sync::mpsc::channel(prefetch_depth);
+        let handle = tokio::spawn(async move {
+            futures::pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                let is_err = item.is_err();
+                if tx.send(item).await.is_err() {
+                    break;
+                }
+                if is_err {
+                    break;
+                }
+            }
+        });
+        Self {
+            receiver: AsyncMutex::new(rx),
+            producer_handle: AsyncMutex::new(Some(handle)),
+        }
+    }
+
+    pub async fn next(
+        &self,
+    ) -> Result<Option<IcebergIncrementalAppendTask>, anyhow::Error> {
+        let mut rx = self.receiver.lock().await;
+        match rx.recv().await {
+            Some(Ok(task)) => Ok(Some(IcebergIncrementalAppendTask { task })),
+            Some(Err(e)) => Err(anyhow::anyhow!("Append task planning error: {}", e)),
+            None => {
+                let mut h = self.producer_handle.lock().await;
+                if let Some(handle) = h.take() {
+                    handle.await.map_err(|e| anyhow::anyhow!("Planner panicked: {}", e))?;
+                }
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Buffered stream of positional-delete tasks produced by incremental `plan_files`.
+/// Only `DeleteScanTask::PositionalDeletes` variants are forwarded; others are dropped.
+pub struct IcebergIncrementalPosDeleteTaskStream {
+    pub(crate) receiver: AsyncMutex<
+        tokio::sync::mpsc::Receiver<Result<IcebergIncrementalPosDeleteTask, anyhow::Error>>,
+    >,
+    pub(crate) producer_handle: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+unsafe impl Send for IcebergIncrementalPosDeleteTaskStream {}
+
+impl IcebergIncrementalPosDeleteTaskStream {
+    pub fn new(
+        stream: futures::stream::BoxStream<'static, Result<DeleteScanTask, iceberg::Error>>,
+        prefetch_depth: usize,
+    ) -> Self {
+        use futures::StreamExt;
+        let (tx, rx) = tokio::sync::mpsc::channel(prefetch_depth);
+        let handle = tokio::spawn(async move {
+            futures::pin_mut!(stream);
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(DeleteScanTask::PositionalDeletes(file_path, dv)) => {
+                        let positions: Vec<u64> = dv.iter().collect();
+                        let task =
+                            IcebergIncrementalPosDeleteTask { file_path, positions };
+                        if tx.send(Ok(task)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Ok(_) => {} // skip DeletedFile and EqualityDeletes
+                    Err(e) => {
+                        let _ = tx.send(Err(anyhow::anyhow!("Delete task error: {}", e))).await;
+                        break;
+                    }
+                }
+            }
+        });
+        Self {
+            receiver: AsyncMutex::new(rx),
+            producer_handle: AsyncMutex::new(Some(handle)),
+        }
+    }
+
+    pub async fn next(
+        &self,
+    ) -> Result<Option<IcebergIncrementalPosDeleteTask>, anyhow::Error> {
+        let mut rx = self.receiver.lock().await;
+        match rx.recv().await {
+            Some(Ok(task)) => Ok(Some(task)),
+            Some(Err(e)) => Err(e),
+            None => {
+                let mut h = self.producer_handle.lock().await;
+                if let Some(handle) = h.take() {
+                    handle.await.map_err(|e| anyhow::anyhow!("Planner panicked: {}", e))?;
+                }
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Read a single `AppendedFileScanTask` into an Arrow record-batch stream.
+/// Wraps the task in a one-element stream and calls the iceberg `StreamsInto` machinery.
+pub(crate) fn read_incremental_append_task(
+    reader: ArrowReader,
+    task: AppendedFileScanTask,
+) -> iceberg::Result<iceberg::scan::ArrowRecordBatchStream> {
+    use futures::{stream, StreamExt};
+    let append_stream =
+        stream::once(async { Ok(task) }).boxed();
+    let delete_stream = stream::empty::<Result<DeleteScanTask, iceberg::Error>>().boxed();
+    let streams = (append_stream, delete_stream);
+    let (arrow_stream, _): UnzippedIncrementalBatchRecordStream =
+        StreamsInto::<ArrowReader, UnzippedIncrementalBatchRecordStream>::stream(streams, reader)?;
+    Ok(arrow_stream)
+}
+
 /// Type aliases for response types
 pub type IcebergTableResponse = IcebergBoxedResponse<IcebergTable>;
 pub type IcebergArrowStreamResponse = IcebergBoxedResponse<IcebergArrowStream>;
 pub type IcebergArrowReaderContextResponse = IcebergBoxedResponse<IcebergArrowReaderContext>;
 pub type IcebergFileScanTaskStreamResponse = IcebergBoxedResponse<IcebergFileScanTaskStream>;
 pub type IcebergFileScanTaskResponse = IcebergBoxedResponse<IcebergFileScanTask>;
+pub type IcebergIncrementalAppendTaskResponse =
+    IcebergBoxedResponse<IcebergIncrementalAppendTask>;
+pub type IcebergIncrementalPosDeleteTaskResponse =
+    IcebergBoxedResponse<IcebergIncrementalPosDeleteTask>;
 
 /// Response for next_file_scan — null value pointer means end-of-stream.
 #[repr(transparent)]
@@ -231,6 +390,44 @@ pub extern "C" fn iceberg_file_scan_task_stream_free(stream: *mut IcebergFileSca
 /// Free a file scan task. Do NOT call after passing it to read_file_scan — that consumes it.
 #[no_mangle]
 pub extern "C" fn iceberg_file_scan_task_free(task: *mut IcebergFileScanTask) {
+    if !task.is_null() {
+        unsafe { let _ = Box::from_raw(task); }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_append_task_stream_free(
+    stream: *mut IcebergIncrementalAppendTaskStream,
+) {
+    if !stream.is_null() {
+        unsafe { let _ = Box::from_raw(stream); }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_pos_delete_task_stream_free(
+    stream: *mut IcebergIncrementalPosDeleteTaskStream,
+) {
+    if !stream.is_null() {
+        unsafe { let _ = Box::from_raw(stream); }
+    }
+}
+
+/// Free an append task. Do NOT call after passing it to read_append_task — that consumes it.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_append_task_free(
+    task: *mut IcebergIncrementalAppendTask,
+) {
+    if !task.is_null() {
+        unsafe { let _ = Box::from_raw(task); }
+    }
+}
+
+/// Free a positional-delete task. Do NOT call after passing to read_pos_delete_task.
+#[no_mangle]
+pub extern "C" fn iceberg_incremental_pos_delete_task_free(
+    task: *mut IcebergIncrementalPosDeleteTask,
+) {
     if !task.is_null() {
         unsafe { let _ = Box::from_raw(task); }
     }

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -68,7 +68,7 @@ pub(crate) const DEFAULT_DELETE_BATCH_SIZE: usize = 1024;
 
 unsafe impl Send for IcebergArrowReaderContext {}
 
-/// A single file scan task (byte range of a Parquet file) returned by next_file_scan.
+/// A single file scan task (byte range of a Parquet file) returned by next_file.
 pub struct IcebergFileScanTask {
     pub task: FileScanTask,
 }
@@ -288,7 +288,7 @@ pub type IcebergIncrementalAppendFileResponse =
 pub type IcebergIncrementalPosDeleteFileResponse =
     IcebergBoxedResponse<IcebergIncrementalPosDeleteFile>;
 
-/// Response for next_file_scan — null value pointer means end-of-stream.
+/// Response for next_file — null value pointer means end-of-stream.
 #[repr(transparent)]
 pub struct IcebergNextFileScanTaskResponse(pub IcebergBoxedResponse<IcebergFileScanTask>);
 

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -62,6 +62,8 @@ pub struct IcebergArrowReaderContext {
     pub serialization_concurrency: usize,
     /// Batch size used for positional-delete Arrow conversion; None = use DEFAULT_DELETE_BATCH_SIZE.
     pub batch_size: Option<usize>,
+    /// Capacity of the per-file batch prefetch channel; 0 = use default.
+    pub batch_prefetch_depth: usize,
 }
 
 pub(crate) const DEFAULT_DELETE_BATCH_SIZE: usize = 1024;

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -131,32 +131,32 @@ impl IcebergFileScanTaskStream {
 // Incremental split-scan API types
 // ---------------------------------------------------------------------------
 
-/// A single appended file scan task returned by `iceberg_incremental_next_append_task`.
-pub struct IcebergIncrementalAppendTask {
+/// A single appended file scan task returned by `iceberg_incremental_next_append_file`.
+pub struct IcebergIncrementalAppendFile {
     pub task: AppendedFileScanTask,
 }
 
-unsafe impl Send for IcebergIncrementalAppendTask {}
+unsafe impl Send for IcebergIncrementalAppendFile {}
 
 /// A single positional-delete task: a set of deleted row positions within one data file.
-/// Produced by `iceberg_incremental_next_pos_delete_task`; skips DeletedFile/EqualityDeletes.
-pub struct IcebergIncrementalPosDeleteTask {
+/// Produced by `iceberg_incremental_next_pos_delete_file`; skips DeletedFile/EqualityDeletes.
+pub struct IcebergIncrementalPosDeleteFile {
     pub file_path: String,
     pub positions: Vec<u64>,
 }
 
-unsafe impl Send for IcebergIncrementalPosDeleteTask {}
+unsafe impl Send for IcebergIncrementalPosDeleteFile {}
 
 /// Buffered stream of `AppendedFileScanTask` items produced by incremental `plan_files`.
-pub struct IcebergIncrementalAppendTaskStream {
+pub struct IcebergIncrementalAppendFileStream {
     pub(crate) receiver:
         AsyncMutex<tokio::sync::mpsc::Receiver<Result<AppendedFileScanTask, iceberg::Error>>>,
     pub(crate) producer_handle: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
-unsafe impl Send for IcebergIncrementalAppendTaskStream {}
+unsafe impl Send for IcebergIncrementalAppendFileStream {}
 
-impl IcebergIncrementalAppendTaskStream {
+impl IcebergIncrementalAppendFileStream {
     pub fn new(
         stream: futures::stream::BoxStream<'static, Result<AppendedFileScanTask, iceberg::Error>>,
         prefetch_depth: usize,
@@ -183,10 +183,10 @@ impl IcebergIncrementalAppendTaskStream {
 
     pub async fn next(
         &self,
-    ) -> Result<Option<IcebergIncrementalAppendTask>, anyhow::Error> {
+    ) -> Result<Option<IcebergIncrementalAppendFile>, anyhow::Error> {
         let mut rx = self.receiver.lock().await;
         match rx.recv().await {
-            Some(Ok(task)) => Ok(Some(IcebergIncrementalAppendTask { task })),
+            Some(Ok(task)) => Ok(Some(IcebergIncrementalAppendFile { task })),
             Some(Err(e)) => Err(anyhow::anyhow!("Append task planning error: {}", e)),
             None => {
                 let mut h = self.producer_handle.lock().await;
@@ -201,16 +201,16 @@ impl IcebergIncrementalAppendTaskStream {
 
 /// Buffered stream of positional-delete tasks produced by incremental `plan_files`.
 /// Only `DeleteScanTask::PositionalDeletes` variants are forwarded; others are dropped.
-pub struct IcebergIncrementalPosDeleteTaskStream {
+pub struct IcebergIncrementalPosDeleteFileStream {
     pub(crate) receiver: AsyncMutex<
-        tokio::sync::mpsc::Receiver<Result<IcebergIncrementalPosDeleteTask, anyhow::Error>>,
+        tokio::sync::mpsc::Receiver<Result<IcebergIncrementalPosDeleteFile, anyhow::Error>>,
     >,
     pub(crate) producer_handle: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
-unsafe impl Send for IcebergIncrementalPosDeleteTaskStream {}
+unsafe impl Send for IcebergIncrementalPosDeleteFileStream {}
 
-impl IcebergIncrementalPosDeleteTaskStream {
+impl IcebergIncrementalPosDeleteFileStream {
     pub fn new(
         stream: futures::stream::BoxStream<'static, Result<DeleteScanTask, iceberg::Error>>,
         prefetch_depth: usize,
@@ -224,7 +224,7 @@ impl IcebergIncrementalPosDeleteTaskStream {
                     Ok(DeleteScanTask::PositionalDeletes(file_path, dv)) => {
                         let positions: Vec<u64> = dv.iter().collect();
                         let task =
-                            IcebergIncrementalPosDeleteTask { file_path, positions };
+                            IcebergIncrementalPosDeleteFile { file_path, positions };
                         if tx.send(Ok(task)).await.is_err() {
                             break;
                         }
@@ -245,7 +245,7 @@ impl IcebergIncrementalPosDeleteTaskStream {
 
     pub async fn next(
         &self,
-    ) -> Result<Option<IcebergIncrementalPosDeleteTask>, anyhow::Error> {
+    ) -> Result<Option<IcebergIncrementalPosDeleteFile>, anyhow::Error> {
         let mut rx = self.receiver.lock().await;
         match rx.recv().await {
             Some(Ok(task)) => Ok(Some(task)),
@@ -263,7 +263,7 @@ impl IcebergIncrementalPosDeleteTaskStream {
 
 /// Read a single `AppendedFileScanTask` into an Arrow record-batch stream.
 /// Wraps the task in a one-element stream and calls the iceberg `StreamsInto` machinery.
-pub(crate) fn read_incremental_append_task(
+pub(crate) fn read_incremental_append_file(
     reader: ArrowReader,
     task: AppendedFileScanTask,
 ) -> iceberg::Result<iceberg::scan::ArrowRecordBatchStream> {
@@ -283,10 +283,10 @@ pub type IcebergArrowStreamResponse = IcebergBoxedResponse<IcebergArrowStream>;
 pub type IcebergArrowReaderContextResponse = IcebergBoxedResponse<IcebergArrowReaderContext>;
 pub type IcebergFileScanTaskStreamResponse = IcebergBoxedResponse<IcebergFileScanTaskStream>;
 pub type IcebergFileScanTaskResponse = IcebergBoxedResponse<IcebergFileScanTask>;
-pub type IcebergIncrementalAppendTaskResponse =
-    IcebergBoxedResponse<IcebergIncrementalAppendTask>;
-pub type IcebergIncrementalPosDeleteTaskResponse =
-    IcebergBoxedResponse<IcebergIncrementalPosDeleteTask>;
+pub type IcebergIncrementalAppendFileResponse =
+    IcebergBoxedResponse<IcebergIncrementalAppendFile>;
+pub type IcebergIncrementalPosDeleteFileResponse =
+    IcebergBoxedResponse<IcebergIncrementalPosDeleteFile>;
 
 /// Response for next_file_scan — null value pointer means end-of-stream.
 #[repr(transparent)]
@@ -396,8 +396,8 @@ pub extern "C" fn iceberg_file_scan_task_free(task: *mut IcebergFileScanTask) {
 }
 
 #[no_mangle]
-pub extern "C" fn iceberg_incremental_append_task_stream_free(
-    stream: *mut IcebergIncrementalAppendTaskStream,
+pub extern "C" fn iceberg_incremental_append_file_stream_free(
+    stream: *mut IcebergIncrementalAppendFileStream,
 ) {
     if !stream.is_null() {
         unsafe { let _ = Box::from_raw(stream); }
@@ -405,28 +405,28 @@ pub extern "C" fn iceberg_incremental_append_task_stream_free(
 }
 
 #[no_mangle]
-pub extern "C" fn iceberg_incremental_pos_delete_task_stream_free(
-    stream: *mut IcebergIncrementalPosDeleteTaskStream,
+pub extern "C" fn iceberg_incremental_pos_delete_file_stream_free(
+    stream: *mut IcebergIncrementalPosDeleteFileStream,
 ) {
     if !stream.is_null() {
         unsafe { let _ = Box::from_raw(stream); }
     }
 }
 
-/// Free an append task. Do NOT call after passing it to read_append_task — that consumes it.
+/// Free an append file. Do NOT call after passing it to read_append_file — that consumes it.
 #[no_mangle]
-pub extern "C" fn iceberg_incremental_append_task_free(
-    task: *mut IcebergIncrementalAppendTask,
+pub extern "C" fn iceberg_incremental_append_file_free(
+    task: *mut IcebergIncrementalAppendFile,
 ) {
     if !task.is_null() {
         unsafe { let _ = Box::from_raw(task); }
     }
 }
 
-/// Free a positional-delete task. Do NOT call after passing to read_pos_delete_task.
+/// Free a positional-delete file. Do NOT call after passing to read_pos_delete_file.
 #[no_mangle]
-pub extern "C" fn iceberg_incremental_pos_delete_task_free(
-    task: *mut IcebergIncrementalPosDeleteTask,
+pub extern "C" fn iceberg_incremental_pos_delete_file_free(
+    task: *mut IcebergIncrementalPosDeleteFile,
 ) {
     if !task.is_null() {
         unsafe { let _ = Box::from_raw(task); }

--- a/iceberg_rust_ffi/src/warm_file_stream.rs
+++ b/iceberg_rust_ffi/src/warm_file_stream.rs
@@ -15,10 +15,12 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
+use arrow_array::RecordBatch;
 use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
 use futures::StreamExt;
 use iceberg::arrow::ArrowReader;
+use iceberg::scan::incremental::AppendedFileScanTask;
 use iceberg::scan::{FileScanTask, FileScanTaskStream};
 use tokio::sync::{mpsc, Mutex as AsyncMutex, Semaphore};
 
@@ -290,6 +292,47 @@ impl IcebergWarmFileScanStream {
 
 pub type IcebergWarmFileScanStreamResponse = IcebergBoxedResponse<IcebergWarmFileScanStream>;
 
+/// Response for iceberg_plan_incremental_warm — returns warm append stream +
+/// delete stream in one FFI call so plan_files() is only called once.
+#[repr(C)]
+pub struct IcebergWarmIncrementalStreamsResponse {
+    result: CResult,
+    pub append_warm_stream: *mut IcebergWarmFileScanStream,
+    pub delete_stream: *mut crate::table::IcebergIncrementalPosDeleteFileStream,
+    error_message: *mut c_char,
+    context: *const Context,
+}
+
+unsafe impl Send for IcebergWarmIncrementalStreamsResponse {}
+
+impl RawResponse for IcebergWarmIncrementalStreamsResponse {
+    type Payload = (
+        IcebergWarmFileScanStream,
+        crate::table::IcebergIncrementalPosDeleteFileStream,
+    );
+    fn result_mut(&mut self) -> &mut CResult {
+        &mut self.result
+    }
+    fn context_mut(&mut self) -> &mut *const Context {
+        &mut self.context
+    }
+    fn error_message_mut(&mut self) -> &mut *mut c_char {
+        &mut self.error_message
+    }
+    fn set_payload(&mut self, payload: Option<Self::Payload>) {
+        match payload {
+            Some((append, delete)) => {
+                self.append_warm_stream = Box::into_raw(Box::new(append));
+                self.delete_stream = Box::into_raw(Box::new(delete));
+            }
+            None => {
+                self.append_warm_stream = std::ptr::null_mut();
+                self.delete_stream = std::ptr::null_mut();
+            }
+        }
+    }
+}
+
 #[repr(transparent)]
 pub struct IcebergNextWarmFileScanResponse(pub IcebergBoxedResponse<IcebergWarmFileScan>);
 
@@ -350,44 +393,41 @@ pub(crate) fn spawn_file_task(
 
 /// Wrapper: sends error to channel and updates stats on failure.
 /// Dropping `tx` signals the consumer that this file is done.
-async fn process_file(
-    task: FileScanTask,
-    reader: ArrowReader,
-    semaphore: Arc<Semaphore>,
+/// Generic wrapper: runs an async producer, forwards any error, updates stats.
+async fn run_file_task<Fut>(
+    producer: impl FnOnce() -> Fut,
     tx: mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
-) {
-    let result = process_file_inner(task, reader, semaphore, &tx).await;
+) where
+    Fut: std::future::Future<Output = Result<(), iceberg::Error>>,
+{
+    let result = producer().await;
     if let Err(e) = result {
         let _ = tx.send(Err(e)).await;
     }
     WARM_SCAN_STATS.track_task_end();
 }
 
-/// Process a single Parquet file through four timed phases:
-///   1. Reader setup — clone reader, call read(), open parquet footer
-///   2. Fetch + decode — batch_stream.next()
-///   3. Serialize — RecordBatch → Arrow IPC via spawn_blocking
-///   4. Backpressure — semaphore acquire
-async fn process_file_inner(
+async fn process_file(
     task: FileScanTask,
     reader: ArrowReader,
     semaphore: Arc<Semaphore>,
+    tx: mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
+) {
+    run_file_task(
+        || process_file_inner(task, reader, semaphore, &tx),
+        tx.clone(),
+    )
+    .await;
+}
+
+/// Shared phases 2-4: drain a RecordBatch stream into the file channel.
+/// Called by both process_file_inner (full scan) and
+/// process_incremental_append_file_inner (incremental).
+async fn drain_batch_stream(
+    mut batch_stream: impl futures::Stream<Item = Result<RecordBatch, iceberg::Error>> + Unpin,
+    semaphore: Arc<Semaphore>,
     tx: &mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
 ) -> Result<(), iceberg::Error> {
-    WARM_SCAN_STATS.track_task_start();
-
-    // ── Phase 1: Reader setup ───────────────────────────────────────────
-    let setup_start = Instant::now();
-    let task_stream = Box::pin(futures::stream::once(async { Ok(task) }));
-    let batch_stream = reader
-        .read(task_stream)
-        .map_err(|e| iceberg::Error::new(iceberg::ErrorKind::Unexpected, e.to_string()))?;
-    WARM_SCAN_STATS
-        .reader_setup_ns
-        .fetch_add(setup_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
-
-    tokio::pin!(batch_stream);
-
     loop {
         // ── Phase 2: Fetch + decode ─────────────────────────────────────
         let fd_start = Instant::now();
@@ -433,7 +473,7 @@ async fn process_file_inner(
         WARM_SCAN_STATS
             .semaphore_wait_ns
             .fetch_add(sem_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
-        std::mem::forget(_permit); // consumer releases via add_permits()
+        std::mem::forget(_permit);
 
         WARM_SCAN_STATS.track_buffer_add(byte_len as u64);
 
@@ -450,26 +490,100 @@ async fn process_file_inner(
             .batch_send_ns
             .fetch_add(send_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
         if send_err {
-            return Ok(()); // consumer dropped the receiver
+            return Ok(());
         }
     }
-
     WARM_SCAN_STATS
         .files_completed
         .fetch_add(1, Ordering::Relaxed);
     Ok(())
 }
 
-/// Orchestrator: drives the planning stream, keeps `task_prefetch_depth` file
-/// tasks in flight via FuturesOrdered, and sends `IcebergWarmFileScan` items
-/// (metadata + per-file batch stream) to `outer_tx` in manifest order.
-pub(crate) async fn run_warm(
-    task_stream: FileScanTaskStream,
+async fn process_file_inner(
+    task: FileScanTask,
+    reader: ArrowReader,
+    semaphore: Arc<Semaphore>,
+    tx: &mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
+) -> Result<(), iceberg::Error> {
+    WARM_SCAN_STATS.track_task_start();
+    let setup_start = Instant::now();
+    let task_stream = Box::pin(futures::stream::once(async { Ok(task) }));
+    let batch_stream = reader
+        .read(task_stream)
+        .map_err(|e| iceberg::Error::new(iceberg::ErrorKind::Unexpected, e.to_string()))?;
+    WARM_SCAN_STATS
+        .reader_setup_ns
+        .fetch_add(setup_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+    tokio::pin!(batch_stream);
+    drain_batch_stream(batch_stream, semaphore, tx).await
+}
+
+// ===========================================================================
+// Incremental append file support
+// ===========================================================================
+
+pub(crate) fn spawn_incremental_append_task(
+    task: AppendedFileScanTask,
+    reader: ArrowReader,
+    batch_prefetch_depth: usize,
+) -> BoxFuture<'static, SpawnFileTaskResult> {
+    let file_path = CString::new(task.base.data_file_path.as_str())
+        .unwrap_or_else(|_| CString::new("").unwrap());
+    let record_count = task.base.record_count;
+    let sem = Arc::new(Semaphore::new(MAX_BUFFERED_BYTES_PER_FILE));
+    let (file_tx, file_rx) = mpsc::channel(batch_prefetch_depth);
+    tokio::spawn(process_incremental_append_file(task, reader, sem, file_tx));
+    Box::pin(async move { Ok((file_path, record_count, file_rx)) })
+}
+
+async fn process_incremental_append_file(
+    task: AppendedFileScanTask,
+    reader: ArrowReader,
+    semaphore: Arc<Semaphore>,
+    tx: mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
+) {
+    run_file_task(
+        || process_incremental_append_file_inner(task, reader, semaphore, &tx),
+        tx.clone(),
+    )
+    .await;
+}
+
+async fn process_incremental_append_file_inner(
+    task: AppendedFileScanTask,
+    reader: ArrowReader,
+    semaphore: Arc<Semaphore>,
+    tx: &mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
+) -> Result<(), iceberg::Error> {
+    WARM_SCAN_STATS.track_task_start();
+    let setup_start = Instant::now();
+    let batch_stream = crate::table::read_incremental_append_file(reader, task)
+        .map_err(|e| iceberg::Error::new(iceberg::ErrorKind::Unexpected, e.to_string()))?;
+    WARM_SCAN_STATS
+        .reader_setup_ns
+        .fetch_add(setup_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+    tokio::pin!(batch_stream);
+    drain_batch_stream(batch_stream, semaphore, tx).await
+}
+
+/// Shared FuturesOrdered orchestrator. Drives any planning stream, keeps
+/// `task_prefetch_depth` file tasks in flight, and forwards
+/// `IcebergWarmFileScan` items to `outer_tx` in order.
+///
+/// `spawn_fn` maps a task + reader + batch_prefetch_depth to a boxed future
+/// that resolves immediately to the file's batch-channel receiver.
+async fn run_warm_orchestrator<T, S, F>(
+    task_stream: S,
     reader: ArrowReader,
     task_prefetch_depth: usize,
     batch_prefetch_depth: usize,
     outer_tx: mpsc::Sender<Result<IcebergWarmFileScan, anyhow::Error>>,
-) {
+    spawn_fn: F,
+) where
+    T: Send + 'static,
+    S: futures::Stream<Item = Result<T, iceberg::Error>> + Unpin + Send,
+    F: Fn(T, ArrowReader, usize) -> BoxFuture<'static, SpawnFileTaskResult>,
+{
     let pipeline_start = Instant::now();
     let mut in_flight: FuturesOrdered<BoxFuture<'static, SpawnFileTaskResult>> =
         FuturesOrdered::new();
@@ -477,11 +591,10 @@ pub(crate) async fn run_warm(
     futures::pin_mut!(task_stream);
     let mut stream_done = false;
 
-    // Seed first task_prefetch_depth tasks.
     for _ in 0..task_prefetch_depth {
         match task_stream.next().await {
             Some(Ok(task)) => {
-                in_flight.push_back(spawn_file_task(task, reader.clone(), batch_prefetch_depth));
+                in_flight.push_back(spawn_fn(task, reader.clone(), batch_prefetch_depth));
             }
             Some(Err(e)) => {
                 let _ = outer_tx
@@ -497,15 +610,10 @@ pub(crate) async fn run_warm(
     }
 
     while let Some(file_result) = in_flight.next().await {
-        // Eagerly seed next task to keep the window full.
         if !stream_done {
             match task_stream.next().await {
                 Some(Ok(task)) => {
-                    in_flight.push_back(spawn_file_task(
-                        task,
-                        reader.clone(),
-                        batch_prefetch_depth,
-                    ));
+                    in_flight.push_back(spawn_fn(task, reader.clone(), batch_prefetch_depth));
                 }
                 Some(Err(e)) => {
                     let _ = outer_tx
@@ -525,8 +633,6 @@ pub(crate) async fn run_warm(
             }
         };
 
-        // Wrap per-file receiver as an IcebergArrowStream. The unfold releases
-        // semaphore permits as Julia drains batches, unblocking the producer.
         let stream = futures::stream::unfold(
             file_rx,
             |mut rx: mpsc::Receiver<Result<BufferedBatch, iceberg::Error>>| async move {
@@ -556,7 +662,7 @@ pub(crate) async fn run_warm(
             .file_send_ns
             .fetch_add(fsend_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
         if fsend_err {
-            return; // Julia dropped the outer stream
+            return;
         }
     }
 
@@ -564,4 +670,40 @@ pub(crate) async fn run_warm(
         pipeline_start.elapsed().as_nanos() as u64,
         Ordering::Relaxed,
     );
+}
+
+pub(crate) async fn run_warm(
+    task_stream: FileScanTaskStream,
+    reader: ArrowReader,
+    task_prefetch_depth: usize,
+    batch_prefetch_depth: usize,
+    outer_tx: mpsc::Sender<Result<IcebergWarmFileScan, anyhow::Error>>,
+) {
+    run_warm_orchestrator(
+        task_stream,
+        reader,
+        task_prefetch_depth,
+        batch_prefetch_depth,
+        outer_tx,
+        spawn_file_task,
+    )
+    .await;
+}
+
+pub(crate) async fn run_warm_append(
+    task_stream: futures::stream::BoxStream<'static, Result<AppendedFileScanTask, iceberg::Error>>,
+    reader: ArrowReader,
+    task_prefetch_depth: usize,
+    batch_prefetch_depth: usize,
+    outer_tx: mpsc::Sender<Result<IcebergWarmFileScan, anyhow::Error>>,
+) {
+    run_warm_orchestrator(
+        task_stream,
+        reader,
+        task_prefetch_depth,
+        batch_prefetch_depth,
+        outer_tx,
+        spawn_incremental_append_task,
+    )
+    .await;
 }

--- a/iceberg_rust_ffi/src/warm_file_stream.rs
+++ b/iceberg_rust_ffi/src/warm_file_stream.rs
@@ -1,0 +1,567 @@
+//! Warm file stream: plan N files concurrently, yield one per-file batch stream
+//! at a time in manifest order.
+//!
+//! Modelled on `ordered_file_pipeline.rs` but instead of a single flat batch
+//! stream, returns a stream of `IcebergWarmFileScan` items — each containing
+//! file metadata and an already-running per-file batch channel.
+//!
+//! # Memory bounding
+//! Each file task owns a `Semaphore(MAX_BUFFERED_BYTES_PER_FILE)`. The producer
+//! acquires `byte_len` permits before sending each `BufferedBatch`; the consumer
+//! releases them as Julia drains batches from the per-file `IcebergArrowStream`.
+
+use std::ffi::{c_char, CString};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use futures::future::BoxFuture;
+use futures::stream::FuturesOrdered;
+use futures::StreamExt;
+use iceberg::arrow::ArrowReader;
+use iceberg::scan::{FileScanTask, FileScanTaskStream};
+use tokio::sync::{mpsc, Mutex as AsyncMutex, Semaphore};
+
+use crate::response::IcebergBoxedResponse;
+use crate::table::{ArrowBatch, IcebergArrowStream};
+use crate::{CResult, Context, RawResponse};
+
+/// Per-file cap on serialized bytes buffered ahead of the consumer.
+pub(crate) const MAX_BUFFERED_BYTES_PER_FILE: usize = 100 * 1024 * 1024;
+
+// ===========================================================================
+// Stats
+// ===========================================================================
+
+pub(crate) struct WarmScanStats {
+    /// Wall time from run_warm start to end (ns).
+    pub(crate) pipeline_wall_ns: AtomicU64,
+    pub(crate) files_completed: AtomicUsize,
+    pub(crate) batches_produced: AtomicUsize,
+    pub(crate) bytes_produced: AtomicU64,
+    pub(crate) peak_concurrency: AtomicUsize,
+    active_tasks: AtomicUsize,
+    /// Phase 1: build reader, open parquet footer, resolve schema, load deletes.
+    pub(crate) reader_setup_ns: AtomicU64,
+    /// Phase 2: fetch + decompress + decode row group.
+    pub(crate) fetch_decode_ns: AtomicU64,
+    /// Phase 3: RecordBatch → Arrow IPC (spawn_blocking).
+    pub(crate) serialize_ns: AtomicU64,
+    /// Phase 4: semaphore acquire — producer blocked waiting for Julia to drain.
+    pub(crate) semaphore_wait_ns: AtomicU64,
+    /// Time blocked on per-file batch channel send (channel full = Julia draining slowly).
+    pub(crate) batch_send_ns: AtomicU64,
+    /// Time blocked on outer file channel send (task_prefetch_depth slots full).
+    pub(crate) file_send_ns: AtomicU64,
+    /// Time Julia waits in iceberg_next_warm_file (outer channel recv latency).
+    pub(crate) consumer_wait_ns: AtomicU64,
+    buffered_bytes: AtomicU64,
+    pub(crate) peak_buffered_bytes: AtomicU64,
+}
+
+impl WarmScanStats {
+    const fn new() -> Self {
+        Self {
+            pipeline_wall_ns: AtomicU64::new(0),
+            files_completed: AtomicUsize::new(0),
+            batches_produced: AtomicUsize::new(0),
+            bytes_produced: AtomicU64::new(0),
+            peak_concurrency: AtomicUsize::new(0),
+            active_tasks: AtomicUsize::new(0),
+            reader_setup_ns: AtomicU64::new(0),
+            fetch_decode_ns: AtomicU64::new(0),
+            serialize_ns: AtomicU64::new(0),
+            semaphore_wait_ns: AtomicU64::new(0),
+            batch_send_ns: AtomicU64::new(0),
+            file_send_ns: AtomicU64::new(0),
+            consumer_wait_ns: AtomicU64::new(0),
+            buffered_bytes: AtomicU64::new(0),
+            peak_buffered_bytes: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn reset(&self) {
+        self.pipeline_wall_ns.store(0, Ordering::Relaxed);
+        self.files_completed.store(0, Ordering::Relaxed);
+        self.batches_produced.store(0, Ordering::Relaxed);
+        self.bytes_produced.store(0, Ordering::Relaxed);
+        self.peak_concurrency.store(0, Ordering::Relaxed);
+        self.active_tasks.store(0, Ordering::Relaxed);
+        self.reader_setup_ns.store(0, Ordering::Relaxed);
+        self.fetch_decode_ns.store(0, Ordering::Relaxed);
+        self.serialize_ns.store(0, Ordering::Relaxed);
+        self.semaphore_wait_ns.store(0, Ordering::Relaxed);
+        self.batch_send_ns.store(0, Ordering::Relaxed);
+        self.file_send_ns.store(0, Ordering::Relaxed);
+        self.consumer_wait_ns.store(0, Ordering::Relaxed);
+        self.buffered_bytes.store(0, Ordering::Relaxed);
+        self.peak_buffered_bytes.store(0, Ordering::Relaxed);
+    }
+
+    fn track_task_start(&self) {
+        let prev = self.active_tasks.fetch_add(1, Ordering::Relaxed);
+        self.peak_concurrency.fetch_max(prev + 1, Ordering::Relaxed);
+    }
+
+    fn track_task_end(&self) {
+        self.active_tasks.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    fn track_buffer_add(&self, bytes: u64) {
+        let prev = self.buffered_bytes.fetch_add(bytes, Ordering::Relaxed);
+        self.peak_buffered_bytes
+            .fetch_max(prev + bytes, Ordering::Relaxed);
+    }
+
+    pub(crate) fn track_buffer_release(&self, bytes: u64) {
+        self.buffered_bytes.fetch_sub(bytes, Ordering::Relaxed);
+    }
+
+    pub(crate) fn print_summary(&self) {
+        let wall_ms = self.pipeline_wall_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let files = self.files_completed.load(Ordering::Relaxed);
+        let batches = self.batches_produced.load(Ordering::Relaxed);
+        let bytes = self.bytes_produced.load(Ordering::Relaxed);
+        let peak = self.peak_concurrency.load(Ordering::Relaxed);
+        let setup_ms = self.reader_setup_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let fd_ms = self.fetch_decode_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let ser_ms = self.serialize_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let sem_ms = self.semaphore_wait_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let send_ms = self.batch_send_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let fsend_ms = self.file_send_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let con_ms = self.consumer_wait_ns.load(Ordering::Relaxed) as f64 / 1e6;
+        let peak_buf = self.peak_buffered_bytes.load(Ordering::Relaxed) as f64 / (1024.0 * 1024.0);
+        let bytes_mb = bytes as f64 / (1024.0 * 1024.0);
+        let limit_mb = MAX_BUFFERED_BYTES_PER_FILE / (1024 * 1024);
+        let throughput = if wall_ms > 0.0 {
+            bytes_mb / (wall_ms / 1000.0)
+        } else {
+            0.0
+        };
+        let file_wall_ms = setup_ms + fd_ms + ser_ms + sem_ms;
+        let parallelism = if wall_ms > 0.0 {
+            file_wall_ms / wall_ms
+        } else {
+            0.0
+        };
+
+        const BOX: usize = 68;
+        let row = |content: &str| {
+            let pad = (BOX - 6).saturating_sub(content.len());
+            println!("│  {}{:pad$}  │", content, "", pad = pad);
+        };
+        let dashes = |n: usize| -> String { "─".repeat(n) };
+        let sep = |label: &str| {
+            let fill = (BOX - 10).saturating_sub(label.len());
+            println!("│  {} {} {}  │", dashes(2), label, dashes(fill));
+        };
+        let border = |left: char, right: char| {
+            println!("{}{}{}", left, dashes(BOX - 2), right);
+        };
+
+        border('┌', '┐');
+        row("Warm-Scan Stats");
+        row("");
+        row(&format!("wall time:       {:>9.1} ms", wall_ms));
+        row(&format!(
+            "files:           {:>9}       peak concurrency: {}",
+            files, peak
+        ));
+        row(&format!(
+            "batches:         {:>9}       serialized: {:.1} MB",
+            batches, bytes_mb
+        ));
+        row(&format!(
+            "throughput:      {:>9.1} MB/s  parallelism: {:.1}x",
+            throughput, parallelism
+        ));
+        sep("time across all file tasks (sum)");
+        row(&format!(
+            "reader setup:    {:>9.1} ms    (open, metadata, deletes)",
+            setup_ms
+        ));
+        row(&format!(
+            "fetch+decode:    {:>9.1} ms    (I/O + ZSTD + decode)",
+            fd_ms
+        ));
+        row(&format!(
+            "serialize IPC:   {:>9.1} ms    (RecordBatch -> Arrow IPC)",
+            ser_ms
+        ));
+        row(&format!(
+            "semaphore wait:  {:>9.1} ms    (backpressure)",
+            sem_ms
+        ));
+        row(&format!(
+            "batch send:      {:>9.1} ms    (channel send to Julia)",
+            send_ms
+        ));
+        row(&format!(
+            "file send:       {:>9.1} ms    (outer channel send, depth full)",
+            fsend_ms
+        ));
+        sep("consumer");
+        row(&format!(
+            "next_file wait:  {:>9.1} ms    (Julia waiting for next file)",
+            con_ms
+        ));
+        sep("memory");
+        row(&format!(
+            "peak buffered:   {:>9.1} MB    (limit: {} MB/file)",
+            peak_buf, limit_mb
+        ));
+        border('└', '┘');
+    }
+}
+
+pub(crate) static WARM_SCAN_STATS: WarmScanStats = WarmScanStats::new();
+
+#[no_mangle]
+pub extern "C" fn iceberg_print_warm_scan_stats() {
+    WARM_SCAN_STATS.print_summary();
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_reset_warm_scan_stats() {
+    WARM_SCAN_STATS.reset();
+}
+
+// ===========================================================================
+// Core types
+// ===========================================================================
+
+/// A serialized batch bundled with its size and the file's semaphore so the
+/// consumer can release permits when the batch is drained.
+pub(crate) struct BufferedBatch {
+    pub(crate) batch: ArrowBatch,
+    pub(crate) byte_len: usize,
+    pub(crate) semaphore: Arc<Semaphore>,
+}
+
+/// One file's worth of metadata + an already-running batch stream.
+/// The stream's unfold releases semaphore permits as Julia drains batches.
+pub struct IcebergWarmFileScan {
+    pub file_path: CString,
+    pub record_count: Option<u64>,
+    pub stream: IcebergArrowStream,
+}
+
+unsafe impl Send for IcebergWarmFileScan {}
+
+/// Stream of warm files. A background producer runs `run_warm`, which uses
+/// `FuturesOrdered` to keep `task_prefetch_depth` file tasks in flight and
+/// sends ready `IcebergWarmFileScan` items to the channel in manifest order.
+pub struct IcebergWarmFileScanStream {
+    pub(crate) receiver: AsyncMutex<mpsc::Receiver<Result<IcebergWarmFileScan, anyhow::Error>>>,
+    pub(crate) producer_handle: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+unsafe impl Send for IcebergWarmFileScanStream {}
+
+impl IcebergWarmFileScanStream {
+    pub async fn next(&self) -> Result<Option<IcebergWarmFileScan>, anyhow::Error> {
+        let mut rx = self.receiver.lock().await;
+        let t = Instant::now();
+        let result = rx.recv().await;
+        WARM_SCAN_STATS
+            .consumer_wait_ns
+            .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        match result {
+            Some(Ok(item)) => Ok(Some(item)),
+            Some(Err(e)) => Err(e),
+            None => {
+                let mut handle_guard = self.producer_handle.lock().await;
+                if let Some(handle) = handle_guard.take() {
+                    match handle.await {
+                        Ok(()) => Ok(None),
+                        Err(e) => Err(anyhow::anyhow!("Warm scan producer panicked: {}", e)),
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
+// ===========================================================================
+// Response types
+// ===========================================================================
+
+pub type IcebergWarmFileScanStreamResponse = IcebergBoxedResponse<IcebergWarmFileScanStream>;
+
+#[repr(transparent)]
+pub struct IcebergNextWarmFileScanResponse(pub IcebergBoxedResponse<IcebergWarmFileScan>);
+
+unsafe impl Send for IcebergNextWarmFileScanResponse {}
+
+impl RawResponse for IcebergNextWarmFileScanResponse {
+    type Payload = Option<IcebergWarmFileScan>;
+    fn result_mut(&mut self) -> &mut CResult {
+        &mut self.0.result
+    }
+    fn context_mut(&mut self) -> &mut *const Context {
+        &mut self.0.context
+    }
+    fn error_message_mut(&mut self) -> &mut *mut c_char {
+        &mut self.0.error_message
+    }
+    fn set_payload(&mut self, payload: Option<Self::Payload>) {
+        use std::ptr;
+        match payload.flatten() {
+            Some(item) => self.0.value = Box::into_raw(Box::new(item)),
+            None => self.0.value = ptr::null_mut(),
+        }
+    }
+}
+
+// ===========================================================================
+// Pipeline implementation
+// ===========================================================================
+
+type SpawnFileTaskResult = Result<
+    (
+        CString,
+        Option<u64>,
+        mpsc::Receiver<Result<BufferedBatch, iceberg::Error>>,
+    ),
+    anyhow::Error,
+>;
+
+/// Spawn a single file task. Captures metadata, creates per-file channel and
+/// semaphore, spawns `process_file` in background, and returns immediately.
+/// The returned future resolves instantly to the receiver so FuturesOrdered
+/// yields them in push order.
+pub(crate) fn spawn_file_task(
+    task: FileScanTask,
+    reader: ArrowReader,
+    batch_prefetch_depth: usize,
+) -> BoxFuture<'static, SpawnFileTaskResult> {
+    let file_path =
+        CString::new(task.data_file_path.as_str()).unwrap_or_else(|_| CString::new("").unwrap());
+    let record_count = task.record_count;
+    let sem = Arc::new(Semaphore::new(MAX_BUFFERED_BYTES_PER_FILE));
+    let (file_tx, file_rx) = mpsc::channel(batch_prefetch_depth);
+
+    tokio::spawn(process_file(task, reader, sem, file_tx));
+
+    Box::pin(async move { Ok((file_path, record_count, file_rx)) })
+}
+
+/// Wrapper: sends error to channel and updates stats on failure.
+/// Dropping `tx` signals the consumer that this file is done.
+async fn process_file(
+    task: FileScanTask,
+    reader: ArrowReader,
+    semaphore: Arc<Semaphore>,
+    tx: mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
+) {
+    let result = process_file_inner(task, reader, semaphore, &tx).await;
+    if let Err(e) = result {
+        let _ = tx.send(Err(e)).await;
+    }
+    WARM_SCAN_STATS.track_task_end();
+}
+
+/// Process a single Parquet file through four timed phases:
+///   1. Reader setup — clone reader, call read(), open parquet footer
+///   2. Fetch + decode — batch_stream.next()
+///   3. Serialize — RecordBatch → Arrow IPC via spawn_blocking
+///   4. Backpressure — semaphore acquire
+async fn process_file_inner(
+    task: FileScanTask,
+    reader: ArrowReader,
+    semaphore: Arc<Semaphore>,
+    tx: &mpsc::Sender<Result<BufferedBatch, iceberg::Error>>,
+) -> Result<(), iceberg::Error> {
+    WARM_SCAN_STATS.track_task_start();
+
+    // ── Phase 1: Reader setup ───────────────────────────────────────────
+    let setup_start = Instant::now();
+    let task_stream = Box::pin(futures::stream::once(async { Ok(task) }));
+    let batch_stream = reader
+        .read(task_stream)
+        .map_err(|e| iceberg::Error::new(iceberg::ErrorKind::Unexpected, e.to_string()))?;
+    WARM_SCAN_STATS
+        .reader_setup_ns
+        .fetch_add(setup_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+
+    tokio::pin!(batch_stream);
+
+    loop {
+        // ── Phase 2: Fetch + decode ─────────────────────────────────────
+        let fd_start = Instant::now();
+        let batch_opt = batch_stream.next().await;
+        WARM_SCAN_STATS
+            .fetch_decode_ns
+            .fetch_add(fd_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+
+        let batch = match batch_opt {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => return Err(e),
+            None => break,
+        };
+
+        // ── Phase 3: Serialize to Arrow IPC ─────────────────────────────
+        let ser_start = Instant::now();
+        let serialized = tokio::task::spawn_blocking(move || crate::serialize_record_batch(batch))
+            .await
+            .map_err(|e| {
+                iceberg::Error::new(
+                    iceberg::ErrorKind::Unexpected,
+                    format!("serialize panicked: {e}"),
+                )
+            })?
+            .map_err(|e| iceberg::Error::new(iceberg::ErrorKind::Unexpected, e.to_string()))?;
+        WARM_SCAN_STATS
+            .serialize_ns
+            .fetch_add(ser_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+
+        let byte_len = serialized.length;
+        WARM_SCAN_STATS
+            .batches_produced
+            .fetch_add(1, Ordering::Relaxed);
+        WARM_SCAN_STATS
+            .bytes_produced
+            .fetch_add(byte_len as u64, Ordering::Relaxed);
+
+        // ── Phase 4: Backpressure ───────────────────────────────────────
+        let sem_start = Instant::now();
+        let _permit = semaphore.acquire_many(byte_len as u32).await.map_err(|e| {
+            iceberg::Error::new(iceberg::ErrorKind::Unexpected, format!("semaphore: {e}"))
+        })?;
+        WARM_SCAN_STATS
+            .semaphore_wait_ns
+            .fetch_add(sem_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        std::mem::forget(_permit); // consumer releases via add_permits()
+
+        WARM_SCAN_STATS.track_buffer_add(byte_len as u64);
+
+        let send_start = Instant::now();
+        let send_err = tx
+            .send(Ok(BufferedBatch {
+                batch: serialized,
+                byte_len,
+                semaphore: semaphore.clone(),
+            }))
+            .await
+            .is_err();
+        WARM_SCAN_STATS
+            .batch_send_ns
+            .fetch_add(send_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        if send_err {
+            return Ok(()); // consumer dropped the receiver
+        }
+    }
+
+    WARM_SCAN_STATS
+        .files_completed
+        .fetch_add(1, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Orchestrator: drives the planning stream, keeps `task_prefetch_depth` file
+/// tasks in flight via FuturesOrdered, and sends `IcebergWarmFileScan` items
+/// (metadata + per-file batch stream) to `outer_tx` in manifest order.
+pub(crate) async fn run_warm(
+    task_stream: FileScanTaskStream,
+    reader: ArrowReader,
+    task_prefetch_depth: usize,
+    batch_prefetch_depth: usize,
+    outer_tx: mpsc::Sender<Result<IcebergWarmFileScan, anyhow::Error>>,
+) {
+    let pipeline_start = Instant::now();
+    let mut in_flight: FuturesOrdered<BoxFuture<'static, SpawnFileTaskResult>> =
+        FuturesOrdered::new();
+
+    futures::pin_mut!(task_stream);
+    let mut stream_done = false;
+
+    // Seed first task_prefetch_depth tasks.
+    for _ in 0..task_prefetch_depth {
+        match task_stream.next().await {
+            Some(Ok(task)) => {
+                in_flight.push_back(spawn_file_task(task, reader.clone(), batch_prefetch_depth));
+            }
+            Some(Err(e)) => {
+                let _ = outer_tx
+                    .send(Err(anyhow::anyhow!("Planning error: {}", e)))
+                    .await;
+                return;
+            }
+            None => {
+                stream_done = true;
+                break;
+            }
+        }
+    }
+
+    while let Some(file_result) = in_flight.next().await {
+        // Eagerly seed next task to keep the window full.
+        if !stream_done {
+            match task_stream.next().await {
+                Some(Ok(task)) => {
+                    in_flight.push_back(spawn_file_task(
+                        task,
+                        reader.clone(),
+                        batch_prefetch_depth,
+                    ));
+                }
+                Some(Err(e)) => {
+                    let _ = outer_tx
+                        .send(Err(anyhow::anyhow!("Planning error: {}", e)))
+                        .await;
+                    return;
+                }
+                None => stream_done = true,
+            }
+        }
+
+        let (file_path, record_count, file_rx) = match file_result {
+            Ok(tuple) => tuple,
+            Err(e) => {
+                let _ = outer_tx.send(Err(e)).await;
+                return;
+            }
+        };
+
+        // Wrap per-file receiver as an IcebergArrowStream. The unfold releases
+        // semaphore permits as Julia drains batches, unblocking the producer.
+        let stream = futures::stream::unfold(
+            file_rx,
+            |mut rx: mpsc::Receiver<Result<BufferedBatch, iceberg::Error>>| async move {
+                rx.recv().await.map(|result| {
+                    let item = result.map(|buf| {
+                        buf.semaphore.add_permits(buf.byte_len);
+                        WARM_SCAN_STATS.track_buffer_release(buf.byte_len as u64);
+                        buf.batch
+                    });
+                    (item, rx)
+                })
+            },
+        )
+        .boxed();
+
+        let warm = IcebergWarmFileScan {
+            file_path,
+            record_count,
+            stream: IcebergArrowStream {
+                stream: AsyncMutex::new(stream),
+            },
+        };
+
+        let fsend_start = Instant::now();
+        let fsend_err = outer_tx.send(Ok(warm)).await.is_err();
+        WARM_SCAN_STATS
+            .file_send_ns
+            .fetch_add(fsend_start.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        if fsend_err {
+            return; // Julia dropped the outer stream
+        }
+    }
+
+    WARM_SCAN_STATS.pipeline_wall_ns.store(
+        pipeline_start.elapsed().as_nanos() as u64,
+        Ordering::Relaxed,
+    );
+}

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -11,12 +11,12 @@ using iceberg_rust_ffi_jll
 export Table, Scan, IncrementalScan, ArrowBatch, StaticConfig, ArrowStream
 export init_runtime
 export IcebergException
-export new_incremental_scan, free_incremental_scan!
-export table_open, free_table, new_scan, free_scan!
+export new_incremental_scan
+export table_open, free_table!, new_scan, free_scan!
 export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_current_snapshot_id, table_schema
 export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
 export with_file_column!, with_pos_column!
-export scan!, next_batch, free_batch, free_stream
+export scan!, next_batch, free_batch!, free_stream!
 export FILE_COLUMN, POS_COLUMN
 export Catalog, catalog_create_rest, catalog_create_memory, free_catalog!
 export load_table, list_tables, list_namespaces, table_exists, create_table, drop_table, drop_namespace, create_namespace

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -12,14 +12,14 @@ export Table, Scan, IncrementalScan, ArrowBatch, StaticConfig, ArrowStream
 export init_runtime
 export IcebergException
 export new_incremental_scan, free_scan!
-export table_open, free_table, new_scan
+export table_open, free_table!, new_scan
 export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_schema
 export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
 export with_file_column!, with_pos_column!
-export scan!, next_batch, free_batch, free_stream
+export scan!, next_batch, free_batch!, free_stream!
 export FileScanStream, ArrowReaderContext, FileScanHandle
-export plan_files, create_reader, next_file, read_file, read_file_scan
-export record_count, file_path, free_file_stream, free_reader, free_file
+export plan_files, create_reader, next_file!, read_file!, read_file_scan!
+export record_count, file_path, free_file_stream!, free_reader!, free_file!
 export AppendFileStream, DeleteFileStream
 export AppendFileHandle, DeleteFileHandle
 export FILE_COLUMN, POS_COLUMN
@@ -418,11 +418,11 @@ function table_open(snapshot_path::String; properties::Dict{String,String}=Dict{
 end
 
 """
-    free_table(table::Table)
+    free_table!(table::Table)
 
 Free the memory associated with an Iceberg table.
 """
-function free_table(table::Table)
+function free_table!(table::Table)
     @ccall rust_lib.iceberg_table_free(table::Table)::Cvoid
 end
 

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -17,13 +17,11 @@ export table_location, table_uuid, table_format_version, table_last_sequence_num
 export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
 export with_file_column!, with_pos_column!
 export scan!, next_batch, free_batch, free_stream
-export FileScanTaskStream, ArrowReaderContext, FileScanHandle
-export plan_files, create_reader, next_file_scan, read_file_scan
+export FileScanStream, ArrowReaderContext, FileScanHandle
+export plan_files, create_reader, next_file, read_file, read_file_scan
 export record_count, file_path, free_file_stream, free_reader, free_file
-export IncrementalAppendFileStream, IncrementalPosDeleteFileStream
-export IncrementalAppendFileHandle, IncrementalPosDeleteFileHandle
-export next_append_file, read_append_file
-export next_pos_delete_file, read_pos_delete_file
+export AppendFileStream, DeleteFileStream
+export AppendFileHandle, DeleteFileHandle
 export FILE_COLUMN, POS_COLUMN
 export Catalog, catalog_create_rest, catalog_create_memory, free_catalog!
 export load_table, list_tables, list_namespaces, table_exists, create_table, drop_table, drop_namespace, create_namespace

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -17,6 +17,9 @@ export table_location, table_uuid, table_format_version, table_last_sequence_num
 export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
 export with_file_column!, with_pos_column!
 export scan!, next_batch, free_batch, free_stream
+export FileScanTaskStream, ArrowReaderContext, FileScanHandle
+export plan_files, create_reader, next_file_scan, read_file_scan
+export file_scan_record_count, free_file_scan_stream, free_reader, free_file_scan
 export FILE_COLUMN, POS_COLUMN
 export Catalog, catalog_create_rest, catalog_create_memory, free_catalog!
 export load_table, list_tables, list_namespaces, table_exists, create_table, drop_table, drop_namespace, create_namespace

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -14,8 +14,6 @@ export IcebergException
 export new_incremental_scan, free_scan!
 export table_open, free_table!, new_scan
 export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_schema
-export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
-export with_file_column!, with_pos_column!
 export scan!, next_batch, free_batch!, free_stream!
 export FileScanStream, ArrowReaderContext, FileScanHandle
 export plan_files, create_reader, next_file!, read_file!, read_file_scan!

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -11,22 +11,19 @@ using iceberg_rust_ffi_jll
 export Table, Scan, IncrementalScan, ArrowBatch, StaticConfig, ArrowStream
 export init_runtime
 export IcebergException
-export new_incremental_scan, free_incremental_scan!
-export table_open, free_table, new_scan, free_scan!
+export new_incremental_scan, free_scan!
+export table_open, free_table, new_scan
 export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_schema
 export select_columns!, with_batch_size!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
 export with_file_column!, with_pos_column!
 export scan!, next_batch, free_batch, free_stream
 export FileScanTaskStream, ArrowReaderContext, FileScanHandle
 export plan_files, create_reader, next_file_scan, read_file_scan
-export file_scan_record_count, free_file_scan_stream, free_reader, free_file_scan
-export IncrementalAppendTaskStream, IncrementalPosDeleteTaskStream
-export IncrementalAppendHandle, IncrementalPosDeleteHandle
-export next_append_task, read_append_task
-export next_pos_delete_task, read_pos_delete_task
-export append_task_record_count
-export free_incremental_append_task_stream, free_incremental_pos_delete_task_stream
-export free_incremental_append_task, free_incremental_pos_delete_task
+export record_count, file_path, free_file_stream, free_reader, free_file
+export IncrementalAppendFileStream, IncrementalPosDeleteFileStream
+export IncrementalAppendFileHandle, IncrementalPosDeleteFileHandle
+export next_append_file, read_append_file
+export next_pos_delete_file, read_pos_delete_file
 export FILE_COLUMN, POS_COLUMN
 export Catalog, catalog_create_rest, catalog_create_memory, free_catalog!
 export load_table, list_tables, list_namespaces, table_exists, create_table, drop_table, drop_namespace, create_namespace

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -20,6 +20,13 @@ export scan!, next_batch, free_batch, free_stream
 export FileScanTaskStream, ArrowReaderContext, FileScanHandle
 export plan_files, create_reader, next_file_scan, read_file_scan
 export file_scan_record_count, free_file_scan_stream, free_reader, free_file_scan
+export IncrementalAppendTaskStream, IncrementalPosDeleteTaskStream
+export IncrementalAppendHandle, IncrementalPosDeleteHandle
+export next_append_task, read_append_task
+export next_pos_delete_task, read_pos_delete_task
+export append_task_record_count
+export free_incremental_append_task_stream, free_incremental_pos_delete_task_stream
+export free_incremental_append_task, free_incremental_pos_delete_task
 export FILE_COLUMN, POS_COLUMN
 export Catalog, catalog_create_rest, catalog_create_memory, free_catalog!
 export load_table, list_tables, list_namespaces, table_exists, create_table, drop_table, drop_namespace, create_namespace

--- a/src/full.jl
+++ b/src/full.jl
@@ -187,16 +187,18 @@ function plan_files(scan::Scan)
 end
 
 """
-    create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))::ArrowReaderContext
+    create_reader(scan::Scan; reader_concurrency::UInt=UInt(0), batch_prefetch_depth::UInt=UInt(0))::ArrowReaderContext
 
 Create a shared reader context from the scan's configuration.
 Pass this to every `read_file_scan!` call.
 `reader_concurrency` overrides the scan-level data_file_concurrency_limit when > 0.
+`batch_prefetch_depth` sets the per-file batch prefetch queue depth (0 = default of 4).
 """
-function create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))
+function create_reader(scan::Scan; reader_concurrency::UInt=UInt(0), batch_prefetch_depth::UInt=UInt(0))
     ptr = @ccall rust_lib.iceberg_create_reader(
         scan.ptr::Ptr{Cvoid},
-        reader_concurrency::Csize_t
+        reader_concurrency::Csize_t,
+        batch_prefetch_depth::Csize_t
     )::Ptr{Cvoid}
     if ptr == C_NULL
         throw(IcebergException("Failed to create reader from scan"))

--- a/src/full.jl
+++ b/src/full.jl
@@ -6,15 +6,12 @@
 A mutable wrapper around a pointer to a regular (full) table scan.
 
 This type enables multiple dispatch and safe memory management for Iceberg table scans.
-Use `new_scan` to create a scan, configure it with builder methods, and call `scan!`
-to build the scan and obtain an Arrow stream.
+Use `new_scan` to create a scan and call `scan!` to build it and obtain an Arrow stream.
 
 # Example
 ```julia
 table = table_open("s3://path/to/table/metadata.json")
-scan = new_scan(table)
-select_columns!(scan, ["col1", "col2"])
-with_batch_size!(scan, UInt(1024))
+scan = new_scan(table; column_names=["col1", "col2"], batch_size=Int64(1024))
 stream = scan!(scan)
 # ... process batches from stream
 free_stream!(stream)
@@ -27,229 +24,68 @@ mutable struct Scan
 end
 
 """
-    new_scan(table::Table) -> Scan
+    new_scan(table::Table; kwargs...) -> Scan
 
-Create a scan for the given table.
+Create a scan for the given table. All scan parameters are configured via keyword arguments.
+
+# Keyword Arguments
+- `column_names`: columns to read (default: all columns)
+- `data_file_concurrency_limit`: data file concurrency (`-1` = reader default)
+- `manifest_file_concurrency_limit`: manifest file concurrency (`-1` = don't set)
+- `manifest_entry_concurrency_limit`: manifest entry concurrency (`-1` = don't set)
+- `batch_size`: Arrow record batch size (`-1` = no override)
+- `file_column`: include `_file` metadata column (default: `false`)
+- `pos_column`: include `_pos` metadata column (default: `false`)
+- `serialization_concurrency`: parallel batch serializations (`-1` = auto-detect)
+- `snapshot_id`: snapshot ID to scan (`-1` = current snapshot)
+- `task_prefetch_depth`: file scan task prefetch depth (`-1` = use default)
 """
-function new_scan(table::Table)
-    scan_ptr = @ccall rust_lib.iceberg_new_scan(table::Table)::Ptr{Cvoid}
+function new_scan(table::Table;
+    column_names::Union{Vector{String}, Nothing} = nothing,
+    data_file_concurrency_limit::Int64 = Int64(-1),
+    manifest_file_concurrency_limit::Int64 = Int64(-1),
+    manifest_entry_concurrency_limit::Int64 = Int64(-1),
+    batch_size::Int64 = Int64(-1),
+    file_column::Bool = false,
+    pos_column::Bool = false,
+    serialization_concurrency::Int64 = Int64(-1),
+    snapshot_id::Int64 = Int64(-1),
+    task_prefetch_depth::Int64 = Int64(-1),
+)
+    if column_names !== nothing
+        c_strings = [pointer(col) for col in column_names]
+        scan_ptr = GC.@preserve column_names c_strings @ccall rust_lib.iceberg_new_scan(
+            table::Table,
+            pointer(c_strings)::Ptr{Cstring},
+            length(column_names)::Csize_t,
+            data_file_concurrency_limit::Int64,
+            manifest_file_concurrency_limit::Int64,
+            manifest_entry_concurrency_limit::Int64,
+            batch_size::Int64,
+            file_column::Bool,
+            pos_column::Bool,
+            serialization_concurrency::Int64,
+            snapshot_id::Int64,
+            task_prefetch_depth::Int64,
+        )::Ptr{Cvoid}
+    else
+        scan_ptr = @ccall rust_lib.iceberg_new_scan(
+            table::Table,
+            C_NULL::Ptr{Cstring},
+            Csize_t(0)::Csize_t,
+            data_file_concurrency_limit::Int64,
+            manifest_file_concurrency_limit::Int64,
+            manifest_entry_concurrency_limit::Int64,
+            batch_size::Int64,
+            file_column::Bool,
+            pos_column::Bool,
+            serialization_concurrency::Int64,
+            snapshot_id::Int64,
+            task_prefetch_depth::Int64,
+        )::Ptr{Cvoid}
+    end
+    scan_ptr == C_NULL && throw(IcebergException("Failed to create scan"))
     return Scan(scan_ptr)
-end
-
-"""
-    select_columns!(scan::Scan, column_names::Vector{String})
-
-Select specific columns for the scan.
-"""
-function select_columns!(scan::Scan, column_names::Vector{String})
-    # Convert String vector to Cstring array
-    c_strings = [pointer(col) for col in column_names]
-    result = GC.@preserve scan c_strings @ccall rust_lib.iceberg_select_columns(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        pointer(c_strings)::Ptr{Cstring},
-        length(column_names)::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to select columns", result))
-    end
-    return nothing
-end
-
-"""
-    with_data_file_concurrency_limit!(scan::Scan, n::UInt)
-
-Sets the data file concurrency level for the scan.
-"""
-function with_data_file_concurrency_limit!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_data_file_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set data file concurrency limit", result))
-    end
-    return nothing
-end
-
-"""
-    with_manifest_file_concurrency_limit!(scan::Scan, n::UInt)
-
-Sets the manifest file concurrency level for the full scan.
-"""
-function with_manifest_file_concurrency_limit!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_manifest_file_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set manifest file concurrency limit", result))
-    end
-    return nothing
-end
-
-"""
-    with_manifest_entry_concurrency_limit!(scan::Scan, n::UInt)
-
-Sets the manifest entry concurrency level for the scan.
-"""
-function with_manifest_entry_concurrency_limit!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_manifest_entry_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set manifest entry concurrency limit", result))
-    end
-    return nothing
-end
-
-"""
-    with_batch_size!(scan::Scan, n::UInt)
-
-Sets the batch size for the scan.
-"""
-function with_batch_size!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_batch_size(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set batch size", result))
-    end
-    return nothing
-end
-
-"""
-    with_file_column!(scan::Scan)
-
-Add the _file metadata column to the scan.
-
-The _file column contains the file path for each row, which can be useful for
-tracking which data files contain specific rows.
-
-# Example
-```julia
-scan = new_scan(table)
-with_file_column!(scan)
-stream = scan!(scan)
-```
-"""
-function with_file_column!(scan::Scan)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_file_column(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to add file column to scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_pos_column!(scan::Scan)
-
-Add the _pos metadata column to the scan.
-
-The _pos column contains the position of each row within its data file, which can
-be useful for tracking row locations and debugging.
-
-# Example
-```julia
-scan = new_scan(table)
-with_pos_column!(scan)
-stream = scan!(scan)
-```
-"""
-function with_pos_column!(scan::Scan)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_pos_column(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to add pos column to scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_serialization_concurrency_limit!(scan::Scan, n::UInt)
-
-Set the serialization concurrency limit for the scan.
-
-This controls how many RecordBatch serializations can happen in parallel.
-- `n = 0`: Auto-detect based on CPU cores (default)
-- `n > 0`: Use exactly n concurrent serializations
-
-Higher values improve throughput for scans with many batches, but use more memory.
-
-# Example
-```julia
-scan = new_scan(table)
-with_serialization_concurrency_limit!(scan, UInt(8))  # Serialize up to 8 batches in parallel
-stream = scan!(scan)
-```
-"""
-function with_serialization_concurrency_limit!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_serialization_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set serialization concurrency limit", result))
-    end
-    return nothing
-end
-
-"""
-    with_snapshot_id!(scan::Scan, snapshot_id::Int64)
-
-Set the snapshot ID for the scan.
-
-By default, a scan uses the current (latest) snapshot of the table. This method allows
-you to scan a specific snapshot by ID, which is useful for reading historical data or
-comparing data across different points in time.
-
-# Example
-```julia
-table = table_open("s3://path/to/table/metadata.json")
-# List available snapshots (if method is available)
-scan = new_scan(table)
-with_snapshot_id!(scan, Int64(123))  # Scan snapshot with ID 123
-stream = scan!(scan)
-```
-"""
-function with_snapshot_id!(scan::Scan, snapshot_id::Int64)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_snapshot_id(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        snapshot_id::Int64
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set snapshot ID", result))
-    end
-    return nothing
-end
-
-"""
-    build!(scan::Scan)
-
-Build the provided table scan object.
-"""
-function build!(scan::Scan)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_build(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to build scan", result))
-    end
-    return nothing
 end
 
 # Type alias using generic Response{T}
@@ -280,10 +116,9 @@ end
 """
     scan!(scan::Scan) -> ArrowStream
 
-Build the provided table scan object and return an Arrow stream.
+Execute the scan and return an Arrow stream.
 """
 function scan!(scan::Scan)
-    build!(scan)
     return arrow_stream(scan)
 end
 
@@ -302,7 +137,6 @@ end
 # Split-scan API
 #
 # Usage:
-#   build!(scan)
 #   reader = create_reader(scan)
 #   file_stream = plan_files(scan)
 #   while (fs = next_file!(file_stream)) !== nothing

--- a/src/full.jl
+++ b/src/full.jl
@@ -17,9 +17,9 @@ select_columns!(scan, ["col1", "col2"])
 with_batch_size!(scan, UInt(1024))
 stream = scan!(scan)
 # ... process batches from stream
-free_stream(stream)
+free_stream!(stream)
 free_scan!(scan)
-free_table(table)
+free_table!(table)
 ```
 """
 mutable struct Scan
@@ -305,16 +305,16 @@ end
 #   build!(scan)
 #   reader = create_reader(scan)
 #   file_stream = plan_files(scan)
-#   while (fs = next_file(file_stream)) !== nothing
-#       stream = read_file_scan(reader, fs)   # consumes fs
+#   while (fs = next_file!(file_stream)) !== nothing
+#       stream = read_file_scan!(reader, fs)   # consumes fs
 #       while (bp = next_batch(stream)) != C_NULL
 #           # ... process batch ...
-#           free_batch(bp)
+#           free_batch!(bp)
 #       end
-#       free_stream(stream)
+#       free_stream!(stream)
 #   end
-#   free_file_stream(file_stream)
-#   free_reader(reader)
+#   free_file_stream!(file_stream)
+#   free_reader!(reader)
 # ---------------------------------------------------------------------------
 
 """Opaque pointer to a stream of FileScanTasks."""
@@ -322,12 +322,12 @@ mutable struct FileScanStream
     ptr::Ptr{Cvoid}
 end
 
-"""Shared ArrowReader context — pass to every read_file_scan call."""
+"""Shared ArrowReader context — pass to every read_file_scan! call."""
 mutable struct ArrowReaderContext
     ptr::Ptr{Cvoid}
 end
 
-"""Handle to a single file scan task returned by next_file."""
+"""Handle to a single file scan task returned by next_file!."""
 mutable struct FileScanHandle
     ptr::Ptr{Cvoid}
 end
@@ -356,7 +356,7 @@ end
     create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))::ArrowReaderContext
 
 Create a shared reader context from the scan's configuration.
-Pass this to every `read_file_scan` call.
+Pass this to every `read_file_scan!` call.
 `reader_concurrency` overrides the scan-level data_file_concurrency_limit when > 0.
 """
 function create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))
@@ -371,11 +371,11 @@ function create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))
 end
 
 """
-    next_file(stream::FileScanStream)::Union{FileScanHandle, Nothing}
+    next_file!(stream::FileScanStream)::Union{FileScanHandle, Nothing}
 
 Pull the next file scan from the stream. Returns `nothing` at end-of-stream.
 """
-function next_file(stream::FileScanStream)
+function next_file!(stream::FileScanStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_next_file_scan_task(
@@ -389,12 +389,12 @@ function next_file(stream::FileScanStream)
 end
 
 """
-    read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)::ArrowStream
+    read_file_scan!(reader::ArrowReaderContext, fs::FileScanHandle)::ArrowStream
 
 Read a single file scan into an Arrow stream. **Consumes `fs`** — do not call
 `free_file_scan` afterwards.
 """
-function read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)
+function read_file_scan!(reader::ArrowReaderContext, fs::FileScanHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_read_file_scan_task(
@@ -436,19 +436,19 @@ function file_path(fs::FileScanHandle)
 end
 
 """Free a file scan stream (from plan_files)."""
-function free_file_stream(stream::FileScanStream)
+function free_file_stream!(stream::FileScanStream)
     @ccall rust_lib.iceberg_file_scan_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
 """Free an ArrowReaderContext (from create_reader)."""
-function free_reader(reader::ArrowReaderContext)
+function free_reader!(reader::ArrowReaderContext)
     @ccall rust_lib.iceberg_arrow_reader_context_free(reader.ptr::Ptr{Cvoid})::Cvoid
 end
 
 """
-Free a FileScanHandle. Only call this if the handle was NOT passed to read_file_scan,
-since read_file_scan consumes the handle.
+Free a FileScanHandle. Only call this if the handle was NOT passed to read_file_scan!,
+since read_file_scan! consumes the handle.
 """
-function free_file(fs::FileScanHandle)
+function free_file!(fs::FileScanHandle)
     @ccall rust_lib.iceberg_file_scan_task_free(fs.ptr::Ptr{Cvoid})::Cvoid
 end

--- a/src/full.jl
+++ b/src/full.jl
@@ -269,6 +269,29 @@ function file_path(fs::FileScanHandle)
     return path
 end
 
+"""
+    file_metadata(scan::Scan) -> Vector{NamedTuple{(:path, :record_count), Tuple{String, Union{Int64, Nothing}}}}
+
+Return all file paths and record counts for a scan by draining the plan_files stream.
+No data files are opened. The returned record counts come from manifest metadata and
+may be `nothing` for delete files or partial scans.
+"""
+function file_metadata(scan::Scan)
+    stream = plan_files(scan)
+    result = NamedTuple{(:path, :record_count), Tuple{String, Union{Int64, Nothing}}}[]
+    try
+        while true
+            handle = next_file!(stream)
+            handle === nothing && break
+            push!(result, (path=file_path(handle), record_count=record_count(handle)))
+            free_file!(handle)
+        end
+    finally
+        free_file_stream!(stream)
+    end
+    return result
+end
+
 """Free a file scan stream (from plan_files)."""
 function free_file_stream!(stream::FileScanStream)
     @ccall rust_lib.iceberg_file_scan_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid

--- a/src/full.jl
+++ b/src/full.jl
@@ -312,6 +312,130 @@ function free_file!(fs::FileScanHandle)
     @ccall rust_lib.iceberg_file_scan_task_free(fs.ptr::Ptr{Cvoid})::Cvoid
 end
 
+# ---------------------------------------------------------------------------
+# Warm file stream API
+#
+# plan_files_warm → next_file! → read_file! → next_batch / free_batch!
+#
+# Up to task_prefetch_depth files are read concurrently in background Tokio
+# tasks. Julia receives them in manifest order via next_file!, each with its
+# batch channel already running. Per-file memory is capped at 100 MB via a
+# semaphore released as batches are drained.
+#
+# Usage:
+#   stream = plan_files_warm(scan, reader)
+#   while (f = next_file!(stream)) !== nothing
+#       path  = file_path(f)
+#       count = record_count(f)
+#       bstream = read_file!(f)       # takes stream ownership
+#       while (bp = next_batch(bstream)) != C_NULL
+#           # process batch
+#           free_batch!(bp)
+#       end
+#       free_stream!(bstream)
+#       free_warm_file!(f)
+#   end
+#   free_warm_file_stream!(stream)
+# ---------------------------------------------------------------------------
+
+"""Opaque handle to a warm file stream (plan_files_warm result)."""
+mutable struct WarmFileScanStream
+    ptr::Ptr{Cvoid}
+end
+
+"""Handle to one warm file — metadata + already-running batch stream."""
+mutable struct WarmFileScanHandle
+    ptr::Ptr{Cvoid}
+end
+
+"""
+    plan_files_warm(scan::Scan, reader::ArrowReaderContext) -> WarmFileScanStream
+
+Plan files and start batch-prefetch streams for up to `task_prefetch_depth`
+files concurrently. Returns a stream of warm file handles in manifest order.
+"""
+function plan_files_warm(scan::Scan, reader::ArrowReaderContext)
+    response = OpaqueResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_plan_files_warm(
+            scan.ptr::Ptr{Cvoid},
+            reader.ptr::Ptr{Cvoid},
+            response::Ref{OpaqueResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_plan_files_warm", IcebergException)
+    return WarmFileScanStream(response.value)
+end
+
+"""
+    next_file!(stream::WarmFileScanStream) -> Union{WarmFileScanHandle, Nothing}
+
+Pull the next warm file in manifest order. Returns `nothing` at end-of-stream.
+"""
+function next_file!(stream::WarmFileScanStream)
+    response = OpaqueResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_next_warm_file(
+            stream.ptr::Ptr{Cvoid},
+            response::Ref{OpaqueResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_next_warm_file", IcebergException)
+    return response.value == C_NULL ? nothing : WarmFileScanHandle(response.value)
+end
+
+"""
+    read_file!(f::WarmFileScanHandle) -> ArrowStream
+
+Extract the already-running batch stream. Consumes the stream slot — call once per handle.
+"""
+function read_file!(f::WarmFileScanHandle)
+    ptr = @ccall rust_lib.iceberg_warm_file_take_stream(f.ptr::Ptr{Cvoid})::Ptr{Cvoid}
+    if ptr == C_NULL
+        throw(IcebergException("Failed to extract stream from warm file handle"))
+    end
+    return ArrowStream(ptr)
+end
+
+"""Record count for a warm file handle. Returns `nothing` if not available."""
+function record_count(f::WarmFileScanHandle)
+    n = @ccall rust_lib.iceberg_warm_file_record_count(f.ptr::Ptr{Cvoid})::Int64
+    return n == -1 ? nothing : n
+end
+
+"""File path for a warm file handle."""
+function file_path(f::WarmFileScanHandle)
+    ptr = @ccall rust_lib.iceberg_warm_file_path(f.ptr::Ptr{Cvoid})::Ptr{Cchar}
+    if ptr == C_NULL
+        throw(IcebergException("Failed to get file path from warm file handle"))
+    end
+    path = unsafe_string(ptr)
+    @ccall rust_lib.iceberg_destroy_cstring(ptr::Ptr{Cchar})::Cvoid
+    return path
+end
+
+"""Free a warm file handle (drops metadata and any unconsumed batch stream)."""
+function free_warm_file!(f::WarmFileScanHandle)
+    @ccall rust_lib.iceberg_warm_file_free(f.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""Free a warm file stream."""
+function free_warm_file_stream!(stream::WarmFileScanStream)
+    @ccall rust_lib.iceberg_warm_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""Print warm-scan performance stats to stdout."""
+function print_warm_scan_stats()
+    @ccall rust_lib.iceberg_print_warm_scan_stats()::Cvoid
+end
+
+"""Reset warm-scan performance counters."""
+function reset_warm_scan_stats!()
+    @ccall rust_lib.iceberg_reset_warm_scan_stats()::Cvoid
+end
+
 """Print a performance summary for the split-scan path to stdout."""
 function print_split_scan_stats()
     @ccall rust_lib.iceberg_print_split_scan_stats()::Cvoid

--- a/src/full.jl
+++ b/src/full.jl
@@ -230,7 +230,7 @@ end
 Read a single file scan into an Arrow stream. **Consumes `fs`** — do not call
 `free_file_scan` afterwards.
 """
-function read_file_scan!(reader::ArrowReaderContext, fs::FileScanHandle)
+function read_file!(reader::ArrowReaderContext, fs::FileScanHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_read_file_scan_task(
@@ -310,4 +310,14 @@ since read_file_scan! consumes the handle.
 """
 function free_file!(fs::FileScanHandle)
     @ccall rust_lib.iceberg_file_scan_task_free(fs.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""Print a performance summary for the split-scan path to stdout."""
+function print_split_scan_stats()
+    @ccall rust_lib.iceberg_print_split_scan_stats()::Cvoid
+end
+
+"""Reset all split-scan performance counters."""
+function reset_split_scan_stats!()
+    @ccall rust_lib.iceberg_reset_split_scan_stats()::Cvoid
 end

--- a/src/full.jl
+++ b/src/full.jl
@@ -313,7 +313,7 @@ end
 #       end
 #       free_stream(stream)
 #   end
-#   free_file_scan_stream(file_stream)
+#   free_file_stream(file_stream)
 #   free_reader(reader)
 # ---------------------------------------------------------------------------
 
@@ -332,8 +332,6 @@ mutable struct FileScanHandle
     ptr::Ptr{Cvoid}
 end
 
-const OpaqueResponse = Response{Ptr{Cvoid}}
-OpaqueResponse() = Response{Ptr{Cvoid}}(-1, C_NULL, C_NULL, C_NULL)
 
 """
     plan_files(scan::Scan)::FileScanTaskStream
@@ -394,7 +392,7 @@ end
     read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)::ArrowStream
 
 Read a single file scan into an Arrow stream. **Consumes `fs`** — do not call
-`free_file_scan` afterwards.
+`free_file` afterwards.
 """
 function read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)
     response = ArrowStreamResponse()
@@ -411,19 +409,34 @@ function read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)
 end
 
 """
-    file_scan_record_count(fs::FileScanHandle)::Union{Int64, Nothing}
+    record_count(fs::FileScanHandle)::Union{Int64, Nothing}
 
 Return the record count for this file scan, or `nothing` if not available.
 """
-function file_scan_record_count(fs::FileScanHandle)
+function record_count(fs::FileScanHandle)
     count = @ccall rust_lib.iceberg_file_scan_task_record_count(
         fs.ptr::Ptr{Cvoid}
     )::Int64
     return count == -1 ? nothing : count
 end
 
+"""
+    file_path(fs::FileScanHandle)::String
+
+Return the data file path for this file scan task.
+"""
+function file_path(fs::FileScanHandle)
+    ptr = @ccall rust_lib.iceberg_file_scan_task_file_path(
+        fs.ptr::Ptr{Cvoid}
+    )::Ptr{Cchar}
+    ptr == C_NULL && throw(IcebergException("Failed to get file path"))
+    path = unsafe_string(ptr)
+    @ccall rust_lib.iceberg_destroy_cstring(ptr::Ptr{Cchar})::Cint
+    return path
+end
+
 """Free a file scan stream (from plan_files)."""
-function free_file_scan_stream(stream::FileScanTaskStream)
+function free_file_stream(stream::FileScanTaskStream)
     @ccall rust_lib.iceberg_file_scan_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
@@ -436,6 +449,6 @@ end
 Free a FileScanHandle. Only call this if the handle was NOT passed to read_file_scan,
 since read_file_scan consumes the handle.
 """
-function free_file_scan(fs::FileScanHandle)
+function free_file(fs::FileScanHandle)
     @ccall rust_lib.iceberg_file_scan_task_free(fs.ptr::Ptr{Cvoid})::Cvoid
 end

--- a/src/full.jl
+++ b/src/full.jl
@@ -305,7 +305,7 @@ end
 #   build!(scan)
 #   reader = create_reader(scan)
 #   file_stream = plan_files(scan)
-#   while (fs = next_file_scan(file_stream)) !== nothing
+#   while (fs = next_file(file_stream)) !== nothing
 #       stream = read_file_scan(reader, fs)   # consumes fs
 #       while (bp = next_batch(stream)) != C_NULL
 #           # ... process batch ...
@@ -318,7 +318,7 @@ end
 # ---------------------------------------------------------------------------
 
 """Opaque pointer to a stream of FileScanTasks."""
-mutable struct FileScanTaskStream
+mutable struct FileScanStream
     ptr::Ptr{Cvoid}
 end
 
@@ -327,14 +327,14 @@ mutable struct ArrowReaderContext
     ptr::Ptr{Cvoid}
 end
 
-"""Handle to a single file scan task returned by next_file_scan."""
+"""Handle to a single file scan task returned by next_file."""
 mutable struct FileScanHandle
     ptr::Ptr{Cvoid}
 end
 
 
 """
-    plan_files(scan::Scan)::FileScanTaskStream
+    plan_files(scan::Scan)::FileScanStream
 
 Plan which files to read. Returns a concurrent-safe task stream.
 The scan must be built first via `build!`.
@@ -349,7 +349,7 @@ function plan_files(scan::Scan)
         )::Cint
     end
     @throw_on_error(response, "iceberg_plan_files", IcebergException)
-    return FileScanTaskStream(response.value)
+    return FileScanStream(response.value)
 end
 
 """
@@ -371,11 +371,11 @@ function create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))
 end
 
 """
-    next_file_scan(stream::FileScanTaskStream)::Union{FileScanHandle, Nothing}
+    next_file(stream::FileScanStream)::Union{FileScanHandle, Nothing}
 
 Pull the next file scan from the stream. Returns `nothing` at end-of-stream.
 """
-function next_file_scan(stream::FileScanTaskStream)
+function next_file(stream::FileScanStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_next_file_scan_task(
@@ -392,7 +392,7 @@ end
     read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)::ArrowStream
 
 Read a single file scan into an Arrow stream. **Consumes `fs`** — do not call
-`free_file` afterwards.
+`free_file_scan` afterwards.
 """
 function read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)
     response = ArrowStreamResponse()
@@ -436,7 +436,7 @@ function file_path(fs::FileScanHandle)
 end
 
 """Free a file scan stream (from plan_files)."""
-function free_file_stream(stream::FileScanTaskStream)
+function free_file_stream(stream::FileScanStream)
     @ccall rust_lib.iceberg_file_scan_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 

--- a/src/full.jl
+++ b/src/full.jl
@@ -297,3 +297,145 @@ function free_scan!(scan::Scan)
         convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
     )::Cvoid
 end
+
+# ---------------------------------------------------------------------------
+# Split-scan API
+#
+# Usage:
+#   build!(scan)
+#   reader = create_reader(scan)
+#   file_stream = plan_files(scan)
+#   while (fs = next_file_scan(file_stream)) !== nothing
+#       stream = read_file_scan(reader, fs)   # consumes fs
+#       while (bp = next_batch(stream)) != C_NULL
+#           # ... process batch ...
+#           free_batch(bp)
+#       end
+#       free_stream(stream)
+#   end
+#   free_file_scan_stream(file_stream)
+#   free_reader(reader)
+# ---------------------------------------------------------------------------
+
+"""Opaque pointer to a stream of FileScanTasks."""
+mutable struct FileScanTaskStream
+    ptr::Ptr{Cvoid}
+end
+
+"""Shared ArrowReader context — pass to every read_file_scan call."""
+mutable struct ArrowReaderContext
+    ptr::Ptr{Cvoid}
+end
+
+"""Handle to a single file scan task returned by next_file_scan."""
+mutable struct FileScanHandle
+    ptr::Ptr{Cvoid}
+end
+
+const OpaqueResponse = Response{Ptr{Cvoid}}
+OpaqueResponse() = Response{Ptr{Cvoid}}(-1, C_NULL, C_NULL, C_NULL)
+
+"""
+    plan_files(scan::Scan)::FileScanTaskStream
+
+Plan which files to read. Returns a concurrent-safe task stream.
+The scan must be built first via `build!`.
+"""
+function plan_files(scan::Scan)
+    response = OpaqueResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_plan_files(
+            scan.ptr::Ptr{Cvoid},
+            response::Ref{OpaqueResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_plan_files", IcebergException)
+    return FileScanTaskStream(response.value)
+end
+
+"""
+    create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))::ArrowReaderContext
+
+Create a shared reader context from the scan's configuration.
+Pass this to every `read_file_scan` call.
+`reader_concurrency` overrides the scan-level data_file_concurrency_limit when > 0.
+"""
+function create_reader(scan::Scan; reader_concurrency::UInt=UInt(0))
+    ptr = @ccall rust_lib.iceberg_create_reader(
+        scan.ptr::Ptr{Cvoid},
+        reader_concurrency::Csize_t
+    )::Ptr{Cvoid}
+    if ptr == C_NULL
+        throw(IcebergException("Failed to create reader from scan"))
+    end
+    return ArrowReaderContext(ptr)
+end
+
+"""
+    next_file_scan(stream::FileScanTaskStream)::Union{FileScanHandle, Nothing}
+
+Pull the next file scan from the stream. Returns `nothing` at end-of-stream.
+"""
+function next_file_scan(stream::FileScanTaskStream)
+    response = OpaqueResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_next_file_scan_task(
+            stream.ptr::Ptr{Cvoid},
+            response::Ref{OpaqueResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_next_file_scan_task", IcebergException)
+    return response.value == C_NULL ? nothing : FileScanHandle(response.value)
+end
+
+"""
+    read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)::ArrowStream
+
+Read a single file scan into an Arrow stream. **Consumes `fs`** — do not call
+`free_file_scan` afterwards.
+"""
+function read_file_scan(reader::ArrowReaderContext, fs::FileScanHandle)
+    response = ArrowStreamResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_read_file_scan_task(
+            reader.ptr::Ptr{Cvoid},
+            fs.ptr::Ptr{Cvoid},
+            response::Ref{ArrowStreamResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_read_file_scan_task", IcebergException)
+    return response.value
+end
+
+"""
+    file_scan_record_count(fs::FileScanHandle)::Union{Int64, Nothing}
+
+Return the record count for this file scan, or `nothing` if not available.
+"""
+function file_scan_record_count(fs::FileScanHandle)
+    count = @ccall rust_lib.iceberg_file_scan_task_record_count(
+        fs.ptr::Ptr{Cvoid}
+    )::Int64
+    return count == -1 ? nothing : count
+end
+
+"""Free a file scan stream (from plan_files)."""
+function free_file_scan_stream(stream::FileScanTaskStream)
+    @ccall rust_lib.iceberg_file_scan_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""Free an ArrowReaderContext (from create_reader)."""
+function free_reader(reader::ArrowReaderContext)
+    @ccall rust_lib.iceberg_arrow_reader_context_free(reader.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""
+Free a FileScanHandle. Only call this if the handle was NOT passed to read_file_scan,
+since read_file_scan consumes the handle.
+"""
+function free_file_scan(fs::FileScanHandle)
+    @ccall rust_lib.iceberg_file_scan_task_free(fs.ptr::Ptr{Cvoid})::Cvoid
+end

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -503,6 +503,18 @@ function record_count(task::IncrementalAppendFileHandle)
 end
 
 """
+    record_count(task::IncrementalPosDeleteFileHandle) -> Int64
+
+Return the number of deleted row positions in this positional-delete file.
+"""
+function record_count(task::IncrementalPosDeleteFileHandle)
+    count = @ccall rust_lib.iceberg_incremental_pos_delete_file_record_count(
+        task.ptr::Ptr{Cvoid}
+    )::Int64
+    return count
+end
+
+"""
     file_path(fs::IncrementalAppendFileHandle)::String
 
 Return the data file path for this incremental append file.

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -319,3 +319,205 @@ function free_incremental_scan!(scan::IncrementalScan)
         convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
     )::Cvoid
 end
+
+# ---------------------------------------------------------------------------
+# Incremental split-scan API
+#
+# Usage:
+#   build!(scan)
+#   reader = create_reader(scan)
+#   append_stream, delete_stream = plan_files(scan)
+#   while (at = next_append_task(append_stream)) !== nothing
+#       stream = read_append_task(reader, at)   # consumes at
+#       while (bp = next_batch(stream)) != C_NULL
+#           # ... process batch ...
+#           free_batch(bp)
+#       end
+#       free_stream(stream)
+#   end
+#   while (dt = next_pos_delete_task(delete_stream)) !== nothing
+#       stream = read_pos_delete_task(reader, dt)  # consumes dt; yields (file_path, pos) batches
+#       while (bp = next_batch(stream)) != C_NULL
+#           free_batch(bp)
+#       end
+#       free_stream(stream)
+#   end
+#   free_incremental_append_task_stream(append_stream)
+#   free_incremental_pos_delete_task_stream(delete_stream)
+#   free_reader(reader)
+# ---------------------------------------------------------------------------
+
+"""Opaque handle to a buffered stream of incremental append tasks."""
+mutable struct IncrementalAppendTaskStream
+    ptr::Ptr{Cvoid}
+end
+
+"""Opaque handle to a buffered stream of positional-delete tasks."""
+mutable struct IncrementalPosDeleteTaskStream
+    ptr::Ptr{Cvoid}
+end
+
+"""Handle to a single incremental append task."""
+mutable struct IncrementalAppendHandle
+    ptr::Ptr{Cvoid}
+end
+
+"""Handle to a single positional-delete task (file_path + row positions)."""
+mutable struct IncrementalPosDeleteHandle
+    ptr::Ptr{Cvoid}
+end
+
+mutable struct IncrementalTaskStreamsResponse
+    result::Cint
+    append_stream::Ptr{Cvoid}
+    delete_stream::Ptr{Cvoid}
+    error_message::Ptr{Cchar}
+    context::Ptr{Cvoid}
+
+    IncrementalTaskStreamsResponse() = new(-1, C_NULL, C_NULL, C_NULL, C_NULL)
+end
+
+"""
+    plan_files(scan::IncrementalScan) -> (IncrementalAppendTaskStream, IncrementalPosDeleteTaskStream)
+
+Plan which files to read for an incremental scan. The scan must be built first via `build!`.
+Returns separate streams for append tasks and positional-delete tasks.
+"""
+function plan_files(scan::IncrementalScan)
+    response = IncrementalTaskStreamsResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_incremental_plan_files(
+            scan.ptr::Ptr{Cvoid},
+            response::Ref{IncrementalTaskStreamsResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_incremental_plan_files", IcebergException)
+    return IncrementalAppendTaskStream(response.append_stream),
+           IncrementalPosDeleteTaskStream(response.delete_stream)
+end
+
+"""
+    create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0)) -> ArrowReaderContext
+
+Create a shared reader context from the incremental scan's configuration.
+Pass this to every `read_append_task` and `read_pos_delete_task` call.
+"""
+function create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0))
+    ptr = @ccall rust_lib.iceberg_incremental_create_reader(
+        scan.ptr::Ptr{Cvoid},
+        reader_concurrency::Csize_t
+    )::Ptr{Cvoid}
+    if ptr == C_NULL
+        throw(IcebergException("Failed to create reader from incremental scan"))
+    end
+    return ArrowReaderContext(ptr)
+end
+
+"""
+    next_append_task(stream::IncrementalAppendTaskStream) -> Union{IncrementalAppendHandle, Nothing}
+
+Pull the next append task from the stream. Returns `nothing` at end-of-stream.
+"""
+function next_append_task(stream::IncrementalAppendTaskStream)
+    response = OpaqueResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_incremental_next_append_task(
+            stream.ptr::Ptr{Cvoid},
+            response::Ref{OpaqueResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_incremental_next_append_task", IcebergException)
+    return response.value == C_NULL ? nothing : IncrementalAppendHandle(response.value)
+end
+
+"""
+    read_append_task(reader::ArrowReaderContext, task::IncrementalAppendHandle) -> ArrowStream
+
+Read a single incremental append task into an Arrow stream. **Consumes `task`**.
+"""
+function read_append_task(reader::ArrowReaderContext, task::IncrementalAppendHandle)
+    response = ArrowStreamResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_incremental_read_append_task(
+            reader.ptr::Ptr{Cvoid},
+            task.ptr::Ptr{Cvoid},
+            response::Ref{ArrowStreamResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_incremental_read_append_task", IcebergException)
+    return response.value
+end
+
+"""
+    next_pos_delete_task(stream::IncrementalPosDeleteTaskStream) -> Union{IncrementalPosDeleteHandle, Nothing}
+
+Pull the next positional-delete task from the stream. Returns `nothing` at end-of-stream.
+Only `PositionalDeletes` tasks are returned; `DeletedFile` and `EqualityDeletes` are skipped.
+"""
+function next_pos_delete_task(stream::IncrementalPosDeleteTaskStream)
+    response = OpaqueResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_incremental_next_pos_delete_task(
+            stream.ptr::Ptr{Cvoid},
+            response::Ref{OpaqueResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_incremental_next_pos_delete_task", IcebergException)
+    return response.value == C_NULL ? nothing : IncrementalPosDeleteHandle(response.value)
+end
+
+"""
+    read_pos_delete_task(reader::ArrowReaderContext, task::IncrementalPosDeleteHandle) -> ArrowStream
+
+Convert a positional-delete task into an Arrow stream of `(file_path, pos)` batches.
+**Consumes `task`**.
+"""
+function read_pos_delete_task(reader::ArrowReaderContext, task::IncrementalPosDeleteHandle)
+    response = ArrowStreamResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_incremental_read_pos_delete_task(
+            reader.ptr::Ptr{Cvoid},
+            task.ptr::Ptr{Cvoid},
+            response::Ref{ArrowStreamResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    @throw_on_error(response, "iceberg_incremental_read_pos_delete_task", IcebergException)
+    return response.value
+end
+
+"""
+    append_task_record_count(task::IncrementalAppendHandle) -> Union{Int64, Nothing}
+
+Return the record count for this append task, or `nothing` if not available.
+"""
+function append_task_record_count(task::IncrementalAppendHandle)
+    count = @ccall rust_lib.iceberg_incremental_append_task_record_count(
+        task.ptr::Ptr{Cvoid}
+    )::Int64
+    return count == -1 ? nothing : count
+end
+
+"""Free a stream of incremental append tasks."""
+function free_incremental_append_task_stream(stream::IncrementalAppendTaskStream)
+    @ccall rust_lib.iceberg_incremental_append_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""Free a stream of positional-delete tasks."""
+function free_incremental_pos_delete_task_stream(stream::IncrementalPosDeleteTaskStream)
+    @ccall rust_lib.iceberg_incremental_pos_delete_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""Free an append task handle. Only call if NOT passed to `read_append_task`."""
+function free_incremental_append_task(task::IncrementalAppendHandle)
+    @ccall rust_lib.iceberg_incremental_append_task_free(task.ptr::Ptr{Cvoid})::Cvoid
+end
+
+"""Free a positional-delete task handle. Only call if NOT passed to `read_pos_delete_task`."""
+function free_incremental_pos_delete_task(task::IncrementalPosDeleteHandle)
+    @ccall rust_lib.iceberg_incremental_pos_delete_task_free(task.ptr::Ptr{Cvoid})::Cvoid
+end

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -19,10 +19,10 @@ scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
 with_batch_size!(scan, UInt(1024))
 inserts_stream, deletes_stream = scan!(scan)
 # ... process batches from both streams
-free_stream(inserts_stream)
-free_stream(deletes_stream)
+free_stream!(inserts_stream)
+free_stream!(deletes_stream)
 free_scan!(scan)
-free_table(table)
+free_table!(table)
 ```
 """
 mutable struct IncrementalScan
@@ -327,24 +327,24 @@ end
 #   build!(scan)
 #   reader = create_reader(scan)
 #   append_stream, delete_stream = plan_files(scan)
-#   while (at = next_file(append_stream)) !== nothing
-#       stream = read_file(reader, at)   # consumes at
+#   while (at = next_file!(append_stream)) !== nothing
+#       stream = read_file!(reader, at)   # consumes at
 #       while (bp = next_batch(stream)) != C_NULL
 #           # ... process batch ...
-#           free_batch(bp)
+#           free_batch!(bp)
 #       end
-#       free_stream(stream)
+#       free_stream!(stream)
 #   end
-#   while (dt = next_file(delete_stream)) !== nothing
-#       stream = read_file(reader, dt)  # consumes dt; yields (file_path, pos) batches
+#   while (dt = next_file!(delete_stream)) !== nothing
+#       stream = read_file!(reader, dt)  # consumes dt; yields (file_path, pos) batches
 #       while (bp = next_batch(stream)) != C_NULL
-#           free_batch(bp)
+#           free_batch!(bp)
 #       end
-#       free_stream(stream)
+#       free_stream!(stream)
 #   end
-#   free_file_stream(append_stream)
-#   free_file_stream(delete_stream)
-#   free_reader(reader)
+#   free_file_stream!(append_stream)
+#   free_file_stream!(delete_stream)
+#   free_reader!(reader)
 # ---------------------------------------------------------------------------
 
 """Opaque handle to a buffered stream of incremental append tasks."""
@@ -415,11 +415,11 @@ function create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0))
 end
 
 """
-    next_file(stream::AppendFileStream) -> Union{AppendFileHandle, Nothing}
+    next_file!(stream::AppendFileStream) -> Union{AppendFileHandle, Nothing}
 
 Pull the next append task from the stream. Returns `nothing` at end-of-stream.
 """
-function next_file(stream::AppendFileStream)
+function next_file!(stream::AppendFileStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_next_append_file(
@@ -433,11 +433,11 @@ function next_file(stream::AppendFileStream)
 end
 
 """
-    read_file(reader::ArrowReaderContext, task::AppendFileHandle) -> ArrowStream
+    read_file!(reader::ArrowReaderContext, task::AppendFileHandle) -> ArrowStream
 
 Read a single incremental append task into an Arrow stream. **Consumes `task`**.
 """
-function read_file(reader::ArrowReaderContext, task::AppendFileHandle)
+function read_file!(reader::ArrowReaderContext, task::AppendFileHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_read_append_file(
@@ -452,12 +452,12 @@ function read_file(reader::ArrowReaderContext, task::AppendFileHandle)
 end
 
 """
-    next_file(stream::DeleteFileStream) -> Union{DeleteFileHandle, Nothing}
+    next_file!(stream::DeleteFileStream) -> Union{DeleteFileHandle, Nothing}
 
 Pull the next positional-delete task from the stream. Returns `nothing` at end-of-stream.
 Only `PositionalDeletes` tasks are returned; `DeletedFile` and `EqualityDeletes` are skipped.
 """
-function next_file(stream::DeleteFileStream)
+function next_file!(stream::DeleteFileStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_next_pos_delete_file(
@@ -471,12 +471,12 @@ function next_file(stream::DeleteFileStream)
 end
 
 """
-    read_file(reader::ArrowReaderContext, task::DeleteFileHandle) -> ArrowStream
+    read_file!(reader::ArrowReaderContext, task::DeleteFileHandle) -> ArrowStream
 
 Convert a positional-delete task into an Arrow stream of `(file_path, pos)` batches.
 **Consumes `task`**.
 """
-function read_file(reader::ArrowReaderContext, task::DeleteFileHandle)
+function read_file!(reader::ArrowReaderContext, task::DeleteFileHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_read_pos_delete_file(
@@ -545,21 +545,21 @@ function file_path(fs::DeleteFileHandle)
 end
 
 """Free a stream of incremental append tasks."""
-function free_file_stream(stream::AppendFileStream)
+function free_file_stream!(stream::AppendFileStream)
     @ccall rust_lib.iceberg_incremental_append_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
 """Free a stream of positional-delete tasks."""
-function free_file_stream(stream::DeleteFileStream)
+function free_file_stream!(stream::DeleteFileStream)
     @ccall rust_lib.iceberg_incremental_pos_delete_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
 """Free an append task handle. Only call if NOT passed to `read_file`."""
-function free_file(task::AppendFileHandle)
+function free_file!(task::AppendFileHandle)
     @ccall rust_lib.iceberg_incremental_append_file_free(task.ptr::Ptr{Cvoid})::Cvoid
 end
 
 """Free a positional-delete task handle. Only call if NOT passed to `read_file`."""
-function free_file(task::DeleteFileHandle)
+function free_file!(task::DeleteFileHandle)
     @ccall rust_lib.iceberg_incremental_pos_delete_file_free(task.ptr::Ptr{Cvoid})::Cvoid
 end

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -327,16 +327,16 @@ end
 #   build!(scan)
 #   reader = create_reader(scan)
 #   append_stream, delete_stream = plan_files(scan)
-#   while (at = next_append_file(append_stream)) !== nothing
-#       stream = read_append_file(reader, at)   # consumes at
+#   while (at = next_file(append_stream)) !== nothing
+#       stream = read_file(reader, at)   # consumes at
 #       while (bp = next_batch(stream)) != C_NULL
 #           # ... process batch ...
 #           free_batch(bp)
 #       end
 #       free_stream(stream)
 #   end
-#   while (dt = next_pos_delete_file(delete_stream)) !== nothing
-#       stream = read_pos_delete_file(reader, dt)  # consumes dt; yields (file_path, pos) batches
+#   while (dt = next_file(delete_stream)) !== nothing
+#       stream = read_file(reader, dt)  # consumes dt; yields (file_path, pos) batches
 #       while (bp = next_batch(stream)) != C_NULL
 #           free_batch(bp)
 #       end
@@ -348,22 +348,22 @@ end
 # ---------------------------------------------------------------------------
 
 """Opaque handle to a buffered stream of incremental append tasks."""
-mutable struct IncrementalAppendFileStream
+mutable struct AppendFileStream
     ptr::Ptr{Cvoid}
 end
 
 """Opaque handle to a buffered stream of positional-delete tasks."""
-mutable struct IncrementalPosDeleteFileStream
+mutable struct DeleteFileStream
     ptr::Ptr{Cvoid}
 end
 
 """Handle to a single incremental append task."""
-mutable struct IncrementalAppendFileHandle
+mutable struct AppendFileHandle
     ptr::Ptr{Cvoid}
 end
 
 """Handle to a single positional-delete task (file_path + row positions)."""
-mutable struct IncrementalPosDeleteFileHandle
+mutable struct DeleteFileHandle
     ptr::Ptr{Cvoid}
 end
 
@@ -378,7 +378,7 @@ mutable struct IncrementalTaskStreamsResponse
 end
 
 """
-    plan_files(scan::IncrementalScan) -> (IncrementalAppendFileStream, IncrementalPosDeleteFileStream)
+    plan_files(scan::IncrementalScan) -> (AppendFileStream, DeleteFileStream)
 
 Plan which files to read for an incremental scan. The scan must be built first via `build!`.
 Returns separate streams for append tasks and positional-delete tasks.
@@ -393,15 +393,15 @@ function plan_files(scan::IncrementalScan)
         )::Cint
     end
     @throw_on_error(response, "iceberg_incremental_plan_files", IcebergException)
-    return IncrementalAppendFileStream(response.append_stream),
-           IncrementalPosDeleteFileStream(response.delete_stream)
+    return AppendFileStream(response.append_stream),
+           DeleteFileStream(response.delete_stream)
 end
 
 """
     create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0)) -> ArrowReaderContext
 
 Create a shared reader context from the incremental scan's configuration.
-Pass this to every `read_append_file` and `read_pos_delete_file` call.
+Pass this to every `read_file` and `read_file` call.
 """
 function create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0))
     ptr = @ccall rust_lib.iceberg_incremental_create_reader(
@@ -415,11 +415,11 @@ function create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0))
 end
 
 """
-    next_append_file(stream::IncrementalAppendFileStream) -> Union{IncrementalAppendFileHandle, Nothing}
+    next_file(stream::AppendFileStream) -> Union{AppendFileHandle, Nothing}
 
 Pull the next append task from the stream. Returns `nothing` at end-of-stream.
 """
-function next_append_file(stream::IncrementalAppendFileStream)
+function next_file(stream::AppendFileStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_next_append_file(
@@ -429,15 +429,15 @@ function next_append_file(stream::IncrementalAppendFileStream)
         )::Cint
     end
     @throw_on_error(response, "iceberg_incremental_next_append_file", IcebergException)
-    return response.value == C_NULL ? nothing : IncrementalAppendFileHandle(response.value)
+    return response.value == C_NULL ? nothing : AppendFileHandle(response.value)
 end
 
 """
-    read_append_file(reader::ArrowReaderContext, task::IncrementalAppendFileHandle) -> ArrowStream
+    read_file(reader::ArrowReaderContext, task::AppendFileHandle) -> ArrowStream
 
 Read a single incremental append task into an Arrow stream. **Consumes `task`**.
 """
-function read_append_file(reader::ArrowReaderContext, task::IncrementalAppendFileHandle)
+function read_file(reader::ArrowReaderContext, task::AppendFileHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_read_append_file(
@@ -452,12 +452,12 @@ function read_append_file(reader::ArrowReaderContext, task::IncrementalAppendFil
 end
 
 """
-    next_pos_delete_file(stream::IncrementalPosDeleteFileStream) -> Union{IncrementalPosDeleteFileHandle, Nothing}
+    next_file(stream::DeleteFileStream) -> Union{DeleteFileHandle, Nothing}
 
 Pull the next positional-delete task from the stream. Returns `nothing` at end-of-stream.
 Only `PositionalDeletes` tasks are returned; `DeletedFile` and `EqualityDeletes` are skipped.
 """
-function next_pos_delete_file(stream::IncrementalPosDeleteFileStream)
+function next_file(stream::DeleteFileStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_next_pos_delete_file(
@@ -467,16 +467,16 @@ function next_pos_delete_file(stream::IncrementalPosDeleteFileStream)
         )::Cint
     end
     @throw_on_error(response, "iceberg_incremental_next_pos_delete_file", IcebergException)
-    return response.value == C_NULL ? nothing : IncrementalPosDeleteFileHandle(response.value)
+    return response.value == C_NULL ? nothing : DeleteFileHandle(response.value)
 end
 
 """
-    read_pos_delete_file(reader::ArrowReaderContext, task::IncrementalPosDeleteFileHandle) -> ArrowStream
+    read_file(reader::ArrowReaderContext, task::DeleteFileHandle) -> ArrowStream
 
 Convert a positional-delete task into an Arrow stream of `(file_path, pos)` batches.
 **Consumes `task`**.
 """
-function read_pos_delete_file(reader::ArrowReaderContext, task::IncrementalPosDeleteFileHandle)
+function read_file(reader::ArrowReaderContext, task::DeleteFileHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
         @ccall rust_lib.iceberg_incremental_read_pos_delete_file(
@@ -491,11 +491,11 @@ function read_pos_delete_file(reader::ArrowReaderContext, task::IncrementalPosDe
 end
 
 """
-    record_count(task::IncrementalAppendFileHandle) -> Union{Int64, Nothing}
+    record_count(task::AppendFileHandle) -> Union{Int64, Nothing}
 
 Return the record count for this append task, or `nothing` if not available.
 """
-function record_count(task::IncrementalAppendFileHandle)
+function record_count(task::AppendFileHandle)
     count = @ccall rust_lib.iceberg_incremental_append_file_record_count(
         task.ptr::Ptr{Cvoid}
     )::Int64
@@ -503,11 +503,11 @@ function record_count(task::IncrementalAppendFileHandle)
 end
 
 """
-    record_count(task::IncrementalPosDeleteFileHandle) -> Int64
+    record_count(task::DeleteFileHandle) -> Int64
 
 Return the number of deleted row positions in this positional-delete file.
 """
-function record_count(task::IncrementalPosDeleteFileHandle)
+function record_count(task::DeleteFileHandle)
     count = @ccall rust_lib.iceberg_incremental_pos_delete_file_record_count(
         task.ptr::Ptr{Cvoid}
     )::Int64
@@ -515,11 +515,11 @@ function record_count(task::IncrementalPosDeleteFileHandle)
 end
 
 """
-    file_path(fs::IncrementalAppendFileHandle)::String
+    file_path(fs::AppendFileHandle)::String
 
 Return the data file path for this incremental append file.
 """
-function file_path(fs::IncrementalAppendFileHandle)
+function file_path(fs::AppendFileHandle)
     ptr = @ccall rust_lib.iceberg_incremental_append_file_path(
         fs.ptr::Ptr{Cvoid}
     )::Ptr{Cchar}
@@ -530,11 +530,11 @@ function file_path(fs::IncrementalAppendFileHandle)
 end
 
 """
-    file_path(fs::IncrementalPosDeleteFileHandle)::String
+    file_path(fs::DeleteFileHandle)::String
 
 Return the data file path for this positional-delete file.
 """
-function file_path(fs::IncrementalPosDeleteFileHandle)
+function file_path(fs::DeleteFileHandle)
     ptr = @ccall rust_lib.iceberg_incremental_pos_delete_file_path(
         fs.ptr::Ptr{Cvoid}
     )::Ptr{Cchar}
@@ -545,21 +545,21 @@ function file_path(fs::IncrementalPosDeleteFileHandle)
 end
 
 """Free a stream of incremental append tasks."""
-function free_file_stream(stream::IncrementalAppendFileStream)
+function free_file_stream(stream::AppendFileStream)
     @ccall rust_lib.iceberg_incremental_append_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
 """Free a stream of positional-delete tasks."""
-function free_file_stream(stream::IncrementalPosDeleteFileStream)
+function free_file_stream(stream::DeleteFileStream)
     @ccall rust_lib.iceberg_incremental_pos_delete_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
-"""Free an append task handle. Only call if NOT passed to `read_append_file`."""
-function free_file(task::IncrementalAppendFileHandle)
+"""Free an append task handle. Only call if NOT passed to `read_file`."""
+function free_file(task::AppendFileHandle)
     @ccall rust_lib.iceberg_incremental_append_file_free(task.ptr::Ptr{Cvoid})::Cvoid
 end
 
-"""Free a positional-delete task handle. Only call if NOT passed to `read_pos_delete_file`."""
-function free_file(task::IncrementalPosDeleteFileHandle)
+"""Free a positional-delete task handle. Only call if NOT passed to `read_file`."""
+function free_file(task::DeleteFileHandle)
     @ccall rust_lib.iceberg_incremental_pos_delete_file_free(task.ptr::Ptr{Cvoid})::Cvoid
 end

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -21,7 +21,7 @@ inserts_stream, deletes_stream = scan!(scan)
 # ... process batches from both streams
 free_stream(inserts_stream)
 free_stream(deletes_stream)
-free_incremental_scan!(scan)
+free_scan!(scan)
 free_table(table)
 ```
 """
@@ -310,11 +310,11 @@ function scan!(scan::IncrementalScan)
 end
 
 """
-    free_incremental_scan!(scan::IncrementalScan)
+    free_scan!(scan::IncrementalScan)
 
 Free the memory associated with an incremental scan.
 """
-function free_incremental_scan!(scan::IncrementalScan)
+function free_scan!(scan::IncrementalScan)
     GC.@preserve scan @ccall rust_lib.iceberg_free_incremental_scan(
         convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
     )::Cvoid
@@ -327,43 +327,43 @@ end
 #   build!(scan)
 #   reader = create_reader(scan)
 #   append_stream, delete_stream = plan_files(scan)
-#   while (at = next_append_task(append_stream)) !== nothing
-#       stream = read_append_task(reader, at)   # consumes at
+#   while (at = next_append_file(append_stream)) !== nothing
+#       stream = read_append_file(reader, at)   # consumes at
 #       while (bp = next_batch(stream)) != C_NULL
 #           # ... process batch ...
 #           free_batch(bp)
 #       end
 #       free_stream(stream)
 #   end
-#   while (dt = next_pos_delete_task(delete_stream)) !== nothing
-#       stream = read_pos_delete_task(reader, dt)  # consumes dt; yields (file_path, pos) batches
+#   while (dt = next_pos_delete_file(delete_stream)) !== nothing
+#       stream = read_pos_delete_file(reader, dt)  # consumes dt; yields (file_path, pos) batches
 #       while (bp = next_batch(stream)) != C_NULL
 #           free_batch(bp)
 #       end
 #       free_stream(stream)
 #   end
-#   free_incremental_append_task_stream(append_stream)
-#   free_incremental_pos_delete_task_stream(delete_stream)
+#   free_file_stream(append_stream)
+#   free_file_stream(delete_stream)
 #   free_reader(reader)
 # ---------------------------------------------------------------------------
 
 """Opaque handle to a buffered stream of incremental append tasks."""
-mutable struct IncrementalAppendTaskStream
+mutable struct IncrementalAppendFileStream
     ptr::Ptr{Cvoid}
 end
 
 """Opaque handle to a buffered stream of positional-delete tasks."""
-mutable struct IncrementalPosDeleteTaskStream
+mutable struct IncrementalPosDeleteFileStream
     ptr::Ptr{Cvoid}
 end
 
 """Handle to a single incremental append task."""
-mutable struct IncrementalAppendHandle
+mutable struct IncrementalAppendFileHandle
     ptr::Ptr{Cvoid}
 end
 
 """Handle to a single positional-delete task (file_path + row positions)."""
-mutable struct IncrementalPosDeleteHandle
+mutable struct IncrementalPosDeleteFileHandle
     ptr::Ptr{Cvoid}
 end
 
@@ -378,7 +378,7 @@ mutable struct IncrementalTaskStreamsResponse
 end
 
 """
-    plan_files(scan::IncrementalScan) -> (IncrementalAppendTaskStream, IncrementalPosDeleteTaskStream)
+    plan_files(scan::IncrementalScan) -> (IncrementalAppendFileStream, IncrementalPosDeleteFileStream)
 
 Plan which files to read for an incremental scan. The scan must be built first via `build!`.
 Returns separate streams for append tasks and positional-delete tasks.
@@ -393,15 +393,15 @@ function plan_files(scan::IncrementalScan)
         )::Cint
     end
     @throw_on_error(response, "iceberg_incremental_plan_files", IcebergException)
-    return IncrementalAppendTaskStream(response.append_stream),
-           IncrementalPosDeleteTaskStream(response.delete_stream)
+    return IncrementalAppendFileStream(response.append_stream),
+           IncrementalPosDeleteFileStream(response.delete_stream)
 end
 
 """
     create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0)) -> ArrowReaderContext
 
 Create a shared reader context from the incremental scan's configuration.
-Pass this to every `read_append_task` and `read_pos_delete_task` call.
+Pass this to every `read_append_file` and `read_pos_delete_file` call.
 """
 function create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0))
     ptr = @ccall rust_lib.iceberg_incremental_create_reader(
@@ -415,109 +415,139 @@ function create_reader(scan::IncrementalScan; reader_concurrency::UInt=UInt(0))
 end
 
 """
-    next_append_task(stream::IncrementalAppendTaskStream) -> Union{IncrementalAppendHandle, Nothing}
+    next_append_file(stream::IncrementalAppendFileStream) -> Union{IncrementalAppendFileHandle, Nothing}
 
 Pull the next append task from the stream. Returns `nothing` at end-of-stream.
 """
-function next_append_task(stream::IncrementalAppendTaskStream)
+function next_append_file(stream::IncrementalAppendFileStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
-        @ccall rust_lib.iceberg_incremental_next_append_task(
+        @ccall rust_lib.iceberg_incremental_next_append_file(
             stream.ptr::Ptr{Cvoid},
             response::Ref{OpaqueResponse},
             handle::Ptr{Cvoid}
         )::Cint
     end
-    @throw_on_error(response, "iceberg_incremental_next_append_task", IcebergException)
-    return response.value == C_NULL ? nothing : IncrementalAppendHandle(response.value)
+    @throw_on_error(response, "iceberg_incremental_next_append_file", IcebergException)
+    return response.value == C_NULL ? nothing : IncrementalAppendFileHandle(response.value)
 end
 
 """
-    read_append_task(reader::ArrowReaderContext, task::IncrementalAppendHandle) -> ArrowStream
+    read_append_file(reader::ArrowReaderContext, task::IncrementalAppendFileHandle) -> ArrowStream
 
 Read a single incremental append task into an Arrow stream. **Consumes `task`**.
 """
-function read_append_task(reader::ArrowReaderContext, task::IncrementalAppendHandle)
+function read_append_file(reader::ArrowReaderContext, task::IncrementalAppendFileHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
-        @ccall rust_lib.iceberg_incremental_read_append_task(
+        @ccall rust_lib.iceberg_incremental_read_append_file(
             reader.ptr::Ptr{Cvoid},
             task.ptr::Ptr{Cvoid},
             response::Ref{ArrowStreamResponse},
             handle::Ptr{Cvoid}
         )::Cint
     end
-    @throw_on_error(response, "iceberg_incremental_read_append_task", IcebergException)
+    @throw_on_error(response, "iceberg_incremental_read_append_file", IcebergException)
     return response.value
 end
 
 """
-    next_pos_delete_task(stream::IncrementalPosDeleteTaskStream) -> Union{IncrementalPosDeleteHandle, Nothing}
+    next_pos_delete_file(stream::IncrementalPosDeleteFileStream) -> Union{IncrementalPosDeleteFileHandle, Nothing}
 
 Pull the next positional-delete task from the stream. Returns `nothing` at end-of-stream.
 Only `PositionalDeletes` tasks are returned; `DeletedFile` and `EqualityDeletes` are skipped.
 """
-function next_pos_delete_task(stream::IncrementalPosDeleteTaskStream)
+function next_pos_delete_file(stream::IncrementalPosDeleteFileStream)
     response = OpaqueResponse()
     async_ccall(response) do handle
-        @ccall rust_lib.iceberg_incremental_next_pos_delete_task(
+        @ccall rust_lib.iceberg_incremental_next_pos_delete_file(
             stream.ptr::Ptr{Cvoid},
             response::Ref{OpaqueResponse},
             handle::Ptr{Cvoid}
         )::Cint
     end
-    @throw_on_error(response, "iceberg_incremental_next_pos_delete_task", IcebergException)
-    return response.value == C_NULL ? nothing : IncrementalPosDeleteHandle(response.value)
+    @throw_on_error(response, "iceberg_incremental_next_pos_delete_file", IcebergException)
+    return response.value == C_NULL ? nothing : IncrementalPosDeleteFileHandle(response.value)
 end
 
 """
-    read_pos_delete_task(reader::ArrowReaderContext, task::IncrementalPosDeleteHandle) -> ArrowStream
+    read_pos_delete_file(reader::ArrowReaderContext, task::IncrementalPosDeleteFileHandle) -> ArrowStream
 
 Convert a positional-delete task into an Arrow stream of `(file_path, pos)` batches.
 **Consumes `task`**.
 """
-function read_pos_delete_task(reader::ArrowReaderContext, task::IncrementalPosDeleteHandle)
+function read_pos_delete_file(reader::ArrowReaderContext, task::IncrementalPosDeleteFileHandle)
     response = ArrowStreamResponse()
     async_ccall(response) do handle
-        @ccall rust_lib.iceberg_incremental_read_pos_delete_task(
+        @ccall rust_lib.iceberg_incremental_read_pos_delete_file(
             reader.ptr::Ptr{Cvoid},
             task.ptr::Ptr{Cvoid},
             response::Ref{ArrowStreamResponse},
             handle::Ptr{Cvoid}
         )::Cint
     end
-    @throw_on_error(response, "iceberg_incremental_read_pos_delete_task", IcebergException)
+    @throw_on_error(response, "iceberg_incremental_read_pos_delete_file", IcebergException)
     return response.value
 end
 
 """
-    append_task_record_count(task::IncrementalAppendHandle) -> Union{Int64, Nothing}
+    record_count(task::IncrementalAppendFileHandle) -> Union{Int64, Nothing}
 
 Return the record count for this append task, or `nothing` if not available.
 """
-function append_task_record_count(task::IncrementalAppendHandle)
-    count = @ccall rust_lib.iceberg_incremental_append_task_record_count(
+function record_count(task::IncrementalAppendFileHandle)
+    count = @ccall rust_lib.iceberg_incremental_append_file_record_count(
         task.ptr::Ptr{Cvoid}
     )::Int64
     return count == -1 ? nothing : count
 end
 
+"""
+    file_path(fs::IncrementalAppendFileHandle)::String
+
+Return the data file path for this incremental append file.
+"""
+function file_path(fs::IncrementalAppendFileHandle)
+    ptr = @ccall rust_lib.iceberg_incremental_append_file_path(
+        fs.ptr::Ptr{Cvoid}
+    )::Ptr{Cchar}
+    ptr == C_NULL && throw(IcebergException("Failed to get append file path"))
+    path = unsafe_string(ptr)
+    @ccall rust_lib.iceberg_destroy_cstring(ptr::Ptr{Cchar})::Cint
+    return path
+end
+
+"""
+    file_path(fs::IncrementalPosDeleteFileHandle)::String
+
+Return the data file path for this positional-delete file.
+"""
+function file_path(fs::IncrementalPosDeleteFileHandle)
+    ptr = @ccall rust_lib.iceberg_incremental_pos_delete_file_path(
+        fs.ptr::Ptr{Cvoid}
+    )::Ptr{Cchar}
+    ptr == C_NULL && throw(IcebergException("Failed to get pos-delete file path"))
+    path = unsafe_string(ptr)
+    @ccall rust_lib.iceberg_destroy_cstring(ptr::Ptr{Cchar})::Cint
+    return path
+end
+
 """Free a stream of incremental append tasks."""
-function free_incremental_append_task_stream(stream::IncrementalAppendTaskStream)
-    @ccall rust_lib.iceberg_incremental_append_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
+function free_file_stream(stream::IncrementalAppendFileStream)
+    @ccall rust_lib.iceberg_incremental_append_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
 """Free a stream of positional-delete tasks."""
-function free_incremental_pos_delete_task_stream(stream::IncrementalPosDeleteTaskStream)
-    @ccall rust_lib.iceberg_incremental_pos_delete_task_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
+function free_file_stream(stream::IncrementalPosDeleteFileStream)
+    @ccall rust_lib.iceberg_incremental_pos_delete_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
-"""Free an append task handle. Only call if NOT passed to `read_append_task`."""
-function free_incremental_append_task(task::IncrementalAppendHandle)
-    @ccall rust_lib.iceberg_incremental_append_task_free(task.ptr::Ptr{Cvoid})::Cvoid
+"""Free an append task handle. Only call if NOT passed to `read_append_file`."""
+function free_file(task::IncrementalAppendFileHandle)
+    @ccall rust_lib.iceberg_incremental_append_file_free(task.ptr::Ptr{Cvoid})::Cvoid
 end
 
-"""Free a positional-delete task handle. Only call if NOT passed to `read_pos_delete_task`."""
-function free_incremental_pos_delete_task(task::IncrementalPosDeleteHandle)
-    @ccall rust_lib.iceberg_incremental_pos_delete_task_free(task.ptr::Ptr{Cvoid})::Cvoid
+"""Free a positional-delete task handle. Only call if NOT passed to `read_pos_delete_file`."""
+function free_file(task::IncrementalPosDeleteFileHandle)
+    @ccall rust_lib.iceberg_incremental_pos_delete_file_free(task.ptr::Ptr{Cvoid})::Cvoid
 end

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -395,6 +395,42 @@ function free_file_stream!(stream::DeleteFileStream)
     @ccall rust_lib.iceberg_incremental_pos_delete_file_stream_free(stream.ptr::Ptr{Cvoid})::Cvoid
 end
 
+"""Response type for iceberg_plan_incremental_warm."""
+mutable struct WarmIncrementalStreamsResponse
+    result::Cint
+    append_warm_stream::Ptr{Cvoid}
+    delete_stream::Ptr{Cvoid}
+    error_message::Ptr{Cchar}
+    context::Ptr{Cvoid}
+end
+WarmIncrementalStreamsResponse() = WarmIncrementalStreamsResponse(0, C_NULL, C_NULL, C_NULL, C_NULL)
+
+"""
+    plan_incremental_warm(scan::IncrementalScan, reader::ArrowReaderContext)
+        -> (WarmFileScanStream, DeleteFileStream)
+
+Plan incremental files in one pass. Returns a warm append stream (batches
+pre-fetched concurrently) and a standard delete file stream. Using a single
+planning call avoids scanning manifests twice.
+"""
+function plan_incremental_warm(scan::IncrementalScan, reader::ArrowReaderContext)
+    response = WarmIncrementalStreamsResponse()
+    async_ccall(response) do handle
+        @ccall rust_lib.iceberg_plan_incremental_warm(
+            scan.ptr::Ptr{Cvoid},
+            reader.ptr::Ptr{Cvoid},
+            response::Ref{WarmIncrementalStreamsResponse},
+            handle::Ptr{Cvoid}
+        )::Cint
+    end
+    if response.result != 0
+        msg = response.error_message != C_NULL ? unsafe_string(response.error_message) : "unknown error"
+        throw(IcebergException(msg))
+    end
+    return WarmFileScanStream(response.append_warm_stream),
+           DeleteFileStream(response.delete_stream)
+end
+
 """Free an append task handle. Only call if NOT passed to `read_file`."""
 function free_file!(task::AppendFileHandle)
     @ccall rust_lib.iceberg_incremental_append_file_free(task.ptr::Ptr{Cvoid})::Cvoid

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -9,14 +9,13 @@ const SNAPSHOT_ID_NONE = Int64(-1)
 A mutable wrapper around a pointer to an incremental table scan.
 
 Incremental scans read changes between two snapshots in an Iceberg table.
-Use `new_incremental_scan` to create a scan between two snapshot IDs, configure it
-with builder methods, and call `scan!` to obtain separate Arrow streams for inserts and deletes.
+Use `new_incremental_scan` to create a scan between two snapshot IDs and call
+`scan!` to obtain separate Arrow streams for inserts and deletes.
 
 # Example
 ```julia
 table = table_open("s3://path/to/table/metadata.json")
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-with_batch_size!(scan, UInt(1024))
+scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; batch_size=Int64(1024))
 inserts_stream, deletes_stream = scan!(scan)
 # ... process batches from both streams
 free_stream!(inserts_stream)
@@ -52,228 +51,72 @@ mutable struct UnzippedStreamsResponse
 end
 
 """
-    new_incremental_scan(table::Table, from_snapshot_id::Union{Int64,Nothing}, to_snapshot_id::Union{Int64,Nothing}) -> IncrementalScan
+    new_incremental_scan(table, from_snapshot_id, to_snapshot_id; kwargs...) -> IncrementalScan
 
 Create an incremental scan for the given table between two snapshots.
 
 # Arguments
 - `table::Table`: The Iceberg table to scan
-- `from_snapshot_id`: Starting snapshot ID, or `nothing` to scan from the root (oldest) snapshot
-- `to_snapshot_id`: Ending snapshot ID, or `nothing` to scan to the current (latest) snapshot
+- `from_snapshot_id`: Starting snapshot ID, or `nothing` (or `Int64(-1)`) for oldest snapshot
+- `to_snapshot_id`: Ending snapshot ID, or `nothing` (or `Int64(-1)`) for current snapshot
+
+# Keyword Arguments
+- `column_names`: columns to read (default: all columns)
+- `data_file_concurrency_limit`: data file concurrency (`-1` = reader default)
+- `manifest_file_concurrency_limit`: manifest file concurrency (`-1` = don't set)
+- `manifest_entry_concurrency_limit`: manifest entry concurrency (`-1` = don't set)
+- `batch_size`: Arrow record batch size (`-1` = no override)
+- `file_column`: include `_file` metadata column (default: `false`)
+- `pos_column`: include `_pos` metadata column (default: `false`)
+- `serialization_concurrency`: parallel batch serializations (`-1` = auto-detect)
+- `task_prefetch_depth`: file scan task prefetch depth (`-1` = use default)
 
 # Examples
 ```julia
 # Scan full history (root to current)
 scan = new_incremental_scan(table, nothing, nothing)
 
-# Scan from root to specific snapshot
-scan = new_incremental_scan(table, nothing, snapshot_id)
-
-# Scan from specific snapshot to current
-scan = new_incremental_scan(table, snapshot_id, nothing)
-
-# Scan between specific snapshots
-scan = new_incremental_scan(table, from_id, to_id)
+# Scan between specific snapshots with batch size
+scan = new_incremental_scan(table, from_id, to_id; batch_size=Int64(1024))
 ```
 """
-function new_incremental_scan(table::Table, from_snapshot_id::Union{Int64,Nothing}, to_snapshot_id::Union{Int64,Nothing})
-    # Convert nothing to SNAPSHOT_ID_NONE for C API
+function new_incremental_scan(
+    table::Table,
+    from_snapshot_id::Union{Int64, Nothing},
+    to_snapshot_id::Union{Int64, Nothing};
+    column_names::Union{Vector{String}, Nothing} = nothing,
+    data_file_concurrency_limit::Int64 = Int64(-1),
+    manifest_file_concurrency_limit::Int64 = Int64(-1),
+    manifest_entry_concurrency_limit::Int64 = Int64(-1),
+    batch_size::Int64 = Int64(-1),
+    file_column::Bool = false,
+    pos_column::Bool = false,
+    serialization_concurrency::Int64 = Int64(-1),
+    task_prefetch_depth::Int64 = Int64(-1),
+)
     from_id = from_snapshot_id === nothing ? SNAPSHOT_ID_NONE : from_snapshot_id
     to_id = to_snapshot_id === nothing ? SNAPSHOT_ID_NONE : to_snapshot_id
+    c_column_names = isnothing(column_names) ? C_NULL : pointer(pointer.(column_names))
+    column_count = isnothing(column_names) ? 0 : length(column_names)
 
-    scan_ptr = @ccall rust_lib.iceberg_new_incremental_scan(
+
+    scan_ptr = GC.@preserve column_names c_column_names @ccall rust_lib.iceberg_new_incremental_scan(
         table::Table,
         from_id::Int64,
-        to_id::Int64
-    )::Ptr{Cvoid}
+        to_id::Int64,
+        c_column_names::Ptr{Cstring},
+        column_count::Csize_t,
+        data_file_concurrency_limit::Int64,
+        manifest_file_concurrency_limit::Int64,
+        manifest_entry_concurrency_limit::Int64,
+        batch_size::Int64,
+        file_column::Bool,
+        pos_column::Bool,
+        serialization_concurrency::Int64,
+        task_prefetch_depth::Int64,
+        )::Ptr{Cvoid}
+    scan_ptr == C_NULL && throw(IcebergException("Failed to create incremental scan"))
     return IncrementalScan(scan_ptr)
-end
-
-"""
-    select_columns!(scan::IncrementalScan, column_names::Vector{String})
-
-Select specific columns for the incremental scan.
-"""
-function select_columns!(scan::IncrementalScan, column_names::Vector{String})
-    # Convert String vector to Cstring array
-    c_strings = [pointer(col) for col in column_names]
-    result = GC.@preserve scan c_strings @ccall rust_lib.iceberg_incremental_select_columns(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        pointer(c_strings)::Ptr{Cstring},
-        length(column_names)::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to select columns for incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_manifest_file_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-Sets the manifest file concurrency level for the incremental scan.
-"""
-function with_manifest_file_concurrency_limit!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_manifest_file_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set manifest file concurrency limit for incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_data_file_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-Sets the data file concurrency level for the incremental scan.
-"""
-function with_data_file_concurrency_limit!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_data_file_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set data file concurrency limit for incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_manifest_entry_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-Sets the manifest entry concurrency level for the incremental scan.
-"""
-function with_manifest_entry_concurrency_limit!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_manifest_entry_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set manifest entry concurrency limit for incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_batch_size!(scan::IncrementalScan, n::UInt)
-
-Sets the batch size for the incremental scan.
-"""
-function with_batch_size!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_batch_size(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set batch size for incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_file_column!(scan::IncrementalScan)
-
-Add the _file metadata column to the incremental scan.
-
-The _file column contains the file path for each row, which can be useful for
-tracking which data files contain specific rows during incremental scans.
-
-# Example
-```julia
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-with_file_column!(scan)
-inserts_stream, deletes_stream = scan!(scan)
-```
-"""
-function with_file_column!(scan::IncrementalScan)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_file_column(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to add file column to incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_serialization_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-Set the serialization concurrency limit for the incremental scan.
-
-This controls how many RecordBatch serializations can happen in parallel for each stream.
-- `n = 0`: Auto-detect based on CPU cores (default)
-- `n > 0`: Use exactly n concurrent serializations per stream
-
-Note: Incremental scans have two separate streams (inserts and deletes), so total
-concurrency can be up to 2×n.
-
-# Example
-```julia
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-with_serialization_concurrency_limit!(scan, UInt(8))  # Each stream serializes up to 8 batches in parallel
-inserts_stream, deletes_stream = scan!(scan)
-```
-"""
-function with_serialization_concurrency_limit!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_serialization_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to set serialization concurrency limit for incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    with_pos_column!(scan::IncrementalScan)
-
-Add the _pos metadata column to the incremental scan.
-
-The _pos column contains the position of each row within its data file, which can
-be useful for tracking row locations during incremental scans.
-
-# Example
-```julia
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-with_pos_column!(scan)
-inserts_stream, deletes_stream = scan!(scan)
-```
-"""
-function with_pos_column!(scan::IncrementalScan)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_pos_column(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to add pos column to incremental scan", result))
-    end
-    return nothing
-end
-
-"""
-    build!(scan::IncrementalScan)
-
-Build the provided incremental table scan object.
-"""
-function build!(scan::IncrementalScan)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_build(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}}
-    )::Cint
-
-    if result != 0
-        throw(IcebergException("Failed to build incremental scan", result))
-    end
-    return nothing
 end
 
 """
@@ -301,11 +144,10 @@ end
 """
     scan!(scan::IncrementalScan) -> (ArrowStream, ArrowStream)
 
-Build the provided incremental table scan object and return unzipped Arrow streams.
+Execute the incremental scan and return unzipped Arrow streams.
 Returns a tuple of (inserts_stream, deletes_stream).
 """
 function scan!(scan::IncrementalScan)
-    build!(scan)
     return incremental_arrow_stream_unzipped(scan)
 end
 
@@ -324,7 +166,6 @@ end
 # Incremental split-scan API
 #
 # Usage:
-#   build!(scan)
 #   reader = create_reader(scan)
 #   append_stream, delete_stream = plan_files(scan)
 #   while (at = next_file!(append_stream)) !== nothing

--- a/src/scan_common.jl
+++ b/src/scan_common.jl
@@ -13,15 +13,13 @@ const ArrowStream = Ptr{Cvoid}
 
 The name of the metadata column containing file paths (_file).
 
-This constant can be used with the `select_columns!` function to include
-file path information in query results. It corresponds to the _file metadata
-column in Iceberg tables.
+This constant can be used as a column name to include file path information
+in query results. It corresponds to the _file metadata column in Iceberg tables.
 
 # Example
 ```julia
 # Select specific columns including the file path
-scan = new_scan(table)
-select_columns!(scan, ["id", "name", FILE_COLUMN])
+scan = new_scan(table; column_names=["id", "name", FILE_COLUMN])
 stream = scan!(scan)
 ```
 """
@@ -32,15 +30,14 @@ const FILE_COLUMN = "_file"
 
 The name of the metadata column containing row positions within files (_pos).
 
-This constant can be used with the `select_columns!` function to include
-position information in query results. It corresponds to the _pos metadata
-column in Iceberg tables, which represents the row's position within its data file.
+This constant can be used as a column name to include position information
+in query results. It corresponds to the _pos metadata column in Iceberg tables,
+which represents the row's position within its data file.
 
 # Example
 ```julia
 # Select specific columns including the position
-scan = new_scan(table)
-select_columns!(scan, ["id", "name", POS_COLUMN])
+scan = new_scan(table; column_names=["id", "name", POS_COLUMN])
 stream = scan!(scan)
 ```
 """

--- a/src/scan_common.jl
+++ b/src/scan_common.jl
@@ -74,20 +74,20 @@ function next_batch(stream::ArrowStream)
 end
 
 """
-    free_batch(batch::Ptr{ArrowBatch})
+    free_batch!(batch::Ptr{ArrowBatch})
 
 Free the memory associated with an Arrow batch.
 """
-function free_batch(batch::Ptr{ArrowBatch})
+function free_batch!(batch::Ptr{ArrowBatch})
     @ccall rust_lib.iceberg_arrow_batch_free(batch::Ptr{ArrowBatch})::Cvoid
 end
 
 """
-    free_stream(stream::ArrowStream)
+    free_stream!(stream::ArrowStream)
 
 Free the memory associated with an Arrow stream.
 """
-function free_stream(stream::ArrowStream)
+function free_stream!(stream::ArrowStream)
     @ccall rust_lib.iceberg_arrow_stream_free(stream::ArrowStream)::Cvoid
 end
 

--- a/src/scan_common.jl
+++ b/src/scan_common.jl
@@ -90,3 +90,5 @@ Free the memory associated with an Arrow stream.
 function free_stream(stream::ArrowStream)
     @ccall rust_lib.iceberg_arrow_stream_free(stream::ArrowStream)::Cvoid
 end
+
+const OpaqueResponse = Response{Ptr{Cvoid}}

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -146,10 +146,10 @@ end
                 @test sorted[3] == (3, "carol",  3.3)
             finally
                 if updated_table != C_NULL
-                    free_table(updated_table)
+                    free_table!(updated_table)
                 end
                 if table != C_NULL
-                    free_table(table)
+                    free_table!(table)
                 end
                 free_catalog!(cat)
             end
@@ -210,10 +210,10 @@ end
                 @test sorted[3] == (30, "z", 3.5)
             finally
                 if updated_table != C_NULL
-                    free_table(updated_table)
+                    free_table!(updated_table)
                 end
                 if table != C_NULL
-                    free_table(table)
+                    free_table!(table)
                 end
                 free_catalog!(cat)
             end
@@ -600,19 +600,19 @@ end
                 println("✅ Batch contains valid Arrow data from catalog-loaded customer table")
 
                 # Clean up the batch
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
             end
         end
     finally
         # Clean up all resources in reverse order
         if stream != C_NULL
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
         end
         if scan != C_NULL
             RustyIceberg.free_scan!(scan)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
         if catalog !== nothing
             RustyIceberg.free_catalog!(catalog)
@@ -687,19 +687,19 @@ end
                 println("✅ Batch contains valid Arrow data from catalog-loaded customer table with vended credentials")
 
                 # Clean up the batch
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
             end
         end
     finally
         # Clean up all resources in reverse order
         if stream != C_NULL
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
         end
         if scan != C_NULL
             RustyIceberg.free_scan!(scan)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
         if catalog !== nothing
             RustyIceberg.free_catalog!(catalog)
@@ -753,13 +753,13 @@ end
             @test credential_error_caught
         finally
             if stream != C_NULL
-                RustyIceberg.free_stream(stream)
+                RustyIceberg.free_stream!(stream)
             end
             if scan != C_NULL
                 RustyIceberg.free_scan!(scan)
             end
             if table != C_NULL
-                RustyIceberg.free_table(table)
+                RustyIceberg.free_table!(table)
             end
             if catalog !== nothing
                 RustyIceberg.free_catalog!(catalog)
@@ -832,18 +832,18 @@ end
                     @test batch.length > 0
                     println("✅ Batch contains valid Arrow data - storage credentials loader worked!")
 
-                    RustyIceberg.free_batch(batch_ptr)
+                    RustyIceberg.free_batch!(batch_ptr)
                 end
             end
         finally
             if stream != C_NULL
-                RustyIceberg.free_stream(stream)
+                RustyIceberg.free_stream!(stream)
             end
             if scan != C_NULL
                 RustyIceberg.free_scan!(scan)
             end
             if table != C_NULL
-                RustyIceberg.free_table(table)
+                RustyIceberg.free_table!(table)
             end
             if catalog !== nothing
                 RustyIceberg.free_catalog!(catalog)
@@ -921,7 +921,7 @@ end
                     println("  Batch $inserts_count: $(nrow(df)) rows")
                 end
             end
-            RustyIceberg.free_batch(batch_ptr)
+            RustyIceberg.free_batch!(batch_ptr)
             batch_ptr = RustyIceberg.next_batch(inserts_stream)
         end
 
@@ -944,7 +944,7 @@ end
                     println("  Batch $deletes_count: $(nrow(df)) rows")
                 end
             end
-            RustyIceberg.free_batch(batch_ptr)
+            RustyIceberg.free_batch!(batch_ptr)
             batch_ptr = RustyIceberg.next_batch(deletes_stream)
         end
 
@@ -959,16 +959,16 @@ end
     finally
         # Clean up all resources in reverse order
         if inserts_stream != C_NULL
-            RustyIceberg.free_stream(inserts_stream)
+            RustyIceberg.free_stream!(inserts_stream)
         end
         if deletes_stream != C_NULL
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(deletes_stream)
         end
         if scan != C_NULL
             RustyIceberg.free_scan!(scan)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
         if catalog !== nothing
             RustyIceberg.free_catalog!(catalog)
@@ -1079,7 +1079,7 @@ end
         println("✅ Table schema retrieved: $(length(parsed_schema["fields"])) fields")
 
         # Clean up first table
-        RustyIceberg.free_table(table_1)
+        RustyIceberg.free_table!(table_1)
 
         # Test 2: Create table with custom properties
         println("\nTest 2: Creating table with custom properties...")
@@ -1107,7 +1107,7 @@ end
         println("✅ Table existence verified: $table_name_2")
 
         # Clean up second table
-        RustyIceberg.free_table(table_2)
+        RustyIceberg.free_table!(table_2)
 
         # Test 3: Create table with partition spec
         println("\nTest 3: Creating table with partition spec...")
@@ -1135,7 +1135,7 @@ end
         println("✅ Table existence verified: $table_name_3")
 
         # Clean up third table
-        RustyIceberg.free_table(table_3)
+        RustyIceberg.free_table!(table_3)
 
         # Test 4: List tables in test namespace to verify all created tables
         println("\nTest 4: Verifying all created tables in namespace...")

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -569,16 +569,11 @@ end
         @test table != C_NULL
         println("✅ Customer table loaded successfully from catalog")
 
-        # Create a scan on the loaded table
+        # Create a scan on the loaded table with specific columns
         println("Creating scan on loaded customer table...")
-        scan = RustyIceberg.new_scan(table)
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name", "c_nationkey"])
         @test scan != C_NULL
         println("✅ Scan created successfully on loaded table")
-
-        # Select specific columns to verify table structure
-        println("Selecting specific columns from customer table...")
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", "c_nationkey"])
-        println("✅ Column selection completed")
 
         # Execute the scan
         println("Executing scan on loaded customer table...")
@@ -656,16 +651,11 @@ end
         @test table != C_NULL
         println("✅ Customer table loaded successfully with vended credentials")
 
-        # Create a scan on the loaded table
+        # Create a scan on the loaded table with specific columns
         println("Creating scan on loaded customer table...")
-        scan = RustyIceberg.new_scan(table)
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name", "c_nationkey"])
         @test scan != C_NULL
         println("✅ Scan created successfully on loaded table")
-
-        # Select specific columns
-        println("Selecting specific columns from customer table...")
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", "c_nationkey"])
-        println("✅ Column selection completed")
 
         # Execute the scan
         println("Executing scan on loaded customer table...")
@@ -738,8 +728,7 @@ end
             credential_error_caught = false
             try
                 table = RustyIceberg.load_table(catalog, ["tpch.sf01"], "customer"; load_credentials=false)
-                scan = RustyIceberg.new_scan(table)
-                RustyIceberg.select_columns!(scan, ["c_custkey"])
+                scan = RustyIceberg.new_scan(table; column_names=["c_custkey"])
                 stream = RustyIceberg.scan!(scan)
                 RustyIceberg.next_batch(stream)
                 error("Expected a credential/access error but none was thrown")
@@ -803,15 +792,11 @@ end
             @test table != C_NULL
             println("✅ Customer table loaded successfully")
 
-            # Create a scan on the loaded table
+            # Create a scan on the loaded table with specific columns
             println("Creating scan on loaded customer table...")
-            scan = RustyIceberg.new_scan(table)
+            scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name", "c_nationkey"])
             @test scan != C_NULL
             println("✅ Scan created successfully on loaded table")
-
-            # Select specific columns
-            println("Selecting specific columns from customer table...")
-            RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", "c_nationkey"])
             println("✅ Column selection completed")
 
             # Execute the scan - this is where the credentials loader should kick in
@@ -885,15 +870,10 @@ end
         to_snapshot_id = Int64(6832180054960511692)
 
         println("Creating incremental scan on catalog-loaded table...")
-        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id; batch_size=Int64(10))
         @test scan isa RustyIceberg.IncrementalScan
         @test scan.ptr != C_NULL
         println("✅ Incremental scan created successfully on catalog-loaded table")
-
-        # Configure scan with batch size
-        println("Configuring incremental scan...")
-        RustyIceberg.with_batch_size!(scan, UInt(10))
-        println("✅ Batch size configured")
 
         # Execute the scan to get streams
         println("Executing incremental scan on catalog-loaded table...")

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -965,7 +965,7 @@ end
             RustyIceberg.free_stream(deletes_stream)
         end
         if scan != C_NULL
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
         end
         if table != C_NULL
             RustyIceberg.free_table(table)

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -1177,7 +1177,7 @@ end
                 fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
                 task_count += 1
-                stream = RustyIceberg.read_file_scan!(reader, fs)
+                stream = RustyIceberg.read_file!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1242,7 +1242,7 @@ end
             while true
                 fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
-                stream = RustyIceberg.read_file_scan!(reader, fs)
+                stream = RustyIceberg.read_file!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1284,7 +1284,7 @@ end
             while true
                 fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
-                stream = RustyIceberg.read_file_scan!(reader, fs)
+                stream = RustyIceberg.read_file!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1328,7 +1328,7 @@ end
                     total_from_counts += count
                 end
 
-                stream = RustyIceberg.read_file_scan!(reader, fs)
+                stream = RustyIceberg.read_file!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1386,7 +1386,7 @@ end
             while true
                 fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
-                stream = RustyIceberg.read_file_scan!(reader, fs)
+                stream = RustyIceberg.read_file!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1424,7 +1424,7 @@ end
                 fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
                 task_count += 1
-                stream = RustyIceberg.read_file_scan!(reader, fs)
+                stream = RustyIceberg.read_file!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -1236,14 +1236,14 @@ end
         reader = RustyIceberg.create_reader(scan)
         @test reader isa RustyIceberg.ArrowReaderContext
         file_stream = RustyIceberg.plan_files(scan)
-        @test file_stream isa RustyIceberg.FileScanTaskStream
+        @test file_stream isa RustyIceberg.FileScanStream
 
         all_rows = Tuple[]
         task_count = 0
 
         try
             while true
-                fs = RustyIceberg.next_file_scan(file_stream)
+                fs = RustyIceberg.next_file(file_stream)
                 fs === nothing && break
                 task_count += 1
                 stream = RustyIceberg.read_file_scan(reader, fs)
@@ -1310,7 +1310,7 @@ end
         split_rows = Tuple[]
         try
             while true
-                fs = RustyIceberg.next_file_scan(file_stream)
+                fs = RustyIceberg.next_file(file_stream)
                 fs === nothing && break
                 stream = RustyIceberg.read_file_scan(reader, fs)
                 try
@@ -1354,7 +1354,7 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file_scan(file_stream)
+                fs = RustyIceberg.next_file(file_stream)
                 fs === nothing && break
                 stream = RustyIceberg.read_file_scan(reader, fs)
                 try
@@ -1392,7 +1392,7 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file_scan(file_stream)
+                fs = RustyIceberg.next_file(file_stream)
                 fs === nothing && break
 
                 count = RustyIceberg.record_count(fs)
@@ -1433,7 +1433,7 @@ end
         file_stream = RustyIceberg.plan_files(scan)
 
         try
-            fs = RustyIceberg.next_file_scan(file_stream)
+            fs = RustyIceberg.next_file(file_stream)
             if fs !== nothing
                 @test_nowarn RustyIceberg.free_file(fs)
             end
@@ -1460,7 +1460,7 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file_scan(file_stream)
+                fs = RustyIceberg.next_file(file_stream)
                 fs === nothing && break
                 stream = RustyIceberg.read_file_scan(reader, fs)
                 try
@@ -1499,7 +1499,7 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file_scan(file_stream)
+                fs = RustyIceberg.next_file(file_stream)
                 fs === nothing && break
                 task_count += 1
                 stream = RustyIceberg.read_file_scan(reader, fs)
@@ -1542,18 +1542,18 @@ end
         reader = RustyIceberg.create_reader(scan)
         @test reader isa RustyIceberg.ArrowReaderContext
         append_stream, delete_stream = RustyIceberg.plan_files(scan)
-        @test append_stream isa RustyIceberg.IncrementalAppendFileStream
-        @test delete_stream isa RustyIceberg.IncrementalPosDeleteFileStream
+        @test append_stream isa RustyIceberg.AppendFileStream
+        @test delete_stream isa RustyIceberg.DeleteFileStream
 
         inserts_values = Int64[]
         append_task_count = 0
 
         try
             while true
-                at = RustyIceberg.next_append_file(append_stream)
+                at = RustyIceberg.next_file(append_stream)
                 at === nothing && break
                 append_task_count += 1
-                stream = RustyIceberg.read_append_file(reader, at)
+                stream = RustyIceberg.read_file(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1574,10 +1574,10 @@ end
             delete_task_count = 0
 
             while true
-                dt = RustyIceberg.next_pos_delete_file(delete_stream)
+                dt = RustyIceberg.next_file(delete_stream)
                 dt === nothing && break
                 delete_task_count += 1
-                stream = RustyIceberg.read_pos_delete_file(reader, dt)
+                stream = RustyIceberg.read_file(reader, dt)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1627,11 +1627,11 @@ end
 
         try
             while true
-                at = RustyIceberg.next_append_file(append_stream)
+                at = RustyIceberg.next_file(append_stream)
                 at === nothing && break
                 count = RustyIceberg.record_count(at)
                 @test count === nothing || count >= 0
-                stream = RustyIceberg.read_append_file(reader, at)
+                stream = RustyIceberg.read_file(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1644,7 +1644,7 @@ end
             end
             total_delete_positions = 0
             while true
-                dt = RustyIceberg.next_pos_delete_file(delete_stream)
+                dt = RustyIceberg.next_file(delete_stream)
                 dt === nothing && break
                 n = RustyIceberg.record_count(dt)
                 @test n >= 0
@@ -1671,7 +1671,7 @@ end
         append_stream, delete_stream = RustyIceberg.plan_files(scan)
 
         try
-            at = RustyIceberg.next_append_file(append_stream)
+            at = RustyIceberg.next_file(append_stream)
             if at !== nothing
                 @test_nowarn RustyIceberg.free_file(at)
             end
@@ -1729,9 +1729,9 @@ end
         sp_deletes = Tuple{String, Int64}[]
         try
             while true
-                at = RustyIceberg.next_append_file(append_stream)
+                at = RustyIceberg.next_file(append_stream)
                 at === nothing && break
-                stream = RustyIceberg.read_append_file(reader, at)
+                stream = RustyIceberg.read_file(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1747,9 +1747,9 @@ end
                 end
             end
             while true
-                dt = RustyIceberg.next_pos_delete_file(delete_stream)
+                dt = RustyIceberg.next_file(delete_stream)
                 dt === nothing && break
-                stream = RustyIceberg.read_pos_delete_file(reader, dt)
+                stream = RustyIceberg.read_file(reader, dt)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -88,9 +88,7 @@ using Arrow
             selected_columns = names(first_df)[1:min(2, length(names(first_df)))]
 
             table2 = RustyIceberg.table_open(snapshot_path)
-            scan2 = RustyIceberg.new_scan(table2)
-            RustyIceberg.select_columns!(scan2, selected_columns)
-            RustyIceberg.with_batch_size!(scan2, UInt(8))
+            scan2 = RustyIceberg.new_scan(table2; column_names=selected_columns, batch_size=Int64(8))
             stream2 = RustyIceberg.scan!(scan2)
 
             try
@@ -143,8 +141,7 @@ end
     println("Testing reading nations table...")
 
     table = RustyIceberg.table_open(nations_snapshot_path)
-    scan = RustyIceberg.new_scan(table)
-    RustyIceberg.with_batch_size!(scan, UInt(5))
+    scan = RustyIceberg.new_scan(table; batch_size=Int64(5))
     stream = RustyIceberg.scan!(scan)
 
     rows = Tuple[]
@@ -226,14 +223,10 @@ end
     to_snapshot_id = Int64(6832180054960511692)
 
     @testset "Incremental Scan E2E Test" begin
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; batch_size=Int64(50))
         @test scan isa RustyIceberg.IncrementalScan
         @test scan.ptr != C_NULL
         println("✅ Incremental scan created (from snapshot $from_snapshot_id to $to_snapshot_id)")
-
-        # Test builder methods
-        @test_nowarn RustyIceberg.with_batch_size!(scan, UInt(50))
-        println("✅ Batch size configured")
 
         # Build and get streams
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
@@ -336,10 +329,7 @@ end
     end
 
     @testset "Incremental Scan with Column Selection" begin
-        scan2 = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        # Select only the "n" column
-        RustyIceberg.select_columns!(scan2, ["n"])
+        scan2 = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; column_names=["n"])
 
         inserts_stream2, deletes_stream2 = RustyIceberg.scan!(scan2)
 
@@ -368,15 +358,15 @@ end
 
     @testset "Incremental Scan with nothing for both snapshot IDs" begin
         # Test scanning from root (nothing) to current (nothing) - full history
-        scan3 = new_incremental_scan(table, nothing, nothing)
+        scan3 = new_incremental_scan(table, nothing, nothing;
+            manifest_file_concurrency_limit=Int64(2),
+            manifest_entry_concurrency_limit=Int64(256),
+            data_file_concurrency_limit=Int64(1024),
+            batch_size=Int64(50),
+        )
         @test scan3 isa RustyIceberg.IncrementalScan
         @test scan3.ptr != C_NULL
         println("✅ Incremental scan created with nothing for both snapshot IDs")
-
-        RustyIceberg.with_manifest_file_concurrency_limit!(scan3, UInt(2))
-        RustyIceberg.with_manifest_entry_concurrency_limit!(scan3, UInt(256))
-        RustyIceberg.with_data_file_concurrency_limit!(scan3, UInt(1024))
-        RustyIceberg.with_batch_size!(scan3, UInt(50))
 
         inserts_stream3, deletes_stream3 = RustyIceberg.scan!(scan3)
         @test inserts_stream3 != C_NULL
@@ -473,12 +463,9 @@ end
     from_snapshot_id = Int64(6540713100348352610)
     to_snapshot_id = Int64(6832180054960511692)
 
-    @testset "select_columns! - Full Scan" begin
+    @testset "column_names - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Select specific columns
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name"])
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -494,7 +481,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ select_columns! test passed for full scan")
+            println("✅ column_names test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -502,11 +489,9 @@ end
         end
     end
 
-    @testset "select_columns! - Incremental Scan" begin
+    @testset "column_names - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        RustyIceberg.select_columns!(scan, ["n"])
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; column_names=["n"])
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -522,7 +507,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ select_columns! test passed for incremental scan")
+            println("✅ column_names test passed for incremental scan")
         finally
             RustyIceberg.free_stream!(inserts_stream)
             RustyIceberg.free_stream!(deletes_stream)
@@ -531,12 +516,9 @@ end
         end
     end
 
-    @testset "with_batch_size! - Full Scan" begin
+    @testset "batch_size - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Set small batch size
-        RustyIceberg.with_batch_size!(scan, UInt(10))
+        scan = RustyIceberg.new_scan(table; batch_size=Int64(10))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -551,7 +533,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_batch_size! test passed for full scan")
+            println("✅ batch_size test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -559,11 +541,9 @@ end
         end
     end
 
-    @testset "with_batch_size! - Incremental Scan" begin
+    @testset "batch_size - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        RustyIceberg.with_batch_size!(scan, UInt(10))
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; batch_size=Int64(10))
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -577,7 +557,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ with_batch_size! test passed for incremental scan")
+            println("✅ batch_size test passed for incremental scan")
         finally
             RustyIceberg.free_stream!(inserts_stream)
             RustyIceberg.free_stream!(deletes_stream)
@@ -586,12 +566,9 @@ end
         end
     end
 
-    @testset "with_data_file_concurrency_limit! - Full Scan" begin
+    @testset "data_file_concurrency_limit - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Set concurrency limit (should not error)
-        @test_nowarn RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(4))
+        scan = RustyIceberg.new_scan(table; data_file_concurrency_limit=Int64(4))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -600,7 +577,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_data_file_concurrency_limit! test passed for full scan")
+            println("✅ data_file_concurrency_limit test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -608,11 +585,9 @@ end
         end
     end
 
-    @testset "with_data_file_concurrency_limit! - Incremental Scan" begin
+    @testset "data_file_concurrency_limit - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        @test_nowarn RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(4))
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; data_file_concurrency_limit=Int64(4))
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -621,7 +596,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ with_data_file_concurrency_limit! test passed for incremental scan")
+            println("✅ data_file_concurrency_limit test passed for incremental scan")
         finally
             RustyIceberg.free_stream!(inserts_stream)
             RustyIceberg.free_stream!(deletes_stream)
@@ -630,12 +605,9 @@ end
         end
     end
 
-    @testset "with_manifest_entry_concurrency_limit! - Full Scan" begin
+    @testset "manifest_entry_concurrency_limit - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Set concurrency limit (should not error)
-        @test_nowarn RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(4))
+        scan = RustyIceberg.new_scan(table; manifest_entry_concurrency_limit=Int64(4))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -644,7 +616,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_manifest_entry_concurrency_limit! test passed for full scan")
+            println("✅ manifest_entry_concurrency_limit test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -652,12 +624,9 @@ end
         end
     end
 
-    @testset "with_manifest_file_concurrency_limit! - Full Scan" begin
+    @testset "manifest_file_concurrency_limit - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Set concurrency limit (should not error)
-        @test_nowarn RustyIceberg.with_manifest_file_concurrency_limit!(scan, UInt(4))
+        scan = RustyIceberg.new_scan(table; manifest_file_concurrency_limit=Int64(4))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -666,7 +635,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_manifest_file_concurrency_limit! test passed for full scan")
+            println("✅ manifest_file_concurrency_limit test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -674,11 +643,9 @@ end
         end
     end
 
-    @testset "with_manifest_entry_concurrency_limit! - Incremental Scan" begin
+    @testset "manifest_entry_concurrency_limit - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        @test_nowarn RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(4))
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; manifest_entry_concurrency_limit=Int64(4))
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -687,7 +654,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ with_manifest_entry_concurrency_limit! test passed for incremental scan")
+            println("✅ manifest_entry_concurrency_limit test passed for incremental scan")
         finally
             RustyIceberg.free_stream!(inserts_stream)
             RustyIceberg.free_stream!(deletes_stream)
@@ -696,17 +663,15 @@ end
         end
     end
 
-    @testset "Combined Builder Methods - Full Scan" begin
+    @testset "Combined Parameters - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Combine multiple builder methods
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", "c_address"])
-        RustyIceberg.with_batch_size!(scan, UInt(5))
-        RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_serialization_concurrency_limit!(scan, UInt(2))
-
+        scan = RustyIceberg.new_scan(table;
+            column_names=["c_custkey", "c_name", "c_address"],
+            batch_size=Int64(5),
+            data_file_concurrency_limit=Int64(2),
+            manifest_entry_concurrency_limit=Int64(2),
+            serialization_concurrency=Int64(2),
+        )
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -724,7 +689,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ Combined builder methods test passed for full scan")
+            println("✅ Combined parameters test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -732,18 +697,16 @@ end
         end
     end
 
-    @testset "Combined Builder Methods - Incremental Scan" begin
+    @testset "Combined Parameters - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        # Combine multiple builder methods
-        RustyIceberg.select_columns!(scan, ["n"])
-        RustyIceberg.with_batch_size!(scan, UInt(5))
-        RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_manifest_file_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_serialization_concurrency_limit!(scan, UInt(2))
-
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id;
+            column_names=["n"],
+            batch_size=Int64(5),
+            data_file_concurrency_limit=Int64(2),
+            manifest_file_concurrency_limit=Int64(2),
+            manifest_entry_concurrency_limit=Int64(2),
+            serialization_concurrency=Int64(2),
+        )
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -760,7 +723,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ Combined builder methods test passed for incremental scan")
+            println("✅ Combined parameters test passed for incremental scan")
         finally
             RustyIceberg.free_stream!(inserts_stream)
             RustyIceberg.free_stream!(deletes_stream)
@@ -769,13 +732,9 @@ end
         end
     end
 
-    @testset "select_columns! with with_file_column! - Full Scan" begin
+    @testset "column_names with file_column - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Select specific columns AND include file metadata
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
-        RustyIceberg.with_file_column!(scan)
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name"], file_column=true)
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -803,7 +762,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ select_columns! with with_file_column! test passed for full scan")
+            println("✅ column_names with file_column test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -811,13 +770,9 @@ end
         end
     end
 
-    @testset "select_columns! with with_file_column! - Incremental Scan" begin
+    @testset "column_names with file_column - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        # Select specific column AND include file metadata for incremental scan
-        RustyIceberg.select_columns!(scan, ["n"])
-        RustyIceberg.with_file_column!(scan)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; column_names=["n"], file_column=true)
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -842,7 +797,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ select_columns! with with_file_column! test passed for incremental scan")
+            println("✅ column_names with file_column test passed for incremental scan")
         finally
             RustyIceberg.free_stream!(inserts_stream)
             RustyIceberg.free_stream!(deletes_stream)
@@ -851,12 +806,9 @@ end
         end
     end
 
-    @testset "select_columns! with FILE_COLUMN constant" begin
+    @testset "column_names with FILE_COLUMN constant" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Select columns including FILE_COLUMN constant
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", RustyIceberg.FILE_COLUMN])
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name", RustyIceberg.FILE_COLUMN])
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -883,7 +835,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ select_columns! with FILE_COLUMN constant test passed")
+            println("✅ column_names with FILE_COLUMN constant test passed")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -891,13 +843,9 @@ end
         end
     end
 
-    @testset "select_columns! with with_pos_column! - Full Scan" begin
+    @testset "column_names with pos_column - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Select specific columns AND include pos metadata
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
-        RustyIceberg.with_pos_column!(scan)
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name"], pos_column=true)
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -928,7 +876,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ select_columns! with with_pos_column! test passed for full scan")
+            println("✅ column_names with pos_column test passed for full scan")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -936,13 +884,9 @@ end
         end
     end
 
-    @testset "select_columns! with with_pos_column! - Incremental Scan" begin
+    @testset "column_names with pos_column - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-
-        # Select specific column AND include pos metadata for incremental scan
-        RustyIceberg.select_columns!(scan, ["n"])
-        RustyIceberg.with_pos_column!(scan)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id; column_names=["n"], pos_column=true)
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -1016,7 +960,7 @@ end
             full_range = 0:19
             @test Set(keys(position_counts)) == Set(full_range)
 
-            println("✅ select_columns! with with_pos_column! test passed for incremental scan")
+            println("✅ column_names with pos_column test passed for incremental scan")
         finally
             RustyIceberg.free_stream!(inserts_stream)
             RustyIceberg.free_stream!(deletes_stream)
@@ -1025,12 +969,9 @@ end
         end
     end
 
-    @testset "select_columns! with POS_COLUMN constant" begin
+    @testset "column_names with POS_COLUMN constant" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Select columns including POS_COLUMN constant
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", RustyIceberg.POS_COLUMN])
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name", RustyIceberg.POS_COLUMN])
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -1060,7 +1001,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ select_columns! with POS_COLUMN constant test passed")
+            println("✅ column_names with POS_COLUMN constant test passed")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -1068,14 +1009,9 @@ end
         end
     end
 
-    @testset "with_file_column! and with_pos_column! combined" begin
+    @testset "file_column and pos_column combined" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Select columns and include both file and pos metadata
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
-        RustyIceberg.with_file_column!(scan)
-        RustyIceberg.with_pos_column!(scan)
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey", "c_name"], file_column=true, pos_column=true)
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -1108,7 +1044,7 @@ end
                 RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_file_column! and with_pos_column! combined test passed")
+            println("✅ file_column and pos_column combined test passed")
         finally
             RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
@@ -1116,20 +1052,17 @@ end
         end
     end
 
-    @testset "with_snapshot_id! - Full Scan via Builder Method" begin
+    @testset "snapshot_id - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
 
         # Use the correct snapshot ID for the customer table
         customer_snapshot_id = Int64(3441867730092225551)
 
-        scan = RustyIceberg.new_scan(table)
-
-        # Set snapshot ID explicitly using builder method
-        RustyIceberg.with_snapshot_id!(scan, customer_snapshot_id)
+        scan = RustyIceberg.new_scan(table;
+            snapshot_id=customer_snapshot_id,
+            column_names=["c_custkey", "c_name"],
+        )
         println("ℹ️  Set snapshot ID to: $customer_snapshot_id")
-
-        # Also select a column to verify scan works correctly
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -1161,7 +1094,7 @@ end
             @test !isempty(custkey_values)
             @test all(custkey_values .> 0)  # Customer keys are positive
 
-            println("✅ with_snapshot_id! builder method test passed for full scan")
+            println("✅ snapshot_id test passed for full scan")
             println("   - Total batches: $batch_count")
             println("   - Total rows: $total_rows")
             println("   - Sample customer keys: $(first(custkey_values, 5))")
@@ -1172,19 +1105,18 @@ end
         end
     end
 
-    @testset "Combined with_snapshot_id! and other builder methods" begin
+    @testset "Combined snapshot_id and other parameters" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
 
         # Use the correct snapshot ID for the customer table
         customer_snapshot_id = Int64(3441867730092225551)
 
-        # Combine multiple builder methods including snapshot_id
-        RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", "c_address"])
-        RustyIceberg.with_snapshot_id!(scan, customer_snapshot_id)
-        RustyIceberg.with_batch_size!(scan, UInt(5))
-        RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(2))
-
+        scan = RustyIceberg.new_scan(table;
+            column_names=["c_custkey", "c_name", "c_address"],
+            snapshot_id=customer_snapshot_id,
+            batch_size=Int64(5),
+            data_file_concurrency_limit=Int64(2),
+        )
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -1213,7 +1145,7 @@ end
             @test !isempty(custkey_values)
             @test all(custkey_values .> 0)  # Valid customer keys
 
-            println("✅ Combined with_snapshot_id! and other builder methods test passed")
+            println("✅ Combined snapshot_id and other parameters test passed")
             println("   - Total batches: $batch_count")
             println("   - All batches respect size limit (≤5)")
         finally
@@ -1231,7 +1163,6 @@ end
     @testset "E2E - Nations Table" begin
         table = RustyIceberg.table_open(nations_path)
         scan = RustyIceberg.new_scan(table)
-        RustyIceberg.build!(scan)
 
         reader = RustyIceberg.create_reader(scan)
         @test reader isa RustyIceberg.ArrowReaderContext
@@ -1304,7 +1235,6 @@ end
 
         # Split scan
         scan_split = RustyIceberg.new_scan(table)
-        RustyIceberg.build!(scan_split)
         reader = RustyIceberg.create_reader(scan_split)
         file_stream = RustyIceberg.plan_files(scan_split)
         split_rows = Tuple[]
@@ -1345,9 +1275,7 @@ end
 
     @testset "Column selection" begin
         table = RustyIceberg.table_open(nations_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.select_columns!(scan, ["n_nationkey", "n_name"])
-        RustyIceberg.build!(scan)
+        scan = RustyIceberg.new_scan(table; column_names=["n_nationkey", "n_name"])
 
         reader = RustyIceberg.create_reader(scan)
         file_stream = RustyIceberg.plan_files(scan)
@@ -1384,7 +1312,6 @@ end
     @testset "record_count" begin
         table = RustyIceberg.table_open(nations_path)
         scan = RustyIceberg.new_scan(table)
-        RustyIceberg.build!(scan)
 
         reader = RustyIceberg.create_reader(scan)
         file_stream = RustyIceberg.plan_files(scan)
@@ -1427,7 +1354,6 @@ end
     @testset "free_file discards task without reading" begin
         table = RustyIceberg.table_open(nations_path)
         scan = RustyIceberg.new_scan(table)
-        RustyIceberg.build!(scan)
 
         reader = RustyIceberg.create_reader(scan)
         file_stream = RustyIceberg.plan_files(scan)
@@ -1448,9 +1374,7 @@ end
 
     @testset "create_reader with reader_concurrency override" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.select_columns!(scan, ["c_custkey"])
-        RustyIceberg.build!(scan)
+        scan = RustyIceberg.new_scan(table; column_names=["c_custkey"])
 
         reader = RustyIceberg.create_reader(scan; reader_concurrency=UInt(4))
         @test reader isa RustyIceberg.ArrowReaderContext
@@ -1488,9 +1412,7 @@ end
 
     @testset "Multi-file with batch_size" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(100))
-        RustyIceberg.build!(scan)
+        scan = RustyIceberg.new_scan(table; batch_size=Int64(100))
 
         reader = RustyIceberg.create_reader(scan)
         file_stream = RustyIceberg.plan_files(scan)
@@ -1537,7 +1459,6 @@ end
     @testset "E2E append + delete streams" begin
         table = RustyIceberg.table_open(incremental_path)
         scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-        RustyIceberg.build!(scan)
 
         reader = RustyIceberg.create_reader(scan)
         @test reader isa RustyIceberg.ArrowReaderContext
@@ -1620,7 +1541,6 @@ end
     @testset "record_count" begin
         table = RustyIceberg.table_open(incremental_path)
         scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-        RustyIceberg.build!(scan)
 
         reader = RustyIceberg.create_reader(scan)
         append_stream, delete_stream = RustyIceberg.plan_files(scan)
@@ -1665,7 +1585,6 @@ end
     @testset "free_file discards without reading" begin
         table = RustyIceberg.table_open(incremental_path)
         scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-        RustyIceberg.build!(scan)
 
         reader = RustyIceberg.create_reader(scan)
         append_stream, delete_stream = RustyIceberg.plan_files(scan)
@@ -1722,7 +1641,6 @@ end
 
         # Split scan
         scan_sp = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-        RustyIceberg.build!(scan_sp)
         reader = RustyIceberg.create_reader(scan_sp)
         append_stream, delete_stream = RustyIceberg.plan_files(scan_sp)
         sp_inserts = Int64[]

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -55,7 +55,7 @@ using Arrow
                 println("   → Columns: $(names(df))")
             end
 
-            RustyIceberg.free_batch(batch_ptr)
+            RustyIceberg.free_batch!(batch_ptr)
 
             # Stop after a few batches for testing to avoid long test times
             if batch_count >= 5
@@ -73,9 +73,9 @@ using Arrow
         println("   - Total Arrow tables: $(length(arrow_tables))")
     finally
         # Clean up
-        RustyIceberg.free_stream(stream)
+        RustyIceberg.free_stream!(stream)
         RustyIceberg.free_scan!(scan)
-        RustyIceberg.free_table(table)
+        RustyIceberg.free_table!(table)
         println("✅ Resources cleaned up")
     end
 
@@ -104,7 +104,7 @@ using Arrow
                     @test arrow_table isa Arrow.Table
                     @test length(arrow_table) <= 8
                     push!(selected_arrow_tables, arrow_table)
-                    RustyIceberg.free_batch(batch_ptr)
+                    RustyIceberg.free_batch!(batch_ptr)
                     batch_ptr = RustyIceberg.next_batch(stream2)
                 end
 
@@ -117,9 +117,9 @@ using Arrow
                 println("   - Selected columns: $(names(selected_df))")
             finally
                 # Clean up
-                RustyIceberg.free_stream(stream2)
+                RustyIceberg.free_stream!(stream2)
                 RustyIceberg.free_scan!(scan2)
-                RustyIceberg.free_table(table2)
+                RustyIceberg.free_table!(table2)
             end
         end
     end
@@ -166,7 +166,7 @@ end
                 push!(rows, Tuple(row))
             end
 
-            RustyIceberg.free_batch(batch_ptr)
+            RustyIceberg.free_batch!(batch_ptr)
             batch_ptr = C_NULL
         end
 
@@ -201,11 +201,11 @@ end
         ]
     finally
         if batch_ptr != C_NULL
-            RustyIceberg.free_batch(batch_ptr)
+            RustyIceberg.free_batch!(batch_ptr)
         end
-        RustyIceberg.free_stream(stream)
+        RustyIceberg.free_stream!(stream)
         RustyIceberg.free_scan!(scan)
-        RustyIceberg.free_table(table)
+        RustyIceberg.free_table!(table)
     end
     println("✅ Nations table read and verified successfully")
 end
@@ -264,7 +264,7 @@ end
                 @test "n" in names(df)
                 append!(inserts_values, df.n)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
             end
 
             # Read from deletes stream
@@ -286,7 +286,7 @@ end
                     push!(deletes_values, (row.file_path, row.pos))
                 end
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
             end
 
             println("✅ Successfully read from incremental scan streams")
@@ -328,8 +328,8 @@ end
             println("✅ Inserts validated: n from 201-299 (excluding 250), total $(length(inserts_values)) rows")
         finally
             # Clean up
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
             println("✅ Resources cleaned up")
         end
@@ -355,13 +355,13 @@ end
                 @test names(df) == ["n"]
                 @test !isempty(df)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream2)
             end
             println("✅ Incremental scan column selection test successful")
         finally
-            RustyIceberg.free_stream(inserts_stream2)
-            RustyIceberg.free_stream(deletes_stream2)
+            RustyIceberg.free_stream!(inserts_stream2)
+            RustyIceberg.free_stream!(deletes_stream2)
             RustyIceberg.free_scan!(scan2)
         end
     end
@@ -405,7 +405,7 @@ end
                     push!(deletes_values, (row.file_path, row.pos))
                 end
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
             end
 
             # Verify we have no delete records (since this is a full history scan)
@@ -433,7 +433,7 @@ end
                 @test "n" in names(df)
                 append!(inserts_values, df.n)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
             end
 
             # When scanning full history (nothing to nothing), we should get rows from all transactions
@@ -454,14 +454,14 @@ end
             println("   - Total inserts batches: $inserts_batches")
             println("   - Total inserts rows: $(length(inserts_values))")
         finally
-            RustyIceberg.free_stream(inserts_stream3)
-            RustyIceberg.free_stream(deletes_stream3)
+            RustyIceberg.free_stream!(inserts_stream3)
+            RustyIceberg.free_stream!(deletes_stream3)
             RustyIceberg.free_scan!(scan3)
         end
     end
 
     # Clean up table
-    RustyIceberg.free_table(table)
+    RustyIceberg.free_table!(table)
     println("✅ Incremental scan test completed successfully!")
 end
 
@@ -491,14 +491,14 @@ end
                 @test names(df) == ["c_custkey", "c_name"]
                 @test !isempty(df)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ select_columns! test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -519,15 +519,15 @@ end
                 @test names(df) == ["n"]
                 @test !isempty(df)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
             println("✅ select_columns! test passed for incremental scan")
         finally
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -548,14 +548,14 @@ end
                 # Batch size should be respected (at most 10 rows)
                 @test length(arrow_table) <= 10
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ with_batch_size! test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -574,15 +574,15 @@ end
 
                 @test length(arrow_table) <= 10
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
             println("✅ with_batch_size! test passed for incremental scan")
         finally
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -597,14 +597,14 @@ end
         try
             batch_ptr = RustyIceberg.next_batch(stream)
             while batch_ptr != C_NULL
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ with_data_file_concurrency_limit! test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -618,15 +618,15 @@ end
         try
             batch_ptr = RustyIceberg.next_batch(inserts_stream)
             while batch_ptr != C_NULL
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
             println("✅ with_data_file_concurrency_limit! test passed for incremental scan")
         finally
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -641,14 +641,14 @@ end
         try
             batch_ptr = RustyIceberg.next_batch(stream)
             while batch_ptr != C_NULL
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ with_manifest_entry_concurrency_limit! test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -663,14 +663,14 @@ end
         try
             batch_ptr = RustyIceberg.next_batch(stream)
             while batch_ptr != C_NULL
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ with_manifest_file_concurrency_limit! test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -684,15 +684,15 @@ end
         try
             batch_ptr = RustyIceberg.next_batch(inserts_stream)
             while batch_ptr != C_NULL
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
             println("✅ with_manifest_entry_concurrency_limit! test passed for incremental scan")
         finally
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -721,14 +721,14 @@ end
                 @test length(arrow_table) <= 5
                 @test !isempty(df)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ Combined builder methods test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -757,15 +757,15 @@ end
                 @test length(arrow_table) <= 5
                 @test !isempty(df)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
             println("✅ Combined builder methods test passed for incremental scan")
         finally
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -800,14 +800,14 @@ end
                 @test all(startswith.(file_paths, "s3://warehouse/tpch.sf01/customer/data/data_customer-"))
                 @test eltype(file_paths) <: AbstractString
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ select_columns! with with_file_column! test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -839,15 +839,15 @@ end
                 @test all(startswith.(file_paths, "s3://warehouse/incremental/"))
                 @test eltype(file_paths) <: AbstractString
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
             println("✅ select_columns! with with_file_column! test passed for incremental scan")
         finally
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -880,14 +880,14 @@ end
                 @test all(startswith.(file_paths, "s3://warehouse/tpch.sf01/customer/data/data_customer-"))
                 @test eltype(file_paths) <: AbstractString
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ select_columns! with FILE_COLUMN constant test passed")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -925,14 +925,14 @@ end
                 sorted_pos = sort(positions)
                 @test all(diff(sorted_pos) .== 1)  # Sequential with no gaps
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ select_columns! with with_pos_column! test passed for full scan")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -969,7 +969,7 @@ end
                 append!(all_positions, positions)
                 append!(all_n_values, df.n)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
 
@@ -1018,10 +1018,10 @@ end
 
             println("✅ select_columns! with with_pos_column! test passed for incremental scan")
         finally
-            RustyIceberg.free_stream(inserts_stream)
-            RustyIceberg.free_stream(deletes_stream)
+            RustyIceberg.free_stream!(inserts_stream)
+            RustyIceberg.free_stream!(deletes_stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1057,14 +1057,14 @@ end
                 sorted_pos = sort(positions)
                 @test all(diff(sorted_pos) .== 1)  # Sequential with no gaps
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ select_columns! with POS_COLUMN constant test passed")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1105,14 +1105,14 @@ end
                 sorted_pos = sort(positions)
                 @test all(diff(sorted_pos) .== 1)  # Sequential with no gaps
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
             println("✅ with_file_column! and with_pos_column! combined test passed")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1151,7 +1151,7 @@ end
                 batch_count += 1
                 total_rows += nrow(df)
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
 
@@ -1166,9 +1166,9 @@ end
             println("   - Total rows: $total_rows")
             println("   - Sample customer keys: $(first(custkey_values, 5))")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1205,7 +1205,7 @@ end
                 append!(custkey_values, df.c_custkey)
                 batch_count += 1
 
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
 
@@ -1217,9 +1217,9 @@ end
             println("   - Total batches: $batch_count")
             println("   - All batches respect size limit (≤5)")
         finally
-            RustyIceberg.free_stream(stream)
+            RustyIceberg.free_stream!(stream)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 end
@@ -1243,10 +1243,10 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file(file_stream)
+                fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
                 task_count += 1
-                stream = RustyIceberg.read_file_scan(reader, fs)
+                stream = RustyIceberg.read_file_scan!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1256,11 +1256,11 @@ end
                         for row in eachrow(df)
                             push!(all_rows, Tuple(row))
                         end
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
 
@@ -1271,10 +1271,10 @@ end
             @test all_rows[end] == (24, "UNITED STATES", 1, "ly ironic requests along the slyly bold ideas hang after the blithely special notornis; blithely even accounts")
             println("✅ Split-scan E2E test passed ($task_count tasks, $(length(all_rows)) rows)")
         finally
-            RustyIceberg.free_file_stream(file_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(file_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1294,11 +1294,11 @@ end
                 for row in eachrow(df)
                     push!(full_rows, Tuple(row))
                 end
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream_full)
             end
         finally
-            RustyIceberg.free_stream(stream_full)
+            RustyIceberg.free_stream!(stream_full)
             RustyIceberg.free_scan!(scan_full)
         end
 
@@ -1310,9 +1310,9 @@ end
         split_rows = Tuple[]
         try
             while true
-                fs = RustyIceberg.next_file(file_stream)
+                fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
-                stream = RustyIceberg.read_file_scan(reader, fs)
+                stream = RustyIceberg.read_file_scan!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1322,20 +1322,20 @@ end
                         for row in eachrow(df)
                             push!(split_rows, Tuple(row))
                         end
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
         finally
-            RustyIceberg.free_file_stream(file_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(file_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan_split)
         end
 
-        RustyIceberg.free_table(table)
+        RustyIceberg.free_table!(table)
 
         sort!(full_rows, by = x -> x[1])
         sort!(split_rows, by = x -> x[1])
@@ -1354,9 +1354,9 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file(file_stream)
+                fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
-                stream = RustyIceberg.read_file_scan(reader, fs)
+                stream = RustyIceberg.read_file_scan!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1365,19 +1365,19 @@ end
                         df = DataFrame(arrow_table)
                         @test names(df) == ["n_nationkey", "n_name"]
                         @test !isempty(df)
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
             println("✅ Split-scan column selection test passed")
         finally
-            RustyIceberg.free_file_stream(file_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(file_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1392,7 +1392,7 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file(file_stream)
+                fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
 
                 count = RustyIceberg.record_count(fs)
@@ -1401,15 +1401,15 @@ end
                     total_from_counts += count
                 end
 
-                stream = RustyIceberg.read_file_scan(reader, fs)
+                stream = RustyIceberg.read_file_scan!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
             if total_from_counts > 0
@@ -1417,10 +1417,10 @@ end
             end
             println("✅ record_count test passed (total=$total_from_counts)")
         finally
-            RustyIceberg.free_file_stream(file_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(file_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1433,16 +1433,16 @@ end
         file_stream = RustyIceberg.plan_files(scan)
 
         try
-            fs = RustyIceberg.next_file(file_stream)
+            fs = RustyIceberg.next_file!(file_stream)
             if fs !== nothing
-                @test_nowarn RustyIceberg.free_file(fs)
+                @test_nowarn RustyIceberg.free_file!(fs)
             end
             println("✅ free_file (discard without reading) test passed")
         finally
-            RustyIceberg.free_file_stream(file_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(file_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1460,29 +1460,29 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file(file_stream)
+                fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
-                stream = RustyIceberg.read_file_scan(reader, fs)
+                stream = RustyIceberg.read_file_scan!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
                         batch = unsafe_load(batch_ptr)
                         arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
                         total_rows += length(arrow_table)
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
             @test total_rows > 0
             println("✅ create_reader with reader_concurrency=4 test passed ($total_rows rows)")
         finally
-            RustyIceberg.free_file_stream(file_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(file_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1499,10 +1499,10 @@ end
 
         try
             while true
-                fs = RustyIceberg.next_file(file_stream)
+                fs = RustyIceberg.next_file!(file_stream)
                 fs === nothing && break
                 task_count += 1
-                stream = RustyIceberg.read_file_scan(reader, fs)
+                stream = RustyIceberg.read_file_scan!(reader, fs)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1510,21 +1510,21 @@ end
                         arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
                         @test length(arrow_table) <= 100
                         total_rows += length(arrow_table)
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
             @test task_count >= 1
             @test total_rows > 0
             println("✅ Split-scan multi-file test passed ($task_count tasks, $total_rows rows)")
         finally
-            RustyIceberg.free_file_stream(file_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(file_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 end
@@ -1550,10 +1550,10 @@ end
 
         try
             while true
-                at = RustyIceberg.next_file(append_stream)
+                at = RustyIceberg.next_file!(append_stream)
                 at === nothing && break
                 append_task_count += 1
-                stream = RustyIceberg.read_file(reader, at)
+                stream = RustyIceberg.read_file!(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1562,11 +1562,11 @@ end
                         df = DataFrame(arrow_table)
                         @test "n" in names(df)
                         append!(inserts_values, df.n)
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
 
@@ -1574,10 +1574,10 @@ end
             delete_task_count = 0
 
             while true
-                dt = RustyIceberg.next_file(delete_stream)
+                dt = RustyIceberg.next_file!(delete_stream)
                 dt === nothing && break
                 delete_task_count += 1
-                stream = RustyIceberg.read_file(reader, dt)
+                stream = RustyIceberg.read_file!(reader, dt)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1588,11 +1588,11 @@ end
                         for row in eachrow(df)
                             push!(deletes_values, (row.file_path, row.pos))
                         end
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
 
@@ -1609,11 +1609,11 @@ end
 
             println("✅ Incremental split-scan E2E test passed ($append_task_count append tasks, $(length(inserts_values)) inserts, $(length(deletes_values)) deletes)")
         finally
-            RustyIceberg.free_file_stream(append_stream)
-            RustyIceberg.free_file_stream(delete_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(append_stream)
+            RustyIceberg.free_file_stream!(delete_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1627,38 +1627,38 @@ end
 
         try
             while true
-                at = RustyIceberg.next_file(append_stream)
+                at = RustyIceberg.next_file!(append_stream)
                 at === nothing && break
                 count = RustyIceberg.record_count(at)
                 @test count === nothing || count >= 0
-                stream = RustyIceberg.read_file(reader, at)
+                stream = RustyIceberg.read_file!(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
             total_delete_positions = 0
             while true
-                dt = RustyIceberg.next_file(delete_stream)
+                dt = RustyIceberg.next_file!(delete_stream)
                 dt === nothing && break
                 n = RustyIceberg.record_count(dt)
                 @test n >= 0
                 total_delete_positions += n
-                RustyIceberg.free_file(dt)
+                RustyIceberg.free_file!(dt)
             end
             @test total_delete_positions == 1
             println("✅ record_count test passed (delete positions=$total_delete_positions)")
         finally
-            RustyIceberg.free_file_stream(append_stream)
-            RustyIceberg.free_file_stream(delete_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(append_stream)
+            RustyIceberg.free_file_stream!(delete_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1671,17 +1671,17 @@ end
         append_stream, delete_stream = RustyIceberg.plan_files(scan)
 
         try
-            at = RustyIceberg.next_file(append_stream)
+            at = RustyIceberg.next_file!(append_stream)
             if at !== nothing
-                @test_nowarn RustyIceberg.free_file(at)
+                @test_nowarn RustyIceberg.free_file!(at)
             end
             println("✅ free_file (discard) test passed")
         finally
-            RustyIceberg.free_file_stream(append_stream)
-            RustyIceberg.free_file_stream(delete_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(append_stream)
+            RustyIceberg.free_file_stream!(delete_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan)
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
     end
 
@@ -1700,7 +1700,7 @@ end
                 arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
                 df = DataFrame(arrow_table)
                 append!(ns_inserts, df.n)
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_ns)
             end
             batch_ptr = RustyIceberg.next_batch(deletes_ns)
@@ -1711,12 +1711,12 @@ end
                 for row in eachrow(df)
                     push!(ns_deletes, (row.file_path, row.pos))
                 end
-                RustyIceberg.free_batch(batch_ptr)
+                RustyIceberg.free_batch!(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(deletes_ns)
             end
         finally
-            RustyIceberg.free_stream(inserts_ns)
-            RustyIceberg.free_stream(deletes_ns)
+            RustyIceberg.free_stream!(inserts_ns)
+            RustyIceberg.free_stream!(deletes_ns)
             RustyIceberg.free_scan!(scan_ns)
         end
 
@@ -1729,9 +1729,9 @@ end
         sp_deletes = Tuple{String, Int64}[]
         try
             while true
-                at = RustyIceberg.next_file(append_stream)
+                at = RustyIceberg.next_file!(append_stream)
                 at === nothing && break
-                stream = RustyIceberg.read_file(reader, at)
+                stream = RustyIceberg.read_file!(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1739,17 +1739,17 @@ end
                         arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
                         df = DataFrame(arrow_table)
                         append!(sp_inserts, df.n)
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
             while true
-                dt = RustyIceberg.next_file(delete_stream)
+                dt = RustyIceberg.next_file!(delete_stream)
                 dt === nothing && break
-                stream = RustyIceberg.read_file(reader, dt)
+                stream = RustyIceberg.read_file!(reader, dt)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1759,21 +1759,21 @@ end
                         for row in eachrow(df)
                             push!(sp_deletes, (row.file_path, row.pos))
                         end
-                        RustyIceberg.free_batch(batch_ptr)
+                        RustyIceberg.free_batch!(batch_ptr)
                         batch_ptr = RustyIceberg.next_batch(stream)
                     end
                 finally
-                    RustyIceberg.free_stream(stream)
+                    RustyIceberg.free_stream!(stream)
                 end
             end
         finally
-            RustyIceberg.free_file_stream(append_stream)
-            RustyIceberg.free_file_stream(delete_stream)
-            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_file_stream!(append_stream)
+            RustyIceberg.free_file_stream!(delete_stream)
+            RustyIceberg.free_reader!(reader)
             RustyIceberg.free_scan!(scan_sp)
         end
 
-        RustyIceberg.free_table(table)
+        RustyIceberg.free_table!(table)
 
         sort!(ns_inserts); sort!(sp_inserts)
         sort!(ns_deletes); sort!(sp_deletes)

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -330,7 +330,7 @@ end
             # Clean up
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             println("✅ Resources cleaned up")
         end
     end
@@ -362,7 +362,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream2)
             RustyIceberg.free_stream(deletes_stream2)
-            RustyIceberg.free_incremental_scan!(scan2)
+            RustyIceberg.free_scan!(scan2)
         end
     end
 
@@ -456,7 +456,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream3)
             RustyIceberg.free_stream(deletes_stream3)
-            RustyIceberg.free_incremental_scan!(scan3)
+            RustyIceberg.free_scan!(scan3)
         end
     end
 
@@ -526,7 +526,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -581,7 +581,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -625,7 +625,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -691,7 +691,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -764,7 +764,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -846,7 +846,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -1020,7 +1020,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -1271,7 +1271,7 @@ end
             @test all_rows[end] == (24, "UNITED STATES", 1, "ly ironic requests along the slyly bold ideas hang after the blithely special notornis; blithely even accounts")
             println("✅ Split-scan E2E test passed ($task_count tasks, $(length(all_rows)) rows)")
         finally
-            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_file_stream(file_stream)
             RustyIceberg.free_reader(reader)
             RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
@@ -1330,7 +1330,7 @@ end
                 end
             end
         finally
-            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_file_stream(file_stream)
             RustyIceberg.free_reader(reader)
             RustyIceberg.free_scan!(scan_split)
         end
@@ -1374,14 +1374,14 @@ end
             end
             println("✅ Split-scan column selection test passed")
         finally
-            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_file_stream(file_stream)
             RustyIceberg.free_reader(reader)
             RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
 
-    @testset "file_scan_record_count" begin
+    @testset "record_count" begin
         table = RustyIceberg.table_open(nations_path)
         scan = RustyIceberg.new_scan(table)
         RustyIceberg.build!(scan)
@@ -1395,7 +1395,7 @@ end
                 fs = RustyIceberg.next_file_scan(file_stream)
                 fs === nothing && break
 
-                count = RustyIceberg.file_scan_record_count(fs)
+                count = RustyIceberg.record_count(fs)
                 @test count === nothing || count >= 0
                 if count !== nothing
                     total_from_counts += count
@@ -1415,16 +1415,16 @@ end
             if total_from_counts > 0
                 @test total_from_counts == 25
             end
-            println("✅ file_scan_record_count test passed (total=$total_from_counts)")
+            println("✅ record_count test passed (total=$total_from_counts)")
         finally
-            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_file_stream(file_stream)
             RustyIceberg.free_reader(reader)
             RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
 
-    @testset "free_file_scan discards task without reading" begin
+    @testset "free_file discards task without reading" begin
         table = RustyIceberg.table_open(nations_path)
         scan = RustyIceberg.new_scan(table)
         RustyIceberg.build!(scan)
@@ -1435,11 +1435,11 @@ end
         try
             fs = RustyIceberg.next_file_scan(file_stream)
             if fs !== nothing
-                @test_nowarn RustyIceberg.free_file_scan(fs)
+                @test_nowarn RustyIceberg.free_file(fs)
             end
-            println("✅ free_file_scan (discard without reading) test passed")
+            println("✅ free_file (discard without reading) test passed")
         finally
-            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_file_stream(file_stream)
             RustyIceberg.free_reader(reader)
             RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
@@ -1479,7 +1479,7 @@ end
             @test total_rows > 0
             println("✅ create_reader with reader_concurrency=4 test passed ($total_rows rows)")
         finally
-            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_file_stream(file_stream)
             RustyIceberg.free_reader(reader)
             RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
@@ -1521,7 +1521,7 @@ end
             @test total_rows > 0
             println("✅ Split-scan multi-file test passed ($task_count tasks, $total_rows rows)")
         finally
-            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_file_stream(file_stream)
             RustyIceberg.free_reader(reader)
             RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
@@ -1542,18 +1542,18 @@ end
         reader = RustyIceberg.create_reader(scan)
         @test reader isa RustyIceberg.ArrowReaderContext
         append_stream, delete_stream = RustyIceberg.plan_files(scan)
-        @test append_stream isa RustyIceberg.IncrementalAppendTaskStream
-        @test delete_stream isa RustyIceberg.IncrementalPosDeleteTaskStream
+        @test append_stream isa RustyIceberg.IncrementalAppendFileStream
+        @test delete_stream isa RustyIceberg.IncrementalPosDeleteFileStream
 
         inserts_values = Int64[]
         append_task_count = 0
 
         try
             while true
-                at = RustyIceberg.next_append_task(append_stream)
+                at = RustyIceberg.next_append_file(append_stream)
                 at === nothing && break
                 append_task_count += 1
-                stream = RustyIceberg.read_append_task(reader, at)
+                stream = RustyIceberg.read_append_file(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1574,10 +1574,10 @@ end
             delete_task_count = 0
 
             while true
-                dt = RustyIceberg.next_pos_delete_task(delete_stream)
+                dt = RustyIceberg.next_pos_delete_file(delete_stream)
                 dt === nothing && break
                 delete_task_count += 1
-                stream = RustyIceberg.read_pos_delete_task(reader, dt)
+                stream = RustyIceberg.read_pos_delete_file(reader, dt)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1609,15 +1609,15 @@ end
 
             println("✅ Incremental split-scan E2E test passed ($append_task_count append tasks, $(length(inserts_values)) inserts, $(length(deletes_values)) deletes)")
         finally
-            RustyIceberg.free_incremental_append_task_stream(append_stream)
-            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_file_stream(append_stream)
+            RustyIceberg.free_file_stream(delete_stream)
             RustyIceberg.free_reader(reader)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
 
-    @testset "append_task_record_count" begin
+    @testset "record_count" begin
         table = RustyIceberg.table_open(incremental_path)
         scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
         RustyIceberg.build!(scan)
@@ -1627,11 +1627,11 @@ end
 
         try
             while true
-                at = RustyIceberg.next_append_task(append_stream)
+                at = RustyIceberg.next_append_file(append_stream)
                 at === nothing && break
-                count = RustyIceberg.append_task_record_count(at)
+                count = RustyIceberg.record_count(at)
                 @test count === nothing || count >= 0
-                stream = RustyIceberg.read_append_task(reader, at)
+                stream = RustyIceberg.read_append_file(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1643,21 +1643,21 @@ end
                 end
             end
             while true
-                dt = RustyIceberg.next_pos_delete_task(delete_stream)
+                dt = RustyIceberg.next_pos_delete_file(delete_stream)
                 dt === nothing && break
-                RustyIceberg.free_incremental_pos_delete_task(dt)
+                RustyIceberg.free_file(dt)
             end
-            println("✅ append_task_record_count test passed")
+            println("✅ record_count test passed")
         finally
-            RustyIceberg.free_incremental_append_task_stream(append_stream)
-            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_file_stream(append_stream)
+            RustyIceberg.free_file_stream(delete_stream)
             RustyIceberg.free_reader(reader)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
 
-    @testset "free_incremental_append_task discards without reading" begin
+    @testset "free_file discards without reading" begin
         table = RustyIceberg.table_open(incremental_path)
         scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
         RustyIceberg.build!(scan)
@@ -1666,16 +1666,16 @@ end
         append_stream, delete_stream = RustyIceberg.plan_files(scan)
 
         try
-            at = RustyIceberg.next_append_task(append_stream)
+            at = RustyIceberg.next_append_file(append_stream)
             if at !== nothing
-                @test_nowarn RustyIceberg.free_incremental_append_task(at)
+                @test_nowarn RustyIceberg.free_file(at)
             end
-            println("✅ free_incremental_append_task (discard) test passed")
+            println("✅ free_file (discard) test passed")
         finally
-            RustyIceberg.free_incremental_append_task_stream(append_stream)
-            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_file_stream(append_stream)
+            RustyIceberg.free_file_stream(delete_stream)
             RustyIceberg.free_reader(reader)
-            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
     end
@@ -1712,7 +1712,7 @@ end
         finally
             RustyIceberg.free_stream(inserts_ns)
             RustyIceberg.free_stream(deletes_ns)
-            RustyIceberg.free_incremental_scan!(scan_ns)
+            RustyIceberg.free_scan!(scan_ns)
         end
 
         # Split scan
@@ -1724,9 +1724,9 @@ end
         sp_deletes = Tuple{String, Int64}[]
         try
             while true
-                at = RustyIceberg.next_append_task(append_stream)
+                at = RustyIceberg.next_append_file(append_stream)
                 at === nothing && break
-                stream = RustyIceberg.read_append_task(reader, at)
+                stream = RustyIceberg.read_append_file(reader, at)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1742,9 +1742,9 @@ end
                 end
             end
             while true
-                dt = RustyIceberg.next_pos_delete_task(delete_stream)
+                dt = RustyIceberg.next_pos_delete_file(delete_stream)
                 dt === nothing && break
-                stream = RustyIceberg.read_pos_delete_task(reader, dt)
+                stream = RustyIceberg.read_pos_delete_file(reader, dt)
                 try
                     batch_ptr = RustyIceberg.next_batch(stream)
                     while batch_ptr != C_NULL
@@ -1762,10 +1762,10 @@ end
                 end
             end
         finally
-            RustyIceberg.free_incremental_append_task_stream(append_stream)
-            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_file_stream(append_stream)
+            RustyIceberg.free_file_stream(delete_stream)
             RustyIceberg.free_reader(reader)
-            RustyIceberg.free_incremental_scan!(scan_sp)
+            RustyIceberg.free_scan!(scan_sp)
         end
 
         RustyIceberg.free_table(table)

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -1528,3 +1528,252 @@ end
         end
     end
 end
+
+@testset "Split-Scan API - Incremental" begin
+    incremental_path = "s3://warehouse/incremental/test1/metadata/00003-359e8bb8-1e5d-46d2-bcde-fdaeaa41114f.metadata.json"
+    from_snapshot_id = Int64(6540713100348352610)
+    to_snapshot_id   = Int64(6832180054960511692)
+
+    @testset "E2E append + delete streams" begin
+        table = RustyIceberg.table_open(incremental_path)
+        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        @test reader isa RustyIceberg.ArrowReaderContext
+        append_stream, delete_stream = RustyIceberg.plan_files(scan)
+        @test append_stream isa RustyIceberg.IncrementalAppendTaskStream
+        @test delete_stream isa RustyIceberg.IncrementalPosDeleteTaskStream
+
+        inserts_values = Int64[]
+        append_task_count = 0
+
+        try
+            while true
+                at = RustyIceberg.next_append_task(append_stream)
+                at === nothing && break
+                append_task_count += 1
+                stream = RustyIceberg.read_append_task(reader, at)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        df = DataFrame(arrow_table)
+                        @test "n" in names(df)
+                        append!(inserts_values, df.n)
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+
+            deletes_values = Tuple{String, Int64}[]
+            delete_task_count = 0
+
+            while true
+                dt = RustyIceberg.next_pos_delete_task(delete_stream)
+                dt === nothing && break
+                delete_task_count += 1
+                stream = RustyIceberg.read_pos_delete_task(reader, dt)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        df = DataFrame(arrow_table)
+                        @test names(df) == ["file_path", "pos"]
+                        for row in eachrow(df)
+                            push!(deletes_values, (row.file_path, row.pos))
+                        end
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+
+            @test append_task_count > 0
+            @test length(inserts_values) == 98
+            sort!(inserts_values)
+            @test minimum(inserts_values) == 201
+            @test maximum(inserts_values) == 299
+            @test 250 ∉ inserts_values
+
+            @test length(deletes_values) == 1
+            @test deletes_values[1][2] == 10
+            @test endswith(deletes_values[1][1], ".parquet")
+
+            println("✅ Incremental split-scan E2E test passed ($append_task_count append tasks, $(length(inserts_values)) inserts, $(length(deletes_values)) deletes)")
+        finally
+            RustyIceberg.free_incremental_append_task_stream(append_stream)
+            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "append_task_record_count" begin
+        table = RustyIceberg.table_open(incremental_path)
+        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        append_stream, delete_stream = RustyIceberg.plan_files(scan)
+
+        try
+            while true
+                at = RustyIceberg.next_append_task(append_stream)
+                at === nothing && break
+                count = RustyIceberg.append_task_record_count(at)
+                @test count === nothing || count >= 0
+                stream = RustyIceberg.read_append_task(reader, at)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+            while true
+                dt = RustyIceberg.next_pos_delete_task(delete_stream)
+                dt === nothing && break
+                RustyIceberg.free_incremental_pos_delete_task(dt)
+            end
+            println("✅ append_task_record_count test passed")
+        finally
+            RustyIceberg.free_incremental_append_task_stream(append_stream)
+            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "free_incremental_append_task discards without reading" begin
+        table = RustyIceberg.table_open(incremental_path)
+        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        append_stream, delete_stream = RustyIceberg.plan_files(scan)
+
+        try
+            at = RustyIceberg.next_append_task(append_stream)
+            if at !== nothing
+                @test_nowarn RustyIceberg.free_incremental_append_task(at)
+            end
+            println("✅ free_incremental_append_task (discard) test passed")
+        finally
+            RustyIceberg.free_incremental_append_task_stream(append_stream)
+            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_incremental_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "Data matches non-split incremental scan" begin
+        table = RustyIceberg.table_open(incremental_path)
+
+        # Non-split scan
+        scan_ns = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        inserts_ns, deletes_ns = RustyIceberg.scan!(scan_ns)
+        ns_inserts = Int64[]
+        ns_deletes = Tuple{String, Int64}[]
+        try
+            batch_ptr = RustyIceberg.next_batch(inserts_ns)
+            while batch_ptr != C_NULL
+                batch = unsafe_load(batch_ptr)
+                arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                df = DataFrame(arrow_table)
+                append!(ns_inserts, df.n)
+                RustyIceberg.free_batch(batch_ptr)
+                batch_ptr = RustyIceberg.next_batch(inserts_ns)
+            end
+            batch_ptr = RustyIceberg.next_batch(deletes_ns)
+            while batch_ptr != C_NULL
+                batch = unsafe_load(batch_ptr)
+                arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                df = DataFrame(arrow_table)
+                for row in eachrow(df)
+                    push!(ns_deletes, (row.file_path, row.pos))
+                end
+                RustyIceberg.free_batch(batch_ptr)
+                batch_ptr = RustyIceberg.next_batch(deletes_ns)
+            end
+        finally
+            RustyIceberg.free_stream(inserts_ns)
+            RustyIceberg.free_stream(deletes_ns)
+            RustyIceberg.free_incremental_scan!(scan_ns)
+        end
+
+        # Split scan
+        scan_sp = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        RustyIceberg.build!(scan_sp)
+        reader = RustyIceberg.create_reader(scan_sp)
+        append_stream, delete_stream = RustyIceberg.plan_files(scan_sp)
+        sp_inserts = Int64[]
+        sp_deletes = Tuple{String, Int64}[]
+        try
+            while true
+                at = RustyIceberg.next_append_task(append_stream)
+                at === nothing && break
+                stream = RustyIceberg.read_append_task(reader, at)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        df = DataFrame(arrow_table)
+                        append!(sp_inserts, df.n)
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+            while true
+                dt = RustyIceberg.next_pos_delete_task(delete_stream)
+                dt === nothing && break
+                stream = RustyIceberg.read_pos_delete_task(reader, dt)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        df = DataFrame(arrow_table)
+                        for row in eachrow(df)
+                            push!(sp_deletes, (row.file_path, row.pos))
+                        end
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+        finally
+            RustyIceberg.free_incremental_append_task_stream(append_stream)
+            RustyIceberg.free_incremental_pos_delete_task_stream(delete_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_incremental_scan!(scan_sp)
+        end
+
+        RustyIceberg.free_table(table)
+
+        sort!(ns_inserts); sort!(sp_inserts)
+        sort!(ns_deletes); sort!(sp_deletes)
+        @test sp_inserts == ns_inserts
+        @test sp_deletes == ns_deletes
+        println("✅ Incremental split-scan data matches non-split scan")
+    end
+end

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -1642,12 +1642,17 @@ end
                     RustyIceberg.free_stream(stream)
                 end
             end
+            total_delete_positions = 0
             while true
                 dt = RustyIceberg.next_pos_delete_file(delete_stream)
                 dt === nothing && break
+                n = RustyIceberg.record_count(dt)
+                @test n >= 0
+                total_delete_positions += n
                 RustyIceberg.free_file(dt)
             end
-            println("✅ record_count test passed")
+            @test total_delete_positions == 1
+            println("✅ record_count test passed (delete positions=$total_delete_positions)")
         finally
             RustyIceberg.free_file_stream(append_stream)
             RustyIceberg.free_file_stream(delete_stream)

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -1223,3 +1223,308 @@ end
         end
     end
 end
+
+@testset "Split-Scan API" begin
+    nations_path = "s3://warehouse/tpch.sf01/nation/metadata/00001-44f668fe-3688-49d5-851f-36e75d143321.metadata.json"
+    customer_path = "s3://warehouse/tpch.sf01/customer/metadata/00001-76f6e7e4-b34f-492f-b6a1-cc9f8c8f4975.metadata.json"
+
+    @testset "E2E - Nations Table" begin
+        table = RustyIceberg.table_open(nations_path)
+        scan = RustyIceberg.new_scan(table)
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        @test reader isa RustyIceberg.ArrowReaderContext
+        file_stream = RustyIceberg.plan_files(scan)
+        @test file_stream isa RustyIceberg.FileScanTaskStream
+
+        all_rows = Tuple[]
+        task_count = 0
+
+        try
+            while true
+                fs = RustyIceberg.next_file_scan(file_stream)
+                fs === nothing && break
+                task_count += 1
+                stream = RustyIceberg.read_file_scan(reader, fs)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        df = DataFrame(arrow_table)
+                        for row in eachrow(df)
+                            push!(all_rows, Tuple(row))
+                        end
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+
+            sort!(all_rows, by = x -> x[1])
+            @test task_count > 0
+            @test length(all_rows) == 25
+            @test all_rows[1] == (0, "ALGERIA", 0, "furiously regular requests. platelets affix furious")
+            @test all_rows[end] == (24, "UNITED STATES", 1, "ly ironic requests along the slyly bold ideas hang after the blithely special notornis; blithely even accounts")
+            println("✅ Split-scan E2E test passed ($task_count tasks, $(length(all_rows)) rows)")
+        finally
+            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "Data matches full scan" begin
+        table = RustyIceberg.table_open(nations_path)
+
+        # Full scan
+        scan_full = RustyIceberg.new_scan(table)
+        stream_full = RustyIceberg.scan!(scan_full)
+        full_rows = Tuple[]
+        try
+            batch_ptr = RustyIceberg.next_batch(stream_full)
+            while batch_ptr != C_NULL
+                batch = unsafe_load(batch_ptr)
+                arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                df = DataFrame(arrow_table)
+                for row in eachrow(df)
+                    push!(full_rows, Tuple(row))
+                end
+                RustyIceberg.free_batch(batch_ptr)
+                batch_ptr = RustyIceberg.next_batch(stream_full)
+            end
+        finally
+            RustyIceberg.free_stream(stream_full)
+            RustyIceberg.free_scan!(scan_full)
+        end
+
+        # Split scan
+        scan_split = RustyIceberg.new_scan(table)
+        RustyIceberg.build!(scan_split)
+        reader = RustyIceberg.create_reader(scan_split)
+        file_stream = RustyIceberg.plan_files(scan_split)
+        split_rows = Tuple[]
+        try
+            while true
+                fs = RustyIceberg.next_file_scan(file_stream)
+                fs === nothing && break
+                stream = RustyIceberg.read_file_scan(reader, fs)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        df = DataFrame(arrow_table)
+                        for row in eachrow(df)
+                            push!(split_rows, Tuple(row))
+                        end
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+        finally
+            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_scan!(scan_split)
+        end
+
+        RustyIceberg.free_table(table)
+
+        sort!(full_rows, by = x -> x[1])
+        sort!(split_rows, by = x -> x[1])
+        @test split_rows == full_rows
+        println("✅ Split-scan data matches full scan ($(length(split_rows)) rows)")
+    end
+
+    @testset "Column selection" begin
+        table = RustyIceberg.table_open(nations_path)
+        scan = RustyIceberg.new_scan(table)
+        RustyIceberg.select_columns!(scan, ["n_nationkey", "n_name"])
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        file_stream = RustyIceberg.plan_files(scan)
+
+        try
+            while true
+                fs = RustyIceberg.next_file_scan(file_stream)
+                fs === nothing && break
+                stream = RustyIceberg.read_file_scan(reader, fs)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        df = DataFrame(arrow_table)
+                        @test names(df) == ["n_nationkey", "n_name"]
+                        @test !isempty(df)
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+            println("✅ Split-scan column selection test passed")
+        finally
+            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "file_scan_record_count" begin
+        table = RustyIceberg.table_open(nations_path)
+        scan = RustyIceberg.new_scan(table)
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        file_stream = RustyIceberg.plan_files(scan)
+        total_from_counts = 0
+
+        try
+            while true
+                fs = RustyIceberg.next_file_scan(file_stream)
+                fs === nothing && break
+
+                count = RustyIceberg.file_scan_record_count(fs)
+                @test count === nothing || count >= 0
+                if count !== nothing
+                    total_from_counts += count
+                end
+
+                stream = RustyIceberg.read_file_scan(reader, fs)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+            if total_from_counts > 0
+                @test total_from_counts == 25
+            end
+            println("✅ file_scan_record_count test passed (total=$total_from_counts)")
+        finally
+            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "free_file_scan discards task without reading" begin
+        table = RustyIceberg.table_open(nations_path)
+        scan = RustyIceberg.new_scan(table)
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        file_stream = RustyIceberg.plan_files(scan)
+
+        try
+            fs = RustyIceberg.next_file_scan(file_stream)
+            if fs !== nothing
+                @test_nowarn RustyIceberg.free_file_scan(fs)
+            end
+            println("✅ free_file_scan (discard without reading) test passed")
+        finally
+            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "create_reader with reader_concurrency override" begin
+        table = RustyIceberg.table_open(customer_path)
+        scan = RustyIceberg.new_scan(table)
+        RustyIceberg.select_columns!(scan, ["c_custkey"])
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan; reader_concurrency=UInt(4))
+        @test reader isa RustyIceberg.ArrowReaderContext
+
+        file_stream = RustyIceberg.plan_files(scan)
+        total_rows = 0
+
+        try
+            while true
+                fs = RustyIceberg.next_file_scan(file_stream)
+                fs === nothing && break
+                stream = RustyIceberg.read_file_scan(reader, fs)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        total_rows += length(arrow_table)
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+            @test total_rows > 0
+            println("✅ create_reader with reader_concurrency=4 test passed ($total_rows rows)")
+        finally
+            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+
+    @testset "Multi-file with batch_size" begin
+        table = RustyIceberg.table_open(customer_path)
+        scan = RustyIceberg.new_scan(table)
+        RustyIceberg.with_batch_size!(scan, UInt(100))
+        RustyIceberg.build!(scan)
+
+        reader = RustyIceberg.create_reader(scan)
+        file_stream = RustyIceberg.plan_files(scan)
+        task_count = 0
+        total_rows = 0
+
+        try
+            while true
+                fs = RustyIceberg.next_file_scan(file_stream)
+                fs === nothing && break
+                task_count += 1
+                stream = RustyIceberg.read_file_scan(reader, fs)
+                try
+                    batch_ptr = RustyIceberg.next_batch(stream)
+                    while batch_ptr != C_NULL
+                        batch = unsafe_load(batch_ptr)
+                        arrow_table = Arrow.Table(unsafe_wrap(Array, batch.data, batch.length))
+                        @test length(arrow_table) <= 100
+                        total_rows += length(arrow_table)
+                        RustyIceberg.free_batch(batch_ptr)
+                        batch_ptr = RustyIceberg.next_batch(stream)
+                    end
+                finally
+                    RustyIceberg.free_stream(stream)
+                end
+            end
+            @test task_count >= 1
+            @test total_rows > 0
+            println("✅ Split-scan multi-file test passed ($task_count tasks, $total_rows rows)")
+        finally
+            RustyIceberg.free_file_scan_stream(file_stream)
+            RustyIceberg.free_reader(reader)
+            RustyIceberg.free_scan!(scan)
+            RustyIceberg.free_table(table)
+        end
+    end
+end

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -29,10 +29,10 @@ function read_table_data(table)
             arrow_data_copy = copy(arrow_data)
             push!(all_batches, Arrow.Table(arrow_data_copy))
         end
-        RustyIceberg.free_batch(batch_ptr)
+        RustyIceberg.free_batch!(batch_ptr)
         batch_ptr = RustyIceberg.next_batch(stream)
     end
-    RustyIceberg.free_stream(stream)
+    RustyIceberg.free_stream!(stream)
     RustyIceberg.free_scan!(scan)
 
     if isempty(all_batches)

--- a/test/transaction_tests.jl
+++ b/test/transaction_tests.jl
@@ -57,7 +57,7 @@ using Test
         println("✅ Empty transaction committed successfully")
 
         # Free the updated table
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
         println("✅ Updated table freed successfully")
 
     finally
@@ -67,7 +67,7 @@ using Test
             println("✅ Transaction cleaned up")
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         if catalog !== nothing
@@ -115,7 +115,7 @@ end
         tx = RustyIceberg.Transaction(table)
         updated_table = RustyIceberg.commit(tx, catalog)
         @test updated_table != C_NULL
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
         # Transaction is consumed after commit, second commit should fail
         error_caught = false
@@ -133,7 +133,7 @@ end
             RustyIceberg.free_transaction!(tx)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
         end
         if catalog !== nothing
             RustyIceberg.free_catalog!(catalog)

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -87,7 +87,7 @@ using Tables
         reloaded_table = RustyIceberg.load_table(catalog, test_namespace, table_name)
         @test reloaded_table != C_NULL
         println("✅ Table exists in catalog and can be loaded")
-        RustyIceberg.free_table(reloaded_table)
+        RustyIceberg.free_table!(reloaded_table)
 
         # Test 7: Verify data was written by scanning the table
         println("\nTest 7: Verifying written data...")
@@ -115,7 +115,7 @@ using Tables
         println("✅ Verified data content matches exactly")
 
         # Clean up updated table
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
     finally
         # Clean up all resources in reverse order
@@ -124,7 +124,7 @@ using Tables
             RustyIceberg.free_data_files!(data_files)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         # Drop table and namespace
@@ -252,7 +252,7 @@ end
         println("✅ Verified data content from both writers matches exactly")
 
         # Clean up
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
     finally
         # Clean up all resources in reverse order
@@ -264,7 +264,7 @@ end
             RustyIceberg.free_data_files!(data_files2)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         # Drop table and namespace
@@ -359,7 +359,7 @@ end
             println("✅ Writer cleaned up")
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         # Drop table and namespace
@@ -480,7 +480,7 @@ end
         println("✅ Verified Arrow.Table data content matches exactly")
 
         # Clean up updated table
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
     finally
         # Clean up all resources in reverse order
@@ -488,7 +488,7 @@ end
             RustyIceberg.free_data_files!(data_files)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         if table_name !== nothing && test_namespace !== nothing && catalog !== nothing
@@ -596,7 +596,7 @@ end
 
             # Free the updated table and reload with fresh credentials for reading
             println("\nReloading table with fresh vended credentials for reading...")
-            RustyIceberg.free_table(updated_table)
+            RustyIceberg.free_table!(updated_table)
             updated_table = RustyIceberg.load_table(catalog, test_namespace, table_name; load_credentials=true)
             @test updated_table != C_NULL
             println("✅ Table reloaded with fresh credentials")
@@ -625,7 +625,7 @@ end
         finally
             # Cleanup
             if table != C_NULL
-                RustyIceberg.free_table(table)
+                RustyIceberg.free_table!(table)
                 println("✅ Table freed")
             end
             if data_files !== nothing && data_files.ptr != C_NULL
@@ -765,7 +765,7 @@ end
         println("✅ Verified write_columns data content matches exactly")
 
         # Clean up updated table
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
     finally
         # Clean up all resources in reverse order
@@ -773,7 +773,7 @@ end
             RustyIceberg.free_data_files!(data_files)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         if table_name !== nothing && test_namespace !== nothing && catalog !== nothing
@@ -877,14 +877,14 @@ end
         @test !ismissing(sorted_values[5]) && sorted_values[5] ≈ 5.5
         println("✅ Verified null values are correctly written and read")
 
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
     finally
         if data_files !== nothing && data_files.ptr != C_NULL
             RustyIceberg.free_data_files!(data_files)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         if table_name !== nothing && test_namespace !== nothing && catalog !== nothing
@@ -1003,14 +1003,14 @@ end
         @test sorted_balances[3].value == Int128(1)
         println("✅ DECIMAL(38, 10) values verified")
 
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
     finally
         if data_files !== nothing && data_files.ptr != C_NULL
             RustyIceberg.free_data_files!(data_files)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         if table_name !== nothing && test_namespace !== nothing && catalog !== nothing
@@ -1100,14 +1100,14 @@ end
         @test !ismissing(sorted_prices[5]) && sorted_prices[5].value == Int128(50000)  # 500.00
         println("✅ Nullable decimal values verified (nulls at positions 2 and 4)")
 
-        RustyIceberg.free_table(updated_table)
+        RustyIceberg.free_table!(updated_table)
 
     finally
         if data_files !== nothing && data_files.ptr != C_NULL
             RustyIceberg.free_data_files!(data_files)
         end
         if table != C_NULL
-            RustyIceberg.free_table(table)
+            RustyIceberg.free_table!(table)
             println("✅ Table cleaned up")
         end
         if table_name !== nothing && test_namespace !== nothing && catalog !== nothing

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -102,7 +102,7 @@ using Tables
         @test snapshot_id_2 isa Int64
         @test snapshot_id_2 != snapshot_id_1
         println("✅ Snapshot ID after second commit: $snapshot_id_2 (differs from first)")
-        RustyIceberg.free_table(updated_table_2)
+        RustyIceberg.free_table!(updated_table_2)
 
         # Test 6: Verify table exists in catalog by loading it fresh
         println("\nTest 6: Verifying table exists in catalog...")


### PR DESCRIPTION
## Summary

- All scan configuration is now passed directly to `new_scan` / `new_incremental_scan` as keyword arguments, using `Int64` with `-1` as the "not set" sentinel (consistent with the existing `snapshot_id` / `SNAPSHOT_ID_NONE` convention)
- The scan is built immediately inside the Rust constructor — `build!` is no longer a separate step, and the `builder: Option<…>` / `scan: Option<…>` fields are replaced by plain `scan: TableScan` and `file_io: FileIO`
- All standalone `iceberg_*_with_*` FFI functions deleted from Rust, along with the macros that generated them (`impl_select_columns!`, `impl_scan_builder_method!`, `impl_with_serialization_concurrency_limit!`, `impl_scan_build!`)
- Julia `build!`, `select_columns!`, and all `with_*!` functions removed; exports updated; tests and doc examples updated throughout

**Before:**
```julia
scan = new_scan(table)
select_columns!(scan, ["col1", "col2"])
with_batch_size!(scan, UInt(1024))
with_snapshot_id!(scan, snapshot_id)
stream = scan!(scan)
```

**After:**
```julia
scan = new_scan(table; column_names=["col1", "col2"], batch_size=Int64(1024), snapshot_id=snapshot_id)
stream = scan!(scan)
```

## Test plan

- [ ] `make run-containers` to start MinIO + Iceberg REST catalog
- [ ] `make test` — all existing scan, incremental scan, split-scan, and catalog tests pass
- [ ] Verify `new_scan(table)` with no kwargs still works (all defaults preserved)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)