### PR TITLE
Remove MAX_FILE_CONCURRENCY

### DIFF
--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceberg_rust_ffi"
-version = "0.7.19"
+version = "0.7.20"
 edition = "2021"
 
 [lib]

--- a/iceberg_rust_ffi/src/ordered_file_pipeline.rs
+++ b/iceberg_rust_ffi/src/ordered_file_pipeline.rs
@@ -41,16 +41,9 @@ use crate::pipeline_stats::{MAX_BUFFERED_BYTES_PER_TASK, STATS};
 use crate::table::{ArrowBatch, IcebergArrowStream, IcebergFileScanStream};
 use crate::unexpected;
 
-/// Hard cap on file-level concurrency to keep total memory bounded.
-const MAX_FILE_CONCURRENCY: usize = 16;
-
-/// Process-global rayon pool for Arrow IPC serialization. Sized to
-/// MAX_FILE_CONCURRENCY so it can saturate the maximum file parallelism
-/// without spinning up per-pipeline threads.
+/// Process-global rayon pool for Arrow IPC serialization.
 static SERIALIZE_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
-    let n = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(MAX_FILE_CONCURRENCY);
+    let n = std::thread::available_parallelism().unwrap().get();
     rayon::ThreadPoolBuilder::new()
         .num_threads(n)
         .build()
@@ -124,10 +117,6 @@ pub async fn create_nested_pipeline(
     concurrency: usize,
     prefetch_depth: usize,
 ) -> anyhow::Result<IcebergFileScanStream> {
-    if concurrency > MAX_FILE_CONCURRENCY {
-        anyhow::bail!("file concurrency {concurrency} exceeds hard cap {MAX_FILE_CONCURRENCY}");
-    }
-
     STATS.reset();
 
     let (tx, rx) = mpsc::channel::<Result<FileScan, iceberg::Error>>(prefetch_depth);


### PR DESCRIPTION
1. Remove the MAX_FILE_CONCURRENCY = 16 constant and the guard in create_nested_pipeline that rejected concurrency values above 16. On machines with more than 16 cores this caused create_nested_pipeline to bail with an error even for reasonable concurrency values, breaking initialization.
2. Memory is already bounded per-file by the Semaphore(MAX_BUFFERED_BYTES_PER_TASK) backpressure mechanism — the hard cap is redundant.
3. Bump version to 0.7.20.