### PR TITLE
Fix timestamptz Arrow timezone: :UTC → Symbol("+00:00")

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -165,7 +165,7 @@ According to the Iceberg specification:
 - `IcebergDate()` → `Date` (from Dates module)
 - `IcebergTime()` → `Int64` - microseconds since midnight
 - `IcebergTimestamp()` → `Arrow.Timestamp{..., nothing}` - microseconds since epoch (no timezone)
-- `IcebergTimestamptz()` → `Arrow.Timestamp{..., :UTC}` - microseconds since epoch UTC
+- `IcebergTimestamptz()` → `Arrow.Timestamp{..., Symbol("+00:00")}` - microseconds since epoch UTC
 - `IcebergString()` → `String`
 - `IcebergUuid()` → `NTuple{16, UInt8}` - 16-byte UUID representation
 - `IcebergBinary()` → `Vector{UInt8}` - variable-length byte array
@@ -194,10 +194,33 @@ iceberg_type_to_arrow_type(::IcebergFloat) = Float32
 iceberg_type_to_arrow_type(::IcebergDouble) = Float64
 iceberg_type_to_arrow_type(::IcebergDate) = Dates.Date
 iceberg_type_to_arrow_type(::IcebergTime) = Int64
+# The Iceberg spec does not define a canonical Arrow format mapping (Arrow is
+# an in-memory format, not a storage format).  Each implementation chooses its
+# own timezone string for timestamptz.  iceberg-rs (our Rust layer) defines:
+# https://github.com/RelationalAI/iceberg-rust/blob/418213731e91544f5eb31a3efa459e88f599030e/crates/iceberg/src/arrow/schema.rs#L45
+#
+#     const UTC_TIME_ZONE: &str = "+00:00";
+#
+# and emits that string into every Arrow IPC schema it writes for Timestamptz
+# fields.  When reading it accepts both "+00:00" and "UTC" for compatibility,
+# but it always *writes* "+00:00".
+#
+# The likely reason for this choice: Parquet encodes UTC-adjusted timestamps
+# via an isAdjustedToUTC=true flag rather than a named timezone, so
+# implementations tend to use the offset form "+00:00" rather than an IANA
+# name like "UTC" when bridging to Arrow.
+#
+# Arrow.jl converts the timezone string from the IPC wire format to a Symbol,
+# so a field written by iceberg-rs arrives as
+#
+#     Arrow.Timestamp{MICROSECOND, Symbol("+00:00")}
+#
+# Using :UTC here would cause a type-mismatch against data returned by the
+# Rust layer, even though the two strings represent the same instant in time.
 iceberg_type_to_arrow_type(::IcebergTimestamp) = Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.MICROSECOND, nothing}
-iceberg_type_to_arrow_type(::IcebergTimestamptz) = Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.MICROSECOND, :UTC}
+iceberg_type_to_arrow_type(::IcebergTimestamptz) = Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.MICROSECOND, Symbol("+00:00")}
 iceberg_type_to_arrow_type(::IcebergTimestampNs) = Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.NANOSECOND, nothing}
-iceberg_type_to_arrow_type(::IcebergTimestamptzNs) = Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.NANOSECOND, :UTC}
+iceberg_type_to_arrow_type(::IcebergTimestamptzNs) = Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.NANOSECOND, Symbol("+00:00")}
 iceberg_type_to_arrow_type(::IcebergString) = String
 iceberg_type_to_arrow_type(::IcebergUuid) = NTuple{16, UInt8}
 iceberg_type_to_arrow_type(::IcebergBinary) = Vector{UInt8}

--- a/test/schema_tests.jl
+++ b/test/schema_tests.jl
@@ -278,9 +278,9 @@ end
         @test iceberg_type_to_arrow_type(IcebergDate()) == Dates.Date
         @test iceberg_type_to_arrow_type(IcebergTime()) == Int64
         @test iceberg_type_to_arrow_type(IcebergTimestamp()) == Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.MICROSECOND, nothing}
-        @test iceberg_type_to_arrow_type(IcebergTimestamptz()) == Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.MICROSECOND, :UTC}
+        @test iceberg_type_to_arrow_type(IcebergTimestamptz()) == Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.MICROSECOND, Symbol("+00:00")}
         @test iceberg_type_to_arrow_type(IcebergTimestampNs()) == Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.NANOSECOND, nothing}
-        @test iceberg_type_to_arrow_type(IcebergTimestamptzNs()) == Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.NANOSECOND, :UTC}
+        @test iceberg_type_to_arrow_type(IcebergTimestamptzNs()) == Arrow.Timestamp{Arrow.Flatbuf.TimeUnit.NANOSECOND, Symbol("+00:00")}
 
         # Complex types
         @test iceberg_type_to_arrow_type(IcebergUuid()) == NTuple{16, UInt8}


### PR DESCRIPTION
## Summary

- `iceberg_type_to_arrow_type(::IcebergTimestamptz)` and `iceberg_type_to_arrow_type(::IcebergTimestamptzNs)` returned `:UTC` as the Arrow timezone symbol. This caused a type mismatch: iceberg-rs emits `"+00:00"` (not `"UTC"`) as the timezone string in Arrow IPC schemas, so Arrow.jl produces `Symbol("+00:00")` when reading the data back.
- There is no canonical Arrow type mapping in the Iceberg spec (Arrow is an in-memory format, not a storage format). The `"+00:00"` choice in iceberg-rs follows the Parquet convention: Parquet's `isAdjustedToUTC=true` flag carries no IANA timezone name, so implementations use the fixed offset string when bridging to Arrow. See [`UTC_TIME_ZONE` in iceberg-rs](https://github.com/RelationalAI/iceberg-rust/blob/418213731e91544f5eb31a3efa459e88f599030e/crates/iceberg/src/arrow/schema.rs#L45).

## Test plan

- [ ] `make test` passes — the corrected `schema_tests.jl` assertions now match what iceberg-rs actually writes into Arrow IPC schemas
- [ ] Verify that reading a `timestamptz` column from a real Iceberg table no longer produces a type mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)