### PR TITLE
Batch builder API

### DIFF
--- a/iceberg_rust_ffi/Cargo.lock
+++ b/iceberg_rust_ffi/Cargo.lock
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg_rust_ffi"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceberg_rust_ffi"
-version = "0.7.21"
+version = "0.7.22"
 edition = "2021"
 
 [lib]

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -279,6 +279,40 @@ unsafe fn append_to_state(
     Ok(())
 }
 
+// Bulk-copy or 1-based-scattered-gather a slice of primitive T into buf (no transform).
+// Identity selection → single memcpy; scattered selection → element-wise gather.
+macro_rules! append_primitive {
+    ($buf:expr, $slice:expr, $len:expr, $T:ty) => {{
+        let src = unsafe { std::slice::from_raw_parts($slice.data_ptr as *const $T, $len) };
+        if $slice.sel_ptr.is_null() {
+            $buf.extend_from_slice(unsafe { as_bytes(src) });
+        } else {
+            let sel = unsafe { std::slice::from_raw_parts($slice.sel_ptr, $len) };
+            for &idx in sel {
+                $buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
+            }
+        }
+    }};
+}
+
+// Element-wise transform from source type S with optional 1-based scattered gather.
+// `$f` maps S → a value whose `.to_ne_bytes()` is written to buf.
+macro_rules! append_transform {
+    ($buf:expr, $slice:expr, $len:expr, $S:ty, $f:expr) => {{
+        let src = unsafe { std::slice::from_raw_parts($slice.data_ptr as *const $S, $len) };
+        if $slice.sel_ptr.is_null() {
+            for &v in src {
+                $buf.extend_from_slice(&($f)(v).to_ne_bytes());
+            }
+        } else {
+            let sel = unsafe { std::slice::from_raw_parts($slice.sel_ptr, $len) };
+            for &idx in sel {
+                $buf.extend_from_slice(&($f)(src[(idx - 1) as usize]).to_ne_bytes());
+            }
+        }
+    }};
+}
+
 /// Append numeric slice data directly into a `MutableBuffer`.
 /// Identity (sequential) slices use a bulk byte copy; scattered slices loop element-wise.
 unsafe fn append_numeric(
@@ -288,78 +322,20 @@ unsafe fn append_numeric(
     len: usize,
 ) -> Result<(), anyhow::Error> {
     match column_type {
-        COLUMN_TYPE_INT32 | COLUMN_TYPE_DATE => {
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i32, len) };
-            if slice.sel_ptr.is_null() {
-                buf.extend_from_slice(as_bytes(src));
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
-                }
-            }
-        }
+        COLUMN_TYPE_INT32 | COLUMN_TYPE_DATE => append_primitive!(buf, slice, len, i32),
         COLUMN_TYPE_INT64 | COLUMN_TYPE_TIMESTAMP | COLUMN_TYPE_TIMESTAMPTZ => {
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
-            if slice.sel_ptr.is_null() {
-                buf.extend_from_slice(as_bytes(src));
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
-                }
-            }
+            append_primitive!(buf, slice, len, i64)
         }
-        COLUMN_TYPE_FLOAT32 => {
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const f32, len) };
-            if slice.sel_ptr.is_null() {
-                buf.extend_from_slice(as_bytes(src));
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
-                }
-            }
-        }
-        COLUMN_TYPE_FLOAT64 => {
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const f64, len) };
-            if slice.sel_ptr.is_null() {
-                buf.extend_from_slice(as_bytes(src));
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
-                }
-            }
-        }
+        COLUMN_TYPE_FLOAT32 => append_primitive!(buf, slice, len, f32),
+        COLUMN_TYPE_FLOAT64 => append_primitive!(buf, slice, len, f64),
         COLUMN_TYPE_DECIMAL_INT32 => {
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i32, len) };
-            if slice.sel_ptr.is_null() {
-                for &x in src {
-                    buf.extend_from_slice(&(x as i128).to_ne_bytes());
-                }
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    buf.extend_from_slice(&(src[(idx - 1) as usize] as i128).to_ne_bytes());
-                }
-            }
+            append_transform!(buf, slice, len, i32, |x: i32| x as i128)
         }
         COLUMN_TYPE_DECIMAL_INT64 => {
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
-            if slice.sel_ptr.is_null() {
-                for &x in src {
-                    buf.extend_from_slice(&(x as i128).to_ne_bytes());
-                }
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    buf.extend_from_slice(&(src[(idx - 1) as usize] as i128).to_ne_bytes());
-                }
-            }
+            append_transform!(buf, slice, len, i64, |x: i64| x as i128)
         }
         COLUMN_TYPE_DECIMAL_INT128 | COLUMN_TYPE_UUID => {
-            // 16-byte elements
+            // 16-byte elements — no primitive type; copy as raw bytes.
             let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const u8, len * 16) };
             if slice.sel_ptr.is_null() {
                 buf.extend_from_slice(src);
@@ -371,58 +347,25 @@ unsafe fn append_numeric(
                 }
             }
         }
+        // Julia date/timestamp types carry a Julia-epoch offset that Rust removes here.
+        // Source: i64[] days since 0001-01-01 → i32 days since 1970-01-01 (Date32).
         COLUMN_TYPE_JULIA_DATE => {
-            // Source: i64[] of Julia days (since 0001-01-01). Destination: i32 Date32 (since Unix epoch).
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
-            if slice.sel_ptr.is_null() {
-                for &v in src {
-                    buf.extend_from_slice(&((v - JULIA_DATE_OFFSET) as i32).to_ne_bytes());
-                }
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    let v = src[(idx - 1) as usize];
-                    buf.extend_from_slice(&((v - JULIA_DATE_OFFSET) as i32).to_ne_bytes());
-                }
-            }
+            append_transform!(buf, slice, len, i64, |v: i64| (v - JULIA_DATE_OFFSET)
+                as i32)
         }
+        // Source: i64[] ms since 0001-01-01 → i64 μs since 1970-01-01.
         COLUMN_TYPE_JULIA_TIMESTAMP | COLUMN_TYPE_JULIA_TIMESTAMPTZ => {
-            // Source: i64[] of Julia ms (since 0001-01-01). Destination: i64 μs since Unix epoch.
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
-            if slice.sel_ptr.is_null() {
-                for &v in src {
-                    buf.extend_from_slice(&((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000).to_ne_bytes());
-                }
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    let v = src[(idx - 1) as usize];
-                    buf.extend_from_slice(&((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000).to_ne_bytes());
-                }
-            }
+            append_transform!(buf, slice, len, i64, |v: i64| (v
+                - JULIA_TIMESTAMP_OFFSET_MS)
+                * 1_000)
         }
+        // Source: i64[] ms since 0001-01-01 → i64 ns since 1970-01-01.
         COLUMN_TYPE_JULIA_TIMESTAMP_NS | COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS => {
-            // Source: i64[] of Julia ms (since 0001-01-01). Destination: i64 ns since Unix epoch.
-            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
-            if slice.sel_ptr.is_null() {
-                for &v in src {
-                    buf.extend_from_slice(
-                        &((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000_000).to_ne_bytes(),
-                    );
-                }
-            } else {
-                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
-                    let v = src[(idx - 1) as usize];
-                    buf.extend_from_slice(
-                        &((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000_000).to_ne_bytes(),
-                    );
-                }
-            }
+            append_transform!(buf, slice, len, i64, |v: i64| (v
+                - JULIA_TIMESTAMP_OFFSET_MS)
+                * 1_000_000)
         }
-        _ => {
-            return Err(anyhow::anyhow!("unsupported column type {}", column_type));
-        }
+        _ => return Err(anyhow::anyhow!("unsupported column type {}", column_type)),
     }
     Ok(())
 }
@@ -513,7 +456,8 @@ fn build_numeric_array(
             ScalarBuffer::new(buf, 0, rows),
             null_buf,
         )),
-        COLUMN_TYPE_DATE => Arc::new(PrimitiveArray::<Date32Type>::new(
+        // JULIA_DATE stores the epoch-adjusted i32 value; Arrow type is the same as DATE.
+        COLUMN_TYPE_DATE | COLUMN_TYPE_JULIA_DATE => Arc::new(PrimitiveArray::<Date32Type>::new(
             ScalarBuffer::new(buf, 0, rows),
             null_buf,
         )),
@@ -521,11 +465,15 @@ fn build_numeric_array(
             ScalarBuffer::new(buf, 0, rows),
             null_buf,
         )),
-        COLUMN_TYPE_TIMESTAMP => Arc::new(PrimitiveArray::<TimestampMicrosecondType>::new(
-            ScalarBuffer::new(buf, 0, rows),
-            null_buf,
-        )),
-        COLUMN_TYPE_TIMESTAMPTZ => Arc::new(
+        // JULIA_TIMESTAMP stores epoch-adjusted μs; Arrow type is the same as TIMESTAMP.
+        COLUMN_TYPE_TIMESTAMP | COLUMN_TYPE_JULIA_TIMESTAMP => {
+            Arc::new(PrimitiveArray::<TimestampMicrosecondType>::new(
+                ScalarBuffer::new(buf, 0, rows),
+                null_buf,
+            ))
+        }
+        // JULIA_TIMESTAMPTZ stores epoch-adjusted μs; Arrow type is the same as TIMESTAMPTZ.
+        COLUMN_TYPE_TIMESTAMPTZ | COLUMN_TYPE_JULIA_TIMESTAMPTZ => Arc::new(
             PrimitiveArray::<TimestampMicrosecondType>::new(
                 ScalarBuffer::new(buf, 0, rows),
                 null_buf,
@@ -564,21 +512,6 @@ fn build_numeric_array(
                     .map_err(|e| anyhow::anyhow!("UUID FixedSizeBinary: {}", e))?,
             )
         }
-        COLUMN_TYPE_JULIA_DATE => Arc::new(PrimitiveArray::<Date32Type>::new(
-            ScalarBuffer::new(buf, 0, rows),
-            null_buf,
-        )),
-        COLUMN_TYPE_JULIA_TIMESTAMP => Arc::new(PrimitiveArray::<TimestampMicrosecondType>::new(
-            ScalarBuffer::new(buf, 0, rows),
-            null_buf,
-        )),
-        COLUMN_TYPE_JULIA_TIMESTAMPTZ => Arc::new(
-            PrimitiveArray::<TimestampMicrosecondType>::new(
-                ScalarBuffer::new(buf, 0, rows),
-                null_buf,
-            )
-            .with_timezone("UTC"),
-        ),
         COLUMN_TYPE_JULIA_TIMESTAMP_NS => Arc::new(PrimitiveArray::<TimestampNanosecondType>::new(
             ScalarBuffer::new(buf, 0, rows),
             null_buf,

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -86,8 +86,10 @@ impl ColumnValues {
             COLUMN_TYPE_BOOLEAN => ColumnValues::Bool(Vec::with_capacity(coalesce_rows)),
             COLUMN_TYPE_STRING => ColumnValues::Str {
                 bytes: Vec::new(),
+                // Start empty; finalize_and_reset right-sizes to the actual slice length
+                // after the first flush, so we never hold a 4MB coalesce_rows-sized Vec.
                 offsets: {
-                    let mut v = Vec::with_capacity(coalesce_rows + 1);
+                    let mut v = Vec::new();
                     v.push(0i32);
                     v
                 },
@@ -219,10 +221,31 @@ unsafe fn append_to_state(
                     state.null_bits.resize(needed, 0u8);
                 }
             }
-            for i in 0..len {
-                let b = unsafe { (*slice.validity_ptr.add(i / 8) >> (i % 8)) & 1 };
-                let pos = out_start + i;
-                state.null_bits[pos / 8] |= b << (pos % 8);
+            // Copy validity bits. When source and destination are byte-aligned (out_start
+            // is a multiple of 8 — always true for flush-per-slice), one copy_nonoverlapping
+            // replaces the 4096-iteration per-bit loop.
+            if out_start % 8 == 0 {
+                let dst = out_start / 8;
+                let n_bytes = (len + 7) / 8;
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        slice.validity_ptr,
+                        state.null_bits.as_mut_ptr().add(dst),
+                        n_bytes,
+                    );
+                }
+                // Mask off garbage bits beyond `len` in the last byte so they don't
+                // corrupt a subsequent coalesced slice that shares that byte.
+                if len % 8 != 0 {
+                    let tail = state.null_bits.last_mut().unwrap();
+                    *tail &= (1u8 << (len % 8)) - 1;
+                }
+            } else {
+                for i in 0..len {
+                    let b = unsafe { (*slice.validity_ptr.add(i / 8) >> (i % 8)) & 1 };
+                    let pos = out_start + i;
+                    state.null_bits[pos / 8] |= b << (pos % 8);
+                }
             }
         } else if state.has_nulls {
             // All-valid slice but nulls seen earlier — extend bitmap with 1s.
@@ -255,19 +278,26 @@ unsafe fn append_to_state(
         ColumnValues::Str { bytes, offsets } => {
             // Pointer-of-pointers protocol: data_ptr is *const *const u8 (array of pointers
             // into Julia source strings), lengths_ptr is *const i64 (byte lengths per row).
-            // Null and empty rows have a null data pointer and length 0 — no bytes are copied.
+            // Null and empty rows have length 0; the nb>0 guard is sufficient since Julia
+            // always sets len=0 for null/empty rows (no null-pointer check needed).
             if slice.lengths_ptr.is_null() {
                 return Err(anyhow::anyhow!("String column: lengths_ptr is null"));
             }
             let ptrs =
                 unsafe { std::slice::from_raw_parts(slice.data_ptr as *const *const u8, len) };
             let lens = unsafe { std::slice::from_raw_parts(slice.lengths_ptr, len) };
+            // Pre-reserve so bytes never reallocates mid-loop.
+            let total: usize = lens.iter().map(|&l| l as usize).sum();
+            bytes.reserve(total);
+            // Track running offset locally instead of reading bytes.len() each iteration.
+            let mut cur_off = bytes.len();
             for i in 0..len {
                 let nb = lens[i] as usize;
-                if nb > 0 && !ptrs[i].is_null() {
+                if nb > 0 {
                     bytes.extend_from_slice(unsafe { std::slice::from_raw_parts(ptrs[i], nb) });
+                    cur_off += nb;
                 }
-                offsets.push(bytes.len() as i32);
+                offsets.push(cur_off as i32);
             }
         }
     }
@@ -421,9 +451,14 @@ fn finalize_and_reset(
             ))
         }
         ColumnValues::Str { bytes, offsets } => {
-            let taken_bytes = std::mem::replace(bytes, Vec::with_capacity(bytes.capacity()));
+            // Capacity hints from the previous window so the reset never over-allocates.
+            // With has_strings flush-per-slice, offsets.len() == slice_len+1 (~4097), not
+            // coalesce_rows+1 (1M). Using len() here shrinks the reset from 4MB to ~16KB.
+            let bytes_cap = bytes.capacity();
+            let offsets_hint = offsets.len(); // rows+1 from the window just taken
+            let taken_bytes = std::mem::replace(bytes, Vec::with_capacity(bytes_cap));
             let taken_offsets = std::mem::replace(offsets, {
-                let mut v = Vec::with_capacity(coalesce_rows + 1);
+                let mut v = Vec::with_capacity(offsets_hint.max(1));
                 v.push(0i32);
                 v
             });

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -22,7 +22,7 @@ use arrow_array::{
 use arrow_buffer::{BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::SchemaRef as ArrowSchemaRef;
 
-use crate::writer::{submit_batch, IcebergDataFileWriter};
+use crate::writer::{submit_batch, IcebergDataFileWriter, GLOBAL_ENCODE_POOL};
 use crate::writer_columns::{
     SliceRef, COLUMN_TYPE_BOOLEAN, COLUMN_TYPE_DATE, COLUMN_TYPE_DECIMAL_INT128,
     COLUMN_TYPE_DECIMAL_INT32, COLUMN_TYPE_DECIMAL_INT64, COLUMN_TYPE_FLOAT32, COLUMN_TYPE_FLOAT64,
@@ -181,6 +181,7 @@ impl ColumnBatchBuilder {
     pub(crate) fn write_and_reset(
         &mut self,
         writer_ref: &IcebergDataFileWriter,
+        pool: &crate::writer::GlobalWorkerPool,
     ) -> Result<(), anyhow::Error> {
         let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.columns.len());
         for (i, state) in self.columns.iter_mut().enumerate() {
@@ -189,7 +190,7 @@ impl ColumnBatchBuilder {
         }
         let batch = arrow_array::RecordBatch::try_new(self.arrow_schema.clone(), arrays)
             .map_err(|e| anyhow::anyhow!("RecordBatch: {}", e))?;
-        submit_batch(writer_ref, batch)
+        submit_batch(writer_ref, pool, batch)
     }
 }
 
@@ -677,10 +678,17 @@ pub extern "C" fn iceberg_batch_builder_write(
     }
     let writer_ref = unsafe { &*writer };
     let builder_ref = unsafe { &mut *builder };
-    match builder_ref.write_and_reset(writer_ref) {
+    let pool = match GLOBAL_ENCODE_POOL.get() {
+        Some(p) => p,
+        None => {
+            eprintln!("[iceberg] encode pool not initialized");
+            return -1;
+        }
+    };
+    match builder_ref.write_and_reset(writer_ref, pool) {
         Ok(()) => 0,
         Err(e) => {
-            crate::writer::store_writer_error(writer_ref, e);
+            crate::writer::store_writer_error_pub(writer_ref, e);
             -1
         }
     }

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -22,7 +22,7 @@ use arrow_array::{
 use arrow_buffer::{BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::SchemaRef as ArrowSchemaRef;
 
-use crate::writer::{submit_batch, IcebergDataFileWriter, GLOBAL_ENCODE_POOL};
+use crate::writer::{submit_batch, IcebergDataFileWriter};
 use crate::writer_columns::{
     SliceRef, COLUMN_TYPE_BOOLEAN, COLUMN_TYPE_DATE, COLUMN_TYPE_DECIMAL_INT128,
     COLUMN_TYPE_DECIMAL_INT32, COLUMN_TYPE_DECIMAL_INT64, COLUMN_TYPE_FLOAT32, COLUMN_TYPE_FLOAT64,
@@ -181,7 +181,6 @@ impl ColumnBatchBuilder {
     pub(crate) fn write_and_reset(
         &mut self,
         writer_ref: &IcebergDataFileWriter,
-        pool: &crate::writer::GlobalWorkerPool,
     ) -> Result<(), anyhow::Error> {
         let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.columns.len());
         for (i, state) in self.columns.iter_mut().enumerate() {
@@ -190,7 +189,7 @@ impl ColumnBatchBuilder {
         }
         let batch = arrow_array::RecordBatch::try_new(self.arrow_schema.clone(), arrays)
             .map_err(|e| anyhow::anyhow!("RecordBatch: {}", e))?;
-        submit_batch(writer_ref, pool, batch)
+        submit_batch(writer_ref, batch)
     }
 }
 
@@ -678,17 +677,10 @@ pub extern "C" fn iceberg_batch_builder_write(
     }
     let writer_ref = unsafe { &*writer };
     let builder_ref = unsafe { &mut *builder };
-    let pool = match GLOBAL_ENCODE_POOL.get() {
-        Some(p) => p,
-        None => {
-            eprintln!("[iceberg] encode pool not initialized");
-            return -1;
-        }
-    };
-    match builder_ref.write_and_reset(writer_ref, pool) {
+    match builder_ref.write_and_reset(writer_ref) {
         Ok(()) => 0,
         Err(e) => {
-            crate::writer::store_writer_error_pub(writer_ref, e);
+            crate::writer::store_writer_error(writer_ref, e);
             -1
         }
     }

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -339,8 +339,9 @@ macro_rules! append_primitive {
             for (i, &idx) in sel.iter().enumerate() {
                 if i + PREFETCH_DIST < $len {
                     unsafe {
-                        prefetch_read(src.as_ptr().add((sel[i + PREFETCH_DIST] - 1) as usize)
-                            as *const u8)
+                        prefetch_read(
+                            src.as_ptr().add((sel[i + PREFETCH_DIST] - 1) as usize) as *const u8
+                        )
                     };
                 }
                 $buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
@@ -398,7 +399,9 @@ unsafe fn append_numeric(
                 for (i, &idx) in sel.iter().enumerate() {
                     if i + PREFETCH_DIST < len {
                         unsafe {
-                            prefetch_read(src.as_ptr().add((sel[i + PREFETCH_DIST] - 1) as usize * 16))
+                            prefetch_read(
+                                src.as_ptr().add((sel[i + PREFETCH_DIST] - 1) as usize * 16),
+                            )
                         };
                     }
                     let off = (idx - 1) as usize * 16;

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -17,8 +17,7 @@
 use std::sync::Arc;
 
 use arrow_array::{
-    types::*,
-    ArrayRef, BooleanArray, FixedSizeBinaryArray, PrimitiveArray, StringArray,
+    types::*, ArrayRef, BooleanArray, FixedSizeBinaryArray, PrimitiveArray, StringArray,
 };
 use arrow_buffer::{BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow_schema::SchemaRef as ArrowSchemaRef;
@@ -26,10 +25,10 @@ use arrow_schema::SchemaRef as ArrowSchemaRef;
 use crate::writer::{submit_batch, IcebergDataFileWriter, GLOBAL_ENCODE_POOL};
 use crate::writer_columns::{
     SliceRef, COLUMN_TYPE_BOOLEAN, COLUMN_TYPE_DATE, COLUMN_TYPE_DECIMAL_INT128,
-    COLUMN_TYPE_DECIMAL_INT32, COLUMN_TYPE_DECIMAL_INT64, COLUMN_TYPE_FLOAT32,
-    COLUMN_TYPE_FLOAT64, COLUMN_TYPE_INT32, COLUMN_TYPE_INT64, COLUMN_TYPE_JULIA_DATE,
-    COLUMN_TYPE_JULIA_TIMESTAMP, COLUMN_TYPE_JULIA_TIMESTAMPTZ, COLUMN_TYPE_JULIA_TIMESTAMP_NS,
-    COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS, COLUMN_TYPE_STRING, COLUMN_TYPE_TIMESTAMP,
+    COLUMN_TYPE_DECIMAL_INT32, COLUMN_TYPE_DECIMAL_INT64, COLUMN_TYPE_FLOAT32, COLUMN_TYPE_FLOAT64,
+    COLUMN_TYPE_INT32, COLUMN_TYPE_INT64, COLUMN_TYPE_JULIA_DATE, COLUMN_TYPE_JULIA_TIMESTAMP,
+    COLUMN_TYPE_JULIA_TIMESTAMPTZ, COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS,
+    COLUMN_TYPE_JULIA_TIMESTAMP_NS, COLUMN_TYPE_STRING, COLUMN_TYPE_TIMESTAMP,
     COLUMN_TYPE_TIMESTAMPTZ, COLUMN_TYPE_UUID,
 };
 
@@ -45,12 +44,20 @@ const DEFAULT_COALESCE_ROWS: usize = 1_048_576;
 /// Bytes per row for numeric column types (0 for Bool/Str which are not Numeric).
 fn column_bytes_per_row(column_type: i32) -> usize {
     match column_type {
-        COLUMN_TYPE_INT32 | COLUMN_TYPE_DATE | COLUMN_TYPE_FLOAT32
-        | COLUMN_TYPE_DECIMAL_INT32 | COLUMN_TYPE_JULIA_DATE => 4,
-        COLUMN_TYPE_INT64 | COLUMN_TYPE_TIMESTAMP | COLUMN_TYPE_TIMESTAMPTZ
-        | COLUMN_TYPE_FLOAT64 | COLUMN_TYPE_DECIMAL_INT64
-        | COLUMN_TYPE_JULIA_TIMESTAMP | COLUMN_TYPE_JULIA_TIMESTAMPTZ
-        | COLUMN_TYPE_JULIA_TIMESTAMP_NS | COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS => 8,
+        COLUMN_TYPE_INT32
+        | COLUMN_TYPE_DATE
+        | COLUMN_TYPE_FLOAT32
+        | COLUMN_TYPE_DECIMAL_INT32
+        | COLUMN_TYPE_JULIA_DATE => 4,
+        COLUMN_TYPE_INT64
+        | COLUMN_TYPE_TIMESTAMP
+        | COLUMN_TYPE_TIMESTAMPTZ
+        | COLUMN_TYPE_FLOAT64
+        | COLUMN_TYPE_DECIMAL_INT64
+        | COLUMN_TYPE_JULIA_TIMESTAMP
+        | COLUMN_TYPE_JULIA_TIMESTAMPTZ
+        | COLUMN_TYPE_JULIA_TIMESTAMP_NS
+        | COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS => 8,
         COLUMN_TYPE_DECIMAL_INT128 | COLUMN_TYPE_UUID => 16,
         _ => 0,
     }
@@ -69,7 +76,7 @@ enum ColumnValues {
     Bool(Vec<u8>),          // BOOLEAN — 1 byte per row; bit-packed at finalize
     Str {
         bytes: Vec<u8>,
-        offsets: Vec<i32>,  // Arrow offset buffer; offsets[0] = 0 always
+        offsets: Vec<i32>, // Arrow offset buffer; offsets[0] = 0 always
     },
 }
 
@@ -146,11 +153,13 @@ impl ColumnBatchBuilder {
         let columns = col_types
             .iter()
             .zip(arrow_schema.fields().iter())
-            .map(|(&ct, field)| {
-                ColumnBuilderState::new(ct, field.is_nullable(), coalesce_rows)
-            })
+            .map(|(&ct, field)| ColumnBuilderState::new(ct, field.is_nullable(), coalesce_rows))
             .collect();
-        Ok(Self { columns, arrow_schema, coalesce_rows })
+        Ok(Self {
+            columns,
+            arrow_schema,
+            coalesce_rows,
+        })
     }
 
     pub(crate) unsafe fn append_slice(&mut self, slices: &[SliceRef]) -> Result<(), anyhow::Error> {
@@ -247,18 +256,15 @@ unsafe fn append_to_state(
             if slice.lengths_ptr.is_null() {
                 return Err(anyhow::anyhow!("String column: lengths_ptr is null"));
             }
-            let ptrs = unsafe {
-                std::slice::from_raw_parts(slice.data_ptr as *const *const u8, len)
-            };
+            let ptrs =
+                unsafe { std::slice::from_raw_parts(slice.data_ptr as *const *const u8, len) };
             let lens = unsafe { std::slice::from_raw_parts(slice.lengths_ptr, len) };
             let out_start = state.rows;
             for i in 0..len {
-                let is_null = state.is_nullable
-                    && state.has_nulls
-                    && {
-                        let pos = out_start + i;
-                        (state.null_bits[pos / 8] >> (pos % 8)) & 1 == 0
-                    };
+                let is_null = state.is_nullable && state.has_nulls && {
+                    let pos = out_start + i;
+                    (state.null_bits[pos / 8] >> (pos % 8)) & 1 == 0
+                };
                 if !is_null && !ptrs[i].is_null() {
                     bytes.extend_from_slice(unsafe {
                         std::slice::from_raw_parts(ptrs[i], lens[i] as usize)
@@ -354,8 +360,7 @@ unsafe fn append_numeric(
         }
         COLUMN_TYPE_DECIMAL_INT128 | COLUMN_TYPE_UUID => {
             // 16-byte elements
-            let src =
-                unsafe { std::slice::from_raw_parts(slice.data_ptr as *const u8, len * 16) };
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const u8, len * 16) };
             if slice.sel_ptr.is_null() {
                 buf.extend_from_slice(src);
             } else {
@@ -516,12 +521,10 @@ fn build_numeric_array(
             ScalarBuffer::new(buf, 0, rows),
             null_buf,
         )),
-        COLUMN_TYPE_TIMESTAMP => Arc::new(
-            PrimitiveArray::<TimestampMicrosecondType>::new(
-                ScalarBuffer::new(buf, 0, rows),
-                null_buf,
-            ),
-        ),
+        COLUMN_TYPE_TIMESTAMP => Arc::new(PrimitiveArray::<TimestampMicrosecondType>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
         COLUMN_TYPE_TIMESTAMPTZ => Arc::new(
             PrimitiveArray::<TimestampMicrosecondType>::new(
                 ScalarBuffer::new(buf, 0, rows),
@@ -565,21 +568,34 @@ fn build_numeric_array(
             ScalarBuffer::new(buf, 0, rows),
             null_buf,
         )),
-        COLUMN_TYPE_JULIA_TIMESTAMP => Arc::new(
-            PrimitiveArray::<TimestampMicrosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf),
-        ),
+        COLUMN_TYPE_JULIA_TIMESTAMP => Arc::new(PrimitiveArray::<TimestampMicrosecondType>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
         COLUMN_TYPE_JULIA_TIMESTAMPTZ => Arc::new(
-            PrimitiveArray::<TimestampMicrosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf)
-                .with_timezone("UTC"),
+            PrimitiveArray::<TimestampMicrosecondType>::new(
+                ScalarBuffer::new(buf, 0, rows),
+                null_buf,
+            )
+            .with_timezone("UTC"),
         ),
-        COLUMN_TYPE_JULIA_TIMESTAMP_NS => Arc::new(
-            PrimitiveArray::<TimestampNanosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf),
-        ),
+        COLUMN_TYPE_JULIA_TIMESTAMP_NS => Arc::new(PrimitiveArray::<TimestampNanosecondType>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
         COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS => Arc::new(
-            PrimitiveArray::<TimestampNanosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf)
-                .with_timezone("UTC"),
+            PrimitiveArray::<TimestampNanosecondType>::new(
+                ScalarBuffer::new(buf, 0, rows),
+                null_buf,
+            )
+            .with_timezone("UTC"),
         ),
-        ct => return Err(anyhow::anyhow!("unsupported column type {} in finalize", ct)),
+        ct => {
+            return Err(anyhow::anyhow!(
+                "unsupported column type {} in finalize",
+                ct
+            ))
+        }
     })
 }
 
@@ -597,8 +613,8 @@ fn set_bits_range(bits: &mut [u8], start: usize, end: usize) {
         // All bits in the same byte: set bits [fi, li].
         bits[fb] |= ((1u16 << (li + 1)) - 1) as u8 & (0xFF_u8 << fi);
     } else {
-        bits[fb] |= 0xFF_u8 << fi;            // partial first byte: bits [fi, 7]
-        bits[(fb + 1)..lb].fill(0xFF);         // full middle bytes
+        bits[fb] |= 0xFF_u8 << fi; // partial first byte: bits [fi, 7]
+        bits[(fb + 1)..lb].fill(0xFF); // full middle bytes
         bits[lb] |= ((1u16 << (li + 1)) - 1) as u8; // partial last byte: bits [0, li]
     }
 }

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -253,22 +253,19 @@ unsafe fn append_to_state(
             }
         }
         ColumnValues::Str { bytes, offsets } => {
+            // Pointer-of-pointers protocol: data_ptr is *const *const u8 (array of pointers
+            // into Julia source strings), lengths_ptr is *const i64 (byte lengths per row).
+            // Null and empty rows have a null data pointer and length 0 — no bytes are copied.
             if slice.lengths_ptr.is_null() {
                 return Err(anyhow::anyhow!("String column: lengths_ptr is null"));
             }
             let ptrs =
                 unsafe { std::slice::from_raw_parts(slice.data_ptr as *const *const u8, len) };
             let lens = unsafe { std::slice::from_raw_parts(slice.lengths_ptr, len) };
-            let out_start = state.rows;
             for i in 0..len {
-                let is_null = state.is_nullable && state.has_nulls && {
-                    let pos = out_start + i;
-                    (state.null_bits[pos / 8] >> (pos % 8)) & 1 == 0
-                };
-                if !is_null && !ptrs[i].is_null() {
-                    bytes.extend_from_slice(unsafe {
-                        std::slice::from_raw_parts(ptrs[i], lens[i] as usize)
-                    });
+                let nb = lens[i] as usize;
+                if nb > 0 && !ptrs[i].is_null() {
+                    bytes.extend_from_slice(unsafe { std::slice::from_raw_parts(ptrs[i], nb) });
                 }
                 offsets.push(bytes.len() as i32);
             }

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -1,0 +1,686 @@
+/// Incremental column batch builder for zero-copy-from-Julia writes.
+///
+/// Julia calls `iceberg_batch_builder_append_slice` once per operator slice, passing
+/// one `SliceRef` per column. Each slice's data is appended directly into a pre-allocated
+/// `MutableBuffer` that becomes the Arrow column buffer at finalize time — no intermediate
+/// Vec or second copy is needed. Julia can reuse source memory as soon as the call returns.
+///
+/// Null bits are populated lazily: all-valid slices are skipped entirely. The first null
+/// slice triggers a one-time backfill of all prior rows as valid, then subsequent slices
+/// are processed normally. If no null slice ever arrives, no NullBuffer is emitted.
+///
+/// When a coalesce window is full, Julia calls `iceberg_batch_builder_write` which
+/// finalises all per-column buffers into Arrow arrays, assembles a `RecordBatch`, and
+/// submits it to the async encode pool — then resets the builder in-place for reuse.
+/// Reset swaps in a fresh pre-allocated `MutableBuffer` (same capacity) so the next
+/// window never reallocates.
+use std::sync::Arc;
+
+use arrow_array::{
+    types::*,
+    ArrayRef, BooleanArray, FixedSizeBinaryArray, PrimitiveArray, StringArray,
+};
+use arrow_buffer::{BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_schema::SchemaRef as ArrowSchemaRef;
+
+use crate::writer::{submit_batch, IcebergDataFileWriter, GLOBAL_ENCODE_POOL};
+use crate::writer_columns::{
+    SliceRef, COLUMN_TYPE_BOOLEAN, COLUMN_TYPE_DATE, COLUMN_TYPE_DECIMAL_INT128,
+    COLUMN_TYPE_DECIMAL_INT32, COLUMN_TYPE_DECIMAL_INT64, COLUMN_TYPE_FLOAT32,
+    COLUMN_TYPE_FLOAT64, COLUMN_TYPE_INT32, COLUMN_TYPE_INT64, COLUMN_TYPE_JULIA_DATE,
+    COLUMN_TYPE_JULIA_TIMESTAMP, COLUMN_TYPE_JULIA_TIMESTAMPTZ, COLUMN_TYPE_JULIA_TIMESTAMP_NS,
+    COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS, COLUMN_TYPE_STRING, COLUMN_TYPE_TIMESTAMP,
+    COLUMN_TYPE_TIMESTAMPTZ, COLUMN_TYPE_UUID,
+};
+
+/// Days from Julia Date epoch (0001-01-01, Rata Die day 1) to Unix epoch (1970-01-01).
+/// Julia Date stores days using 1-based Rata Die: Dates.value(Date(1970,1,1)) == 719163.
+const JULIA_DATE_OFFSET: i64 = 719_163;
+/// Milliseconds from Julia DateTime epoch (0001-01-01) to Unix epoch (1970-01-01).
+const JULIA_TIMESTAMP_OFFSET_MS: i64 = 719_163 * 86_400_000;
+
+// Default coalesce_rows — must match Julia's DEFAULT_COALESCE_ROWS.
+const DEFAULT_COALESCE_ROWS: usize = 1_048_576;
+
+/// Bytes per row for numeric column types (0 for Bool/Str which are not Numeric).
+fn column_bytes_per_row(column_type: i32) -> usize {
+    match column_type {
+        COLUMN_TYPE_INT32 | COLUMN_TYPE_DATE | COLUMN_TYPE_FLOAT32
+        | COLUMN_TYPE_DECIMAL_INT32 | COLUMN_TYPE_JULIA_DATE => 4,
+        COLUMN_TYPE_INT64 | COLUMN_TYPE_TIMESTAMP | COLUMN_TYPE_TIMESTAMPTZ
+        | COLUMN_TYPE_FLOAT64 | COLUMN_TYPE_DECIMAL_INT64
+        | COLUMN_TYPE_JULIA_TIMESTAMP | COLUMN_TYPE_JULIA_TIMESTAMPTZ
+        | COLUMN_TYPE_JULIA_TIMESTAMP_NS | COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS => 8,
+        COLUMN_TYPE_DECIMAL_INT128 | COLUMN_TYPE_UUID => 16,
+        _ => 0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-column value buffer
+//
+// All numeric and UUID variants use `MutableBuffer` (byte-oriented, Arrow-native).
+// On append we write typed bytes directly into it; on finalize we call `.into()` to
+// get an Arrow `Buffer` — ownership transfer, no copy. The buffer is then swapped out
+// for a fresh pre-allocated one so the next window never reallocates.
+
+enum ColumnValues {
+    Numeric(MutableBuffer), // I32/I64/F32/F64/I128/UUID — bytes per row varies by type
+    Bool(Vec<u8>),          // BOOLEAN — 1 byte per row; bit-packed at finalize
+    Str {
+        bytes: Vec<u8>,
+        offsets: Vec<i32>,  // Arrow offset buffer; offsets[0] = 0 always
+    },
+}
+
+impl ColumnValues {
+    fn new(column_type: i32, coalesce_rows: usize) -> Self {
+        match column_type {
+            COLUMN_TYPE_BOOLEAN => ColumnValues::Bool(Vec::with_capacity(coalesce_rows)),
+            COLUMN_TYPE_STRING => ColumnValues::Str {
+                bytes: Vec::new(),
+                offsets: {
+                    let mut v = Vec::with_capacity(coalesce_rows + 1);
+                    v.push(0i32);
+                    v
+                },
+            },
+            _ => {
+                let bpr = column_bytes_per_row(column_type).max(8); // fallback 8 for unknown
+                ColumnValues::Numeric(MutableBuffer::with_capacity(coalesce_rows * bpr))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-column builder state
+
+struct ColumnBuilderState {
+    column_type: i32,
+    bytes_per_row: usize, // for Numeric variant: bytes per element
+    is_nullable: bool,
+    values: ColumnValues,
+    /// Lazily-populated validity bitmap. Empty until the first null slice.
+    null_bits: Vec<u8>,
+    rows: usize,
+    has_nulls: bool,
+}
+
+impl ColumnBuilderState {
+    fn new(column_type: i32, is_nullable: bool, coalesce_rows: usize) -> Self {
+        Self {
+            column_type,
+            bytes_per_row: column_bytes_per_row(column_type),
+            is_nullable,
+            values: ColumnValues::new(column_type, coalesce_rows),
+            null_bits: Vec::new(),
+            rows: 0,
+            has_nulls: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public builder type
+
+pub struct ColumnBatchBuilder {
+    columns: Vec<ColumnBuilderState>,
+    arrow_schema: ArrowSchemaRef,
+    coalesce_rows: usize,
+}
+
+impl ColumnBatchBuilder {
+    pub(crate) fn new(
+        arrow_schema: ArrowSchemaRef,
+        col_types: &[i32],
+        coalesce_rows: usize,
+    ) -> Result<Self, anyhow::Error> {
+        if col_types.len() != arrow_schema.fields().len() {
+            return Err(anyhow::anyhow!(
+                "col_types length {} != schema field count {}",
+                col_types.len(),
+                arrow_schema.fields().len()
+            ));
+        }
+        let columns = col_types
+            .iter()
+            .zip(arrow_schema.fields().iter())
+            .map(|(&ct, field)| {
+                ColumnBuilderState::new(ct, field.is_nullable(), coalesce_rows)
+            })
+            .collect();
+        Ok(Self { columns, arrow_schema, coalesce_rows })
+    }
+
+    pub(crate) unsafe fn append_slice(&mut self, slices: &[SliceRef]) -> Result<(), anyhow::Error> {
+        if slices.len() != self.columns.len() {
+            return Err(anyhow::anyhow!(
+                "slice count {} != column count {}",
+                slices.len(),
+                self.columns.len()
+            ));
+        }
+        for (state, slice) in self.columns.iter_mut().zip(slices.iter()) {
+            unsafe { append_to_state(state, slice) }?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn write_and_reset(
+        &mut self,
+        writer_ref: &IcebergDataFileWriter,
+        pool: &crate::writer::GlobalWorkerPool,
+    ) -> Result<(), anyhow::Error> {
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.columns.len());
+        for (i, state) in self.columns.iter_mut().enumerate() {
+            let field = self.arrow_schema.field(i);
+            arrays.push(finalize_and_reset(state, field, self.coalesce_rows)?);
+        }
+        let batch = arrow_array::RecordBatch::try_new(self.arrow_schema.clone(), arrays)
+            .map_err(|e| anyhow::anyhow!("RecordBatch: {}", e))?;
+        submit_batch(writer_ref, pool, batch)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Append logic
+
+unsafe fn append_to_state(
+    state: &mut ColumnBuilderState,
+    slice: &SliceRef,
+) -> Result<(), anyhow::Error> {
+    let len = slice.len;
+
+    // ---- null bits (lazy) -------------------------------------------------
+    // Skip entirely for all-valid slices when no nulls have been seen yet.
+    // On the first null slice, backfill all prior rows as valid, then copy bits.
+    // For all-valid slices after nulls have been seen, extend the bitmap with 1s.
+    if state.is_nullable {
+        if !slice.validity_ptr.is_null() {
+            let out_start = state.rows;
+            let needed = (out_start + len + 7) / 8;
+            if !state.has_nulls {
+                // First null slice: backfill all prior rows as valid.
+                state.null_bits.resize(needed, 0u8);
+                set_bits_range(&mut state.null_bits, 0, out_start);
+                state.has_nulls = true;
+            } else {
+                if state.null_bits.len() < needed {
+                    state.null_bits.resize(needed, 0u8);
+                }
+            }
+            for i in 0..len {
+                let b = unsafe { (*slice.validity_ptr.add(i / 8) >> (i % 8)) & 1 };
+                let pos = out_start + i;
+                state.null_bits[pos / 8] |= b << (pos % 8);
+            }
+        } else if state.has_nulls {
+            // All-valid slice but nulls seen earlier — extend bitmap with 1s.
+            let out_start = state.rows;
+            let needed = (out_start + len + 7) / 8;
+            if state.null_bits.len() < needed {
+                state.null_bits.resize(needed, 0u8);
+            }
+            set_bits_range(&mut state.null_bits, out_start, out_start + len);
+        }
+        // else: all-valid slice, no nulls yet — nothing to do.
+    }
+
+    // ---- values -----------------------------------------------------------
+    match &mut state.values {
+        ColumnValues::Numeric(buf) => {
+            append_numeric(buf, slice, state.column_type, len)?;
+        }
+        ColumnValues::Bool(v) => {
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const u8, len) };
+            if slice.sel_ptr.is_null() {
+                v.extend_from_slice(src);
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    v.push(src[(idx - 1) as usize]);
+                }
+            }
+        }
+        ColumnValues::Str { bytes, offsets } => {
+            if slice.lengths_ptr.is_null() {
+                return Err(anyhow::anyhow!("String column: lengths_ptr is null"));
+            }
+            let ptrs = unsafe {
+                std::slice::from_raw_parts(slice.data_ptr as *const *const u8, len)
+            };
+            let lens = unsafe { std::slice::from_raw_parts(slice.lengths_ptr, len) };
+            let out_start = state.rows;
+            for i in 0..len {
+                let is_null = state.is_nullable
+                    && state.has_nulls
+                    && {
+                        let pos = out_start + i;
+                        (state.null_bits[pos / 8] >> (pos % 8)) & 1 == 0
+                    };
+                if !is_null && !ptrs[i].is_null() {
+                    bytes.extend_from_slice(unsafe {
+                        std::slice::from_raw_parts(ptrs[i], lens[i] as usize)
+                    });
+                }
+                offsets.push(bytes.len() as i32);
+            }
+        }
+    }
+
+    state.rows += len;
+    Ok(())
+}
+
+/// Append numeric slice data directly into a `MutableBuffer`.
+/// Identity (sequential) slices use a bulk byte copy; scattered slices loop element-wise.
+unsafe fn append_numeric(
+    buf: &mut MutableBuffer,
+    slice: &SliceRef,
+    column_type: i32,
+    len: usize,
+) -> Result<(), anyhow::Error> {
+    match column_type {
+        COLUMN_TYPE_INT32 | COLUMN_TYPE_DATE => {
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i32, len) };
+            if slice.sel_ptr.is_null() {
+                buf.extend_from_slice(as_bytes(src));
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_INT64 | COLUMN_TYPE_TIMESTAMP | COLUMN_TYPE_TIMESTAMPTZ => {
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
+            if slice.sel_ptr.is_null() {
+                buf.extend_from_slice(as_bytes(src));
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_FLOAT32 => {
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const f32, len) };
+            if slice.sel_ptr.is_null() {
+                buf.extend_from_slice(as_bytes(src));
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_FLOAT64 => {
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const f64, len) };
+            if slice.sel_ptr.is_null() {
+                buf.extend_from_slice(as_bytes(src));
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_DECIMAL_INT32 => {
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i32, len) };
+            if slice.sel_ptr.is_null() {
+                for &x in src {
+                    buf.extend_from_slice(&(x as i128).to_ne_bytes());
+                }
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    buf.extend_from_slice(&(src[(idx - 1) as usize] as i128).to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_DECIMAL_INT64 => {
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
+            if slice.sel_ptr.is_null() {
+                for &x in src {
+                    buf.extend_from_slice(&(x as i128).to_ne_bytes());
+                }
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    buf.extend_from_slice(&(src[(idx - 1) as usize] as i128).to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_DECIMAL_INT128 | COLUMN_TYPE_UUID => {
+            // 16-byte elements
+            let src =
+                unsafe { std::slice::from_raw_parts(slice.data_ptr as *const u8, len * 16) };
+            if slice.sel_ptr.is_null() {
+                buf.extend_from_slice(src);
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    let off = (idx - 1) as usize * 16;
+                    buf.extend_from_slice(&src[off..off + 16]);
+                }
+            }
+        }
+        COLUMN_TYPE_JULIA_DATE => {
+            // Source: i64[] of Julia days (since 0001-01-01). Destination: i32 Date32 (since Unix epoch).
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
+            if slice.sel_ptr.is_null() {
+                for &v in src {
+                    buf.extend_from_slice(&((v - JULIA_DATE_OFFSET) as i32).to_ne_bytes());
+                }
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    let v = src[(idx - 1) as usize];
+                    buf.extend_from_slice(&((v - JULIA_DATE_OFFSET) as i32).to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_JULIA_TIMESTAMP | COLUMN_TYPE_JULIA_TIMESTAMPTZ => {
+            // Source: i64[] of Julia ms (since 0001-01-01). Destination: i64 μs since Unix epoch.
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
+            if slice.sel_ptr.is_null() {
+                for &v in src {
+                    buf.extend_from_slice(&((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000).to_ne_bytes());
+                }
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    let v = src[(idx - 1) as usize];
+                    buf.extend_from_slice(&((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000).to_ne_bytes());
+                }
+            }
+        }
+        COLUMN_TYPE_JULIA_TIMESTAMP_NS | COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS => {
+            // Source: i64[] of Julia ms (since 0001-01-01). Destination: i64 ns since Unix epoch.
+            let src = unsafe { std::slice::from_raw_parts(slice.data_ptr as *const i64, len) };
+            if slice.sel_ptr.is_null() {
+                for &v in src {
+                    buf.extend_from_slice(
+                        &((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000_000).to_ne_bytes(),
+                    );
+                }
+            } else {
+                let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
+                for &idx in sel {
+                    let v = src[(idx - 1) as usize];
+                    buf.extend_from_slice(
+                        &((v - JULIA_TIMESTAMP_OFFSET_MS) * 1_000_000).to_ne_bytes(),
+                    );
+                }
+            }
+        }
+        _ => {
+            return Err(anyhow::anyhow!("unsupported column type {}", column_type));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Finalize
+
+/// Build an Arrow array from `state`'s accumulated data and reset all buffers
+/// in-place for the next coalesce window.
+fn finalize_and_reset(
+    state: &mut ColumnBuilderState,
+    schema_field: &arrow_schema::Field,
+    coalesce_rows: usize,
+) -> Result<ArrayRef, anyhow::Error> {
+    let rows = state.rows;
+    state.rows = 0;
+    state.has_nulls = false;
+
+    // Build NullBuffer from lazily-accumulated bits (None if no nulls seen).
+    // Preserve the Vec's capacity for the next window to avoid repeated allocation.
+    let null_buf: Option<NullBuffer> = if state.is_nullable && !state.null_bits.is_empty() {
+        let cap = state.null_bits.capacity();
+        let bits = std::mem::replace(&mut state.null_bits, Vec::with_capacity(cap));
+        Some(NullBuffer::new(BooleanBuffer::new(
+            Buffer::from_vec(bits),
+            0,
+            rows,
+        )))
+    } else {
+        state.null_bits.clear();
+        None
+    };
+
+    let array: ArrayRef = match &mut state.values {
+        ColumnValues::Numeric(buf) => {
+            // Swap in a fresh pre-allocated buffer; take the old one as Arrow Buffer.
+            let old = std::mem::replace(
+                buf,
+                MutableBuffer::with_capacity(coalesce_rows * state.bytes_per_row),
+            );
+            let arrow_buf: Buffer = old.into();
+            build_numeric_array(state.column_type, arrow_buf, rows, null_buf, schema_field)?
+        }
+        ColumnValues::Bool(v) => {
+            let cap = v.capacity();
+            let taken = std::mem::replace(v, Vec::with_capacity(cap));
+            let mut bits = vec![0u8; (rows + 7) / 8];
+            for (i, &b) in taken.iter().enumerate().take(rows) {
+                if b != 0 {
+                    bits[i / 8] |= 1u8 << (i % 8);
+                }
+            }
+            Arc::new(BooleanArray::new(
+                BooleanBuffer::new(Buffer::from_vec(bits), 0, rows),
+                null_buf,
+            ))
+        }
+        ColumnValues::Str { bytes, offsets } => {
+            let taken_bytes = std::mem::replace(bytes, Vec::with_capacity(bytes.capacity()));
+            let taken_offsets = std::mem::replace(offsets, {
+                let mut v = Vec::with_capacity(coalesce_rows + 1);
+                v.push(0i32);
+                v
+            });
+            let arr = unsafe {
+                StringArray::new_unchecked(
+                    OffsetBuffer::new(ScalarBuffer::from(taken_offsets)),
+                    Buffer::from_vec(taken_bytes),
+                    null_buf,
+                )
+            };
+            Arc::new(arr)
+        }
+    };
+
+    Ok(array)
+}
+
+fn build_numeric_array(
+    column_type: i32,
+    buf: Buffer,
+    rows: usize,
+    null_buf: Option<NullBuffer>,
+    schema_field: &arrow_schema::Field,
+) -> Result<ArrayRef, anyhow::Error> {
+    Ok(match column_type {
+        COLUMN_TYPE_INT32 => Arc::new(PrimitiveArray::<Int32Type>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
+        COLUMN_TYPE_DATE => Arc::new(PrimitiveArray::<Date32Type>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
+        COLUMN_TYPE_INT64 => Arc::new(PrimitiveArray::<Int64Type>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
+        COLUMN_TYPE_TIMESTAMP => Arc::new(
+            PrimitiveArray::<TimestampMicrosecondType>::new(
+                ScalarBuffer::new(buf, 0, rows),
+                null_buf,
+            ),
+        ),
+        COLUMN_TYPE_TIMESTAMPTZ => Arc::new(
+            PrimitiveArray::<TimestampMicrosecondType>::new(
+                ScalarBuffer::new(buf, 0, rows),
+                null_buf,
+            )
+            .with_timezone("UTC"),
+        ),
+        COLUMN_TYPE_FLOAT32 => Arc::new(PrimitiveArray::<Float32Type>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
+        COLUMN_TYPE_FLOAT64 => Arc::new(PrimitiveArray::<Float64Type>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
+        COLUMN_TYPE_DECIMAL_INT32 | COLUMN_TYPE_DECIMAL_INT64 | COLUMN_TYPE_DECIMAL_INT128 => {
+            let (precision, scale) = match schema_field.data_type() {
+                arrow_schema::DataType::Decimal128(p, s) => (*p, *s),
+                dt => {
+                    return Err(anyhow::anyhow!(
+                        "Expected Decimal128 for field {}, got {:?}",
+                        schema_field.name(),
+                        dt
+                    ))
+                }
+            };
+            Arc::new(
+                PrimitiveArray::<Decimal128Type>::new(ScalarBuffer::new(buf, 0, rows), null_buf)
+                    .with_precision_and_scale(precision, scale)
+                    .map_err(|e| anyhow::anyhow!("Decimal precision/scale: {}", e))?,
+            )
+        }
+        COLUMN_TYPE_UUID => {
+            // UUID: FixedSizeBinary(16)
+            Arc::new(
+                FixedSizeBinaryArray::try_new(16, buf, null_buf)
+                    .map_err(|e| anyhow::anyhow!("UUID FixedSizeBinary: {}", e))?,
+            )
+        }
+        COLUMN_TYPE_JULIA_DATE => Arc::new(PrimitiveArray::<Date32Type>::new(
+            ScalarBuffer::new(buf, 0, rows),
+            null_buf,
+        )),
+        COLUMN_TYPE_JULIA_TIMESTAMP => Arc::new(
+            PrimitiveArray::<TimestampMicrosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf),
+        ),
+        COLUMN_TYPE_JULIA_TIMESTAMPTZ => Arc::new(
+            PrimitiveArray::<TimestampMicrosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf)
+                .with_timezone("UTC"),
+        ),
+        COLUMN_TYPE_JULIA_TIMESTAMP_NS => Arc::new(
+            PrimitiveArray::<TimestampNanosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf),
+        ),
+        COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS => Arc::new(
+            PrimitiveArray::<TimestampNanosecondType>::new(ScalarBuffer::new(buf, 0, rows), null_buf)
+                .with_timezone("UTC"),
+        ),
+        ct => return Err(anyhow::anyhow!("unsupported column type {} in finalize", ct)),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+/// Set bits [start, end) to 1 in `bits` (Arrow bit layout: bit i at byte i/8, shift i%8).
+fn set_bits_range(bits: &mut [u8], start: usize, end: usize) {
+    if start >= end {
+        return;
+    }
+    let (fb, lb) = (start / 8, (end - 1) / 8);
+    let (fi, li) = (start % 8, (end - 1) % 8);
+    if fb == lb {
+        // All bits in the same byte: set bits [fi, li].
+        bits[fb] |= ((1u16 << (li + 1)) - 1) as u8 & (0xFF_u8 << fi);
+    } else {
+        bits[fb] |= 0xFF_u8 << fi;            // partial first byte: bits [fi, 7]
+        bits[(fb + 1)..lb].fill(0xFF);         // full middle bytes
+        bits[lb] |= ((1u16 << (li + 1)) - 1) as u8; // partial last byte: bits [0, li]
+    }
+}
+
+/// Reinterpret a typed slice as bytes.
+#[inline(always)]
+unsafe fn as_bytes<T>(s: &[T]) -> &[u8] {
+    unsafe {
+        std::slice::from_raw_parts(s.as_ptr() as *const u8, s.len() * std::mem::size_of::<T>())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FFI entry points
+
+#[no_mangle]
+pub extern "C" fn iceberg_batch_builder_new(
+    writer: *mut IcebergDataFileWriter,
+    col_types: *const i32,
+    num_columns: usize,
+) -> *mut ColumnBatchBuilder {
+    if writer.is_null() || col_types.is_null() || num_columns == 0 {
+        return std::ptr::null_mut();
+    }
+    let writer_ref = unsafe { &*writer };
+    let col_types_slice = unsafe { std::slice::from_raw_parts(col_types, num_columns) };
+    match ColumnBatchBuilder::new(
+        writer_ref.arrow_schema.clone(),
+        col_types_slice,
+        DEFAULT_COALESCE_ROWS,
+    ) {
+        Ok(b) => Box::into_raw(Box::new(b)),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_batch_builder_append_slice(
+    builder: *mut ColumnBatchBuilder,
+    slices: *const SliceRef,
+    num_columns: usize,
+) -> i32 {
+    if builder.is_null() || slices.is_null() || num_columns == 0 {
+        return -1;
+    }
+    let builder_ref = unsafe { &mut *builder };
+    let slices_slice = unsafe { std::slice::from_raw_parts(slices, num_columns) };
+    match unsafe { builder_ref.append_slice(slices_slice) } {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_batch_builder_write(
+    writer: *mut IcebergDataFileWriter,
+    builder: *mut ColumnBatchBuilder,
+) -> i32 {
+    if writer.is_null() || builder.is_null() {
+        return -1;
+    }
+    let writer_ref = unsafe { &*writer };
+    let builder_ref = unsafe { &mut *builder };
+    let pool = match GLOBAL_ENCODE_POOL.get() {
+        Some(p) => p,
+        None => {
+            eprintln!("[iceberg] encode pool not initialized");
+            return -1;
+        }
+    };
+    match builder_ref.write_and_reset(writer_ref, pool) {
+        Ok(()) => 0,
+        Err(e) => {
+            crate::writer::store_writer_error_pub(writer_ref, e);
+            -1
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn iceberg_batch_builder_free(builder: *mut ColumnBatchBuilder) {
+    if !builder.is_null() {
+        unsafe { drop(Box::from_raw(builder)) }
+    }
+}

--- a/iceberg_rust_ffi/src/batch_builder.rs
+++ b/iceberg_rust_ffi/src/batch_builder.rs
@@ -286,12 +286,17 @@ unsafe fn append_to_state(
             let ptrs =
                 unsafe { std::slice::from_raw_parts(slice.data_ptr as *const *const u8, len) };
             let lens = unsafe { std::slice::from_raw_parts(slice.lengths_ptr, len) };
-            // Pre-reserve so bytes never reallocates mid-loop.
+            // Pre-reserve so bytes/offsets never reallocate mid-loop.
             let total: usize = lens.iter().map(|&l| l as usize).sum();
             bytes.reserve(total);
+            offsets.reserve(len);
             // Track running offset locally instead of reading bytes.len() each iteration.
             let mut cur_off = bytes.len();
             for i in 0..len {
+                // Prefetch the string data that will be read PREFETCH_DIST iterations ahead.
+                if i + PREFETCH_DIST < len {
+                    unsafe { prefetch_read(ptrs[i + PREFETCH_DIST]) };
+                }
                 let nb = lens[i] as usize;
                 if nb > 0 {
                     bytes.extend_from_slice(unsafe { std::slice::from_raw_parts(ptrs[i], nb) });
@@ -306,8 +311,24 @@ unsafe fn append_to_state(
     Ok(())
 }
 
+/// Issue a read prefetch for the cache line at `ptr`.
+/// Compiles to a real prefetch on x86_64 and aarch64; no-op elsewhere.
+#[inline(always)]
+unsafe fn prefetch_read(ptr: *const u8) {
+    #[cfg(target_arch = "x86_64")]
+    std::arch::x86_64::_mm_prefetch(ptr as *const i8, std::arch::x86_64::_MM_HINT_T1);
+    #[cfg(target_arch = "aarch64")]
+    core::arch::asm!("prfm pldl2keep, [{ptr}]", ptr = in(reg) ptr, options(nostack, readonly));
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = ptr;
+}
+
 // Bulk-copy or 1-based-scattered-gather a slice of primitive T into buf (no transform).
 // Identity selection → single memcpy; scattered selection → element-wise gather.
+// Prefetch distance for scatter-gather loops: enough to cover ~200-cycle cache miss
+// latency at typical throughput of a few cycles per element.
+const PREFETCH_DIST: usize = 16;
+
 macro_rules! append_primitive {
     ($buf:expr, $slice:expr, $len:expr, $T:ty) => {{
         let src = unsafe { std::slice::from_raw_parts($slice.data_ptr as *const $T, $len) };
@@ -315,7 +336,13 @@ macro_rules! append_primitive {
             $buf.extend_from_slice(unsafe { as_bytes(src) });
         } else {
             let sel = unsafe { std::slice::from_raw_parts($slice.sel_ptr, $len) };
-            for &idx in sel {
+            for (i, &idx) in sel.iter().enumerate() {
+                if i + PREFETCH_DIST < $len {
+                    unsafe {
+                        prefetch_read(src.as_ptr().add((sel[i + PREFETCH_DIST] - 1) as usize)
+                            as *const u8)
+                    };
+                }
                 $buf.extend_from_slice(&src[(idx - 1) as usize].to_ne_bytes());
             }
         }
@@ -368,7 +395,12 @@ unsafe fn append_numeric(
                 buf.extend_from_slice(src);
             } else {
                 let sel = unsafe { std::slice::from_raw_parts(slice.sel_ptr, len) };
-                for &idx in sel {
+                for (i, &idx) in sel.iter().enumerate() {
+                    if i + PREFETCH_DIST < len {
+                        unsafe {
+                            prefetch_read(src.as_ptr().add((sel[i + PREFETCH_DIST] - 1) as usize * 16))
+                        };
+                    }
                     let off = (idx - 1) as usize * 16;
                     buf.extend_from_slice(&src[off..off + 16]);
                 }

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -41,6 +41,9 @@ mod writer;
 // Column-based writer module (zero-copy from Julia)
 mod writer_columns;
 
+// Incremental batch builder: per-slice copy into owned buffers, finalize to RecordBatch
+mod batch_builder;
+
 // Profiling stats for the file-parallel pipeline
 mod pipeline_stats;
 

--- a/iceberg_rust_ffi/src/writer.rs
+++ b/iceberg_rust_ffi/src/writer.rs
@@ -183,11 +183,7 @@ pub(crate) fn submit_batch(
 ) -> Result<(), anyhow::Error> {
     let enc = match GLOBAL_ENCODE_STATE.get() {
         Some(s) => s,
-        None => {
-            return Err(anyhow::anyhow!(
-                "encode state not initialized; call iceberg_writer_new first"
-            ))
-        }
+        None => return Err(anyhow::anyhow!("encode state not initialized; call iceberg_writer_new first")),
     };
     let state = writer_ref.writer_state.clone();
     let semaphore = enc.semaphore.clone();
@@ -200,14 +196,10 @@ pub(crate) fn submit_batch(
             Ok(p) => p,
             Err(_) => {
                 let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
-                if slot.is_none() {
-                    *slot = Some(anyhow::anyhow!("encode semaphore closed unexpectedly"));
-                }
+                if slot.is_none() { *slot = Some(anyhow::anyhow!("encode semaphore closed unexpectedly")); }
                 drop(slot);
                 let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
-                if prev == 1 {
-                    state.done_notify.notify_one();
-                }
+                if prev == 1 { state.done_notify.notify_one(); }
                 return;
             }
         };
@@ -232,14 +224,10 @@ pub(crate) fn submit_batch(
         };
         if let Some(e) = err {
             let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
-            if slot.is_none() {
-                *slot = Some(e);
-            }
+            if slot.is_none() { *slot = Some(e); }
         }
         let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
-        if prev == 1 {
-            state.done_notify.notify_one();
-        }
+        if prev == 1 { state.done_notify.notify_one(); }
     });
 
     Ok(())

--- a/iceberg_rust_ffi/src/writer.rs
+++ b/iceberg_rust_ffi/src/writer.rs
@@ -1,14 +1,11 @@
 /// Writer support for iceberg_rust_ffi
 ///
-/// Encoding is handled by a global pool of N=available_parallelism OS threads shared
-/// across all writers. Per-writer ordering is guaranteed by the per-writer
-/// `Arc<Mutex<ConcreteDataFileWriter>>` inside WriterState: only one pool thread encodes
-/// a given writer at a time, and the FIFO global queue ensures batches are submitted
-/// in order.
-use std::any::Any;
+/// Encoding uses Tokio's blocking thread pool via `spawn_blocking`. A global `Semaphore`
+/// with N=available_parallelism permits bounds concurrent Parquet+ZSTD encodes. Per-writer
+/// ordering is guaranteed by the per-writer `Arc<Mutex<ConcreteDataFileWriter>>` inside
+/// WriterState: only one blocking task encodes a given writer at a time.
 use std::ffi::{c_char, c_void};
 use std::io::Cursor;
-use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
@@ -105,149 +102,41 @@ use object_store_ffi::{
 type ConcreteDataFileWriter =
     DataFileWriter<ParquetWriterBuilder, DefaultLocationGenerator, DefaultFileNameGenerator>;
 
-/// Encode task submitted to the global worker pool.
-pub(crate) struct EncodeTask {
-    batch: RecordBatch,
-    state: Arc<WriterState>,
-}
-
-// Safety: RecordBatch is Send; WriterState fields are Send.
-unsafe impl Send for EncodeTask {}
-
 /// Shared mutable state for one IcebergDataFileWriter.
-/// Owned by the IcebergDataFileWriter and shared with pool workers via Arc.
 pub(crate) struct WriterState {
-    /// The underlying Parquet writer. Protected by a Mutex so pool workers can access it
-    /// concurrently (though at most one worker encodes a given writer at a time due to the
-    /// bounded per-writer channel). Set to None when the writer is closed or freed.
+    /// The underlying Parquet writer. Protected by a Mutex so at most one blocking task
+    /// encodes a given writer at a time. Set to None when the writer is closed or freed.
     writer: Mutex<Option<ConcreteDataFileWriter>>,
-    /// Number of encode tasks submitted to the pool but not yet completed.
+    /// Number of encode tasks submitted but not yet completed.
     pending: AtomicUsize,
-    /// Notified when `pending` drops to zero, so iceberg_writer_close can wait efficiently.
+    /// Notified when `pending` drops to zero so iceberg_writer_close can wait efficiently.
     done_notify: tokio::sync::Notify,
-    /// First encode error encountered by a pool worker, if any.
+    /// First encode error encountered by any task for this writer, if any.
     error: Mutex<Option<anyhow::Error>>,
 }
 
-// Safety: ConcreteDataFileWriter is Send (verified by its use in spawn_blocking previously).
+// Safety: ConcreteDataFileWriter is Send.
 unsafe impl Send for WriterState {}
 unsafe impl Sync for WriterState {}
 
-/// Global pool of N=available_parallelism encode worker threads shared across all writers.
-pub(crate) struct GlobalWorkerPool {
-    pub(crate) task_tx: tokio::sync::mpsc::Sender<EncodeTask>,
-}
-
-pub(crate) static GLOBAL_ENCODE_POOL: OnceLock<GlobalWorkerPool> = OnceLock::new();
-
-/// Formats a Rust panic payload into an anyhow error, preserving the message where possible.
-fn format_panic_error(panic: Box<dyn Any + Send>) -> anyhow::Error {
-    let msg = if let Some(s) = panic.downcast_ref::<&str>() {
-        format!("encode worker panicked: {}", s)
-    } else if let Some(s) = panic.downcast_ref::<String>() {
-        format!("encode worker panicked: {}", s)
-    } else {
-        "encode worker panicked (no string payload)".to_string()
-    };
-    anyhow::anyhow!(msg)
-}
-
-/// Body of each encode worker thread: receives tasks from the shared channel and encodes them.
-fn encode_worker_loop(
-    task_rx: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<EncodeTask>>>,
+/// Global encode state: semaphore + Tokio handle.
+/// Captured at first writer creation (inside the Tokio runtime) so submit_batch can
+/// spawn tasks even when called from Julia's sync (non-Tokio) context.
+struct GlobalEncodeState {
+    semaphore: Arc<tokio::sync::Semaphore>,
     handle: tokio::runtime::Handle,
-) {
-    loop {
-        // Acquire the shared receiver lock, then wait for a task.
-        // The lock is released as soon as recv() returns, so workers are not serialized
-        // during encoding — only during task pickup.
-        let task = {
-            let mut rx = handle.block_on(task_rx.lock());
-            match handle.block_on(rx.recv()) {
-                Some(t) => t,
-                None => break, // sender dropped → pool shutting down
-            }
-        };
-
-        // Clone state before moving task into the closure so we can always decrement
-        // pending even if the closure panics.
-        let state = task.state.clone();
-        let handle_enc = handle.clone();
-        let encode_result = catch_unwind(AssertUnwindSafe(move || {
-            let mut guard = task.state.writer.lock().unwrap_or_else(|e| e.into_inner());
-            match guard.as_mut() {
-                Some(w) => handle_enc
-                    .block_on(w.write(task.batch))
-                    .map_err(|e| anyhow::anyhow!("write batch: {}", e)),
-                None => Err(anyhow::anyhow!("writer already closed")),
-            }
-        }));
-
-        let err = match encode_result {
-            Ok(Ok(())) => None,
-            Ok(Err(e)) => Some(e),
-            Err(panic) => Some(format_panic_error(panic)),
-        };
-        if let Some(e) = err {
-            let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
-            if slot.is_none() {
-                *slot = Some(e);
-            }
-        }
-
-        // Always decrement pending; notify close() if this was the last task.
-        let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
-        if prev == 1 {
-            state.done_notify.notify_one();
-        }
-    }
 }
 
-/// Desired encode worker count. 0 means "use available_parallelism".
-/// Must be set before the first iceberg_writer_new call.
-static ENCODE_WORKERS: AtomicUsize = AtomicUsize::new(0);
+static GLOBAL_ENCODE_STATE: OnceLock<GlobalEncodeState> = OnceLock::new();
 
-/// Set the number of encode worker threads in the global pool.
-/// Must be called before any writer is created. Returns 0 on success, 1 if the pool is
-/// already initialized (call ignored).
-#[no_mangle]
-pub extern "C" fn iceberg_set_encode_workers(n: i32) -> i32 {
-    if GLOBAL_ENCODE_POOL.get().is_some() {
-        return 1;
-    }
-    if n > 0 {
-        ENCODE_WORKERS.store(n as usize, Ordering::Relaxed);
-    }
-    0
-}
-
-/// Initialize the global encode pool on first call.
 /// Must be called from within a Tokio runtime (iceberg_writer_new satisfies this).
-fn get_or_init_encode_pool() -> &'static GlobalWorkerPool {
-    GLOBAL_ENCODE_POOL.get_or_init(|| {
-        let configured = ENCODE_WORKERS.load(Ordering::Relaxed);
-        let n = if configured > 0 {
-            configured
-        } else {
-            // available_parallelism() only fails on unusual platforms (embedded, some sandboxes).
-            // On Linux/macOS/Windows it always succeeds, so the unwrap never fires in practice.
-            thread::available_parallelism().unwrap().get()
-        };
-        let handle = tokio::runtime::Handle::current();
-        // Buffer 2× workers — drain tasks are rarely blocked on submit.
-        let (task_tx, task_rx) = tokio::sync::mpsc::channel::<EncodeTask>(n * 2);
-        let task_rx = Arc::new(tokio::sync::Mutex::new(task_rx));
-
-        for i in 0..n {
-            let task_rx = task_rx.clone();
-            let handle = handle.clone();
-            thread::Builder::new()
-                .name(format!("iceberg-encode-{}", i))
-                .spawn(move || encode_worker_loop(task_rx, handle))
-                .expect("failed to spawn iceberg encode worker");
+fn get_or_init_encode_state() -> &'static GlobalEncodeState {
+    GLOBAL_ENCODE_STATE.get_or_init(|| {
+        let n = thread::available_parallelism().unwrap().get();
+        GlobalEncodeState {
+            semaphore: Arc::new(tokio::sync::Semaphore::new(n)),
+            handle: tokio::runtime::Handle::current(),
         }
-
-        GlobalWorkerPool { task_tx }
     })
 }
 
@@ -273,7 +162,7 @@ pub type IcebergDataFileWriterResponse = IcebergBoxedResponse<IcebergDataFileWri
 pub type IcebergWriterCloseResponse = IcebergBoxedResponse<IcebergDataFiles>;
 
 /// Store an error in the writer state (first error wins).
-fn store_writer_error(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
+pub(crate) fn store_writer_error(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
     let mut slot = writer_ref
         .writer_state
         .error
@@ -284,49 +173,68 @@ fn store_writer_error(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
     }
 }
 
-/// Store an error in the writer state (public for batch_builder module).
-pub(crate) fn store_writer_error_pub(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
-    store_writer_error(writer_ref, e);
-}
-
-/// Submit a `RecordBatch` to the global encode pool.
+/// Submit a `RecordBatch` for async Parquet encoding via `spawn_blocking`.
 ///
-/// Increments the writer's pending count before sending and rolls it back on channel failure.
+/// A semaphore permit is acquired before the blocking task runs, bounding concurrent
+/// encodes to N. The caller returns immediately; errors are surfaced at close time.
 pub(crate) fn submit_batch(
     writer_ref: &IcebergDataFileWriter,
-    pool: &GlobalWorkerPool,
     batch: RecordBatch,
 ) -> Result<(), anyhow::Error> {
-    writer_ref
-        .writer_state
-        .pending
-        .fetch_add(1, Ordering::AcqRel);
-    let task = EncodeTask {
-        batch,
-        state: writer_ref.writer_state.clone(),
+    let enc = match GLOBAL_ENCODE_STATE.get() {
+        Some(s) => s,
+        None => return Err(anyhow::anyhow!("encode state not initialized; call iceberg_writer_new first")),
     };
-    match pool.task_tx.blocking_send(task) {
-        Ok(()) => Ok(()),
-        Err(_) => {
-            let prev = writer_ref
-                .writer_state
-                .pending
-                .fetch_sub(1, Ordering::AcqRel);
-            if prev == 1 {
-                writer_ref.writer_state.done_notify.notify_one();
+    let state = writer_ref.writer_state.clone();
+    let semaphore = enc.semaphore.clone();
+    let handle = enc.handle.clone();
+    state.pending.fetch_add(1, Ordering::AcqRel);
+
+    handle.clone().spawn(async move {
+        // Acquire a permit before spawning — this is the backpressure mechanism.
+        let permit = match semaphore.acquire_owned().await {
+            Ok(p) => p,
+            Err(_) => {
+                let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
+                if slot.is_none() { *slot = Some(anyhow::anyhow!("encode semaphore closed unexpectedly")); }
+                drop(slot);
+                let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
+                if prev == 1 { state.done_notify.notify_one(); }
+                return;
             }
-            Err(anyhow::anyhow!("encode pool channel closed unexpectedly"))
+        };
+
+        let state2 = state.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let _permit = permit; // released when blocking work completes
+            let mut guard = state2.writer.lock().unwrap_or_else(|e| e.into_inner());
+            match guard.as_mut() {
+                Some(w) => handle
+                    .block_on(w.write(batch))
+                    .map_err(|e| anyhow::anyhow!("write batch: {}", e)),
+                None => Err(anyhow::anyhow!("writer already closed")),
+            }
+        })
+        .await;
+
+        let err = match result {
+            Ok(Ok(())) => None,
+            Ok(Err(e)) => Some(e),
+            Err(join_err) => Some(anyhow::anyhow!("encode task failed: {}", join_err)),
+        };
+        if let Some(e) = err {
+            let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
+            if slot.is_none() { *slot = Some(e); }
         }
-    }
+        let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
+        if prev == 1 { state.done_notify.notify_one(); }
+    });
+
+    Ok(())
 }
 
-/// Validates column count, converts each `ColumnDescriptor` into a single-slice `SliceRef`,
-/// routes through `ColumnBatchBuilder`, and submits the resulting `RecordBatch` to the
-/// encode pool.  Using the builder here keeps all type-conversion and null-bit logic in one
-/// place (`batch_builder.rs`) instead of duplicating it.
 unsafe fn write_columns_inner(
     writer_ref: &IcebergDataFileWriter,
-    pool: &GlobalWorkerPool,
     arrow_schema: ArrowSchemaRef,
     col_descs: &[ColumnDescriptor],
 ) -> Result<(), anyhow::Error> {
@@ -351,7 +259,7 @@ unsafe fn write_columns_inner(
         })
         .collect();
     unsafe { builder.append_slice(&slices) }?;
-    builder.write_and_reset(writer_ref, pool)
+    builder.write_and_reset(writer_ref)
 }
 
 /// Synchronous write of flat column data: copies each column from Julia memory into
@@ -370,16 +278,9 @@ pub extern "C" fn iceberg_writer_write_columns(
         return -1;
     }
     let writer_ref = unsafe { &*writer };
-    let pool = match GLOBAL_ENCODE_POOL.get() {
-        Some(p) => p,
-        None => {
-            eprintln!("[iceberg] encode pool not initialized; call iceberg_writer_new first");
-            return -1;
-        }
-    };
     let arrow_schema = writer_ref.arrow_schema.clone();
     let col_descs = unsafe { std::slice::from_raw_parts(columns, num_columns) };
-    if let Err(e) = unsafe { write_columns_inner(writer_ref, pool, arrow_schema, col_descs) } {
+    if let Err(e) = unsafe { write_columns_inner(writer_ref, arrow_schema, col_descs) } {
         store_writer_error(writer_ref, e);
         return -1;
     }
@@ -470,8 +371,8 @@ export_runtime_op!(
                 .map_err(|e| anyhow::anyhow!("Failed to convert schema to Arrow: {}", e))?
         );
 
-        // Initialize global pool (no-op if already running).
-        get_or_init_encode_pool();
+        // Initialize global encode state (no-op if already done).
+        get_or_init_encode_state();
 
         let writer_state = Arc::new(WriterState {
             writer: Mutex::new(Some(concrete_writer)),
@@ -506,15 +407,6 @@ pub extern "C" fn iceberg_writer_write(
     }
 
     let writer_ref = unsafe { &*writer };
-
-    let pool = match GLOBAL_ENCODE_POOL.get() {
-        Some(p) => p,
-        None => {
-            eprintln!("[iceberg:sync] encode pool not initialized; call iceberg_writer_new first");
-            return -1;
-        }
-    };
-
     let ipc_bytes = unsafe { std::slice::from_raw_parts(arrow_ipc_data, arrow_ipc_len).to_vec() };
 
     let cursor = Cursor::new(ipc_bytes);
@@ -534,7 +426,7 @@ pub extern "C" fn iceberg_writer_write(
                 return -1;
             }
         };
-        if let Err(e) = submit_batch(writer_ref, pool, batch) {
+        if let Err(e) = submit_batch(writer_ref, batch) {
             store_writer_error(writer_ref, e);
             return -1;
         }

--- a/iceberg_rust_ffi/src/writer.rs
+++ b/iceberg_rust_ffi/src/writer.rs
@@ -6,8 +6,7 @@
 /// a given writer at a time, and the FIFO global queue ensures batches are submitted
 /// in order.
 use std::any::Any;
-use std::cell::RefCell;
-use std::ffi::{c_char, c_void, CString};
+use std::ffi::{c_char, c_void};
 use std::io::Cursor;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -92,13 +91,12 @@ impl ParquetWriterPropertiesFFI {
     }
 }
 
+use crate::batch_builder::ColumnBatchBuilder;
 use crate::response::IcebergBoxedResponse;
 use crate::table::IcebergTable;
 use crate::transaction::IcebergDataFiles;
 use crate::util::parse_c_string;
-use crate::writer_columns::{
-    build_arrow_array_gathered, ColumnDescriptor, GatheredColumnDescriptor, SliceRef,
-};
+use crate::writer_columns::{ColumnDescriptor, SliceRef};
 use object_store_ffi::{
     export_runtime_op, with_cancellation, CResult, NotifyGuard, ResponseGuard, RT,
 };
@@ -108,7 +106,7 @@ type ConcreteDataFileWriter =
     DataFileWriter<ParquetWriterBuilder, DefaultLocationGenerator, DefaultFileNameGenerator>;
 
 /// Encode task submitted to the global worker pool.
-struct EncodeTask {
+pub(crate) struct EncodeTask {
     batch: RecordBatch,
     state: Arc<WriterState>,
 }
@@ -136,37 +134,11 @@ unsafe impl Send for WriterState {}
 unsafe impl Sync for WriterState {}
 
 /// Global pool of N=available_parallelism encode worker threads shared across all writers.
-struct GlobalWorkerPool {
-    task_tx: tokio::sync::mpsc::Sender<EncodeTask>,
+pub(crate) struct GlobalWorkerPool {
+    pub(crate) task_tx: tokio::sync::mpsc::Sender<EncodeTask>,
 }
 
-static GLOBAL_ENCODE_POOL: OnceLock<GlobalWorkerPool> = OnceLock::new();
-
-// Thread-local storage for the most recent synchronous gather error.
-// Set by iceberg_writer_write_gathered_columns on failure; consumed by iceberg_take_gather_error.
-thread_local! {
-    static LAST_GATHER_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
-}
-
-fn store_gather_error(e: &anyhow::Error) {
-    let msg = format!("{:#}", e);
-    LAST_GATHER_ERROR.with(|cell| {
-        *cell.borrow_mut() = CString::new(msg).ok();
-    });
-}
-
-/// Returns a heap-allocated C string with the most recent gather error on this thread,
-/// or NULL if none. Must be called on the same thread as the failed write call, immediately
-/// after it returns. The caller must free the returned string with `iceberg_destroy_cstring`.
-#[no_mangle]
-pub extern "C" fn iceberg_take_gather_error() -> *mut c_char {
-    LAST_GATHER_ERROR.with(|cell| {
-        cell.borrow_mut()
-            .take()
-            .map(|s| s.into_raw())
-            .unwrap_or(std::ptr::null_mut())
-    })
-}
+pub(crate) static GLOBAL_ENCODE_POOL: OnceLock<GlobalWorkerPool> = OnceLock::new();
 
 /// Formats a Rust panic payload into an anyhow error, preserving the message where possible.
 fn format_panic_error(panic: Box<dyn Any + Send>) -> anyhow::Error {
@@ -312,32 +284,15 @@ fn store_writer_error(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
     }
 }
 
-/// Build a `RecordBatch` from a slice of `GatheredColumnDescriptor`s.
-///
-/// # Safety
-/// All pointers inside each `GatheredColumnDescriptor` must be valid for the duration of
-/// this call (callers hold `GC.@preserve` or equivalent).
-unsafe fn build_record_batch<I>(
-    arrow_schema: ArrowSchemaRef,
-    col_descs: I,
-) -> Result<RecordBatch, anyhow::Error>
-where
-    I: IntoIterator<Item = GatheredColumnDescriptor>,
-    I::IntoIter: ExactSizeIterator,
-{
-    let iter = col_descs.into_iter();
-    let mut arrays = Vec::with_capacity(iter.len());
-    for (i, desc) in iter.enumerate() {
-        arrays.push(unsafe { build_arrow_array_gathered(&desc, arrow_schema.field(i))? });
-    }
-    RecordBatch::try_new(arrow_schema, arrays)
-        .map_err(|_| anyhow::anyhow!("failed to construct RecordBatch"))
+/// Store an error in the writer state (public for batch_builder module).
+pub(crate) fn store_writer_error_pub(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
+    store_writer_error(writer_ref, e);
 }
 
 /// Submit a `RecordBatch` to the global encode pool.
 ///
 /// Increments the writer's pending count before sending and rolls it back on channel failure.
-fn submit_batch(
+pub(crate) fn submit_batch(
     writer_ref: &IcebergDataFileWriter,
     pool: &GlobalWorkerPool,
     batch: RecordBatch,
@@ -365,35 +320,10 @@ fn submit_batch(
     }
 }
 
-/// Validates column count, builds a `RecordBatch` from pre-built gathered descriptors,
-/// and submits it to the encode pool.
-unsafe fn write_gathered_inner<I>(
-    writer_ref: &IcebergDataFileWriter,
-    pool: &GlobalWorkerPool,
-    arrow_schema: ArrowSchemaRef,
-    num_columns: usize,
-    col_descs: I,
-) -> Result<(), anyhow::Error>
-where
-    I: IntoIterator<Item = GatheredColumnDescriptor>,
-    I::IntoIter: ExactSizeIterator,
-{
-    if num_columns != arrow_schema.fields().len() {
-        return Err(anyhow::anyhow!(
-            "Column count mismatch: got {} but schema has {}",
-            num_columns,
-            arrow_schema.fields().len()
-        ));
-    }
-    let batch = unsafe { build_record_batch(arrow_schema, col_descs) }?;
-    submit_batch(writer_ref, pool, batch)
-}
-
-/// Validates column count, builds a `RecordBatch` from flat `ColumnDescriptor`s (each
-/// treated as a single sequential slice), and submits it to the encode pool.
-///
-/// Each `SliceRef` is constructed on the stack and used within the same loop iteration,
-/// so no heap allocation is needed for the descriptor conversion.
+/// Validates column count, converts each `ColumnDescriptor` into a single-slice `SliceRef`,
+/// routes through `ColumnBatchBuilder`, and submits the resulting `RecordBatch` to the
+/// encode pool.  Using the builder here keeps all type-conversion and null-bit logic in one
+/// place (`batch_builder.rs`) instead of duplicating it.
 unsafe fn write_columns_inner(
     writer_ref: &IcebergDataFileWriter,
     pool: &GlobalWorkerPool,
@@ -407,73 +337,21 @@ unsafe fn write_columns_inner(
             arrow_schema.fields().len()
         ));
     }
-    let mut arrays = Vec::with_capacity(col_descs.len());
-    for (i, d) in col_descs.iter().enumerate() {
-        // SliceRef lives on the stack for exactly this iteration; the raw pointer
-        // is consumed by build_arrow_array_gathered before the next iteration begins.
-        let slice = SliceRef {
+    let num_rows = col_descs.iter().map(|d| d.num_rows).max().unwrap_or(0);
+    let col_types: Vec<i32> = col_descs.iter().map(|d| d.column_type).collect();
+    let mut builder = ColumnBatchBuilder::new(arrow_schema.clone(), &col_types, num_rows.max(1))?;
+    let slices: Vec<SliceRef> = col_descs
+        .iter()
+        .map(|d| SliceRef {
             data_ptr: d.data_ptr,
             lengths_ptr: d.lengths_ptr,
             validity_ptr: d.validity_ptr,
             sel_ptr: std::ptr::null(),
             len: d.num_rows,
-        };
-        let desc = GatheredColumnDescriptor {
-            slices: &slice as *const SliceRef,
-            num_slices: 1,
-            total_rows: d.num_rows,
-            column_type: d.column_type,
-            is_nullable: d.is_nullable,
-        };
-        arrays.push(unsafe { build_arrow_array_gathered(&desc, arrow_schema.field(i))? });
-    }
-    let batch = RecordBatch::try_new(arrow_schema, arrays)
-        .map_err(|_| anyhow::anyhow!("failed to construct RecordBatch"))?;
-    submit_batch(writer_ref, pool, batch)
-}
-
-/// Gather column data from Julia memory into Arrow arrays in the calling thread, then
-/// submit the RecordBatch to the global encode pool asynchronously.
-///
-/// Julia keeps source arrays alive via `GC.@preserve` for the duration of this call.
-/// After this function returns, all Julia pointers have been consumed and Julia may safely
-/// release the source data. Encode is still asynchronous in the global pool; call
-/// `iceberg_writer_close` to wait for all pending encodes.
-///
-/// Returns 0 on success, -1 on error (error stored in writer state, propagated on close).
-#[no_mangle]
-pub extern "C" fn iceberg_writer_write_gathered_columns(
-    writer: *mut IcebergDataFileWriter,
-    columns: *const GatheredColumnDescriptor,
-    num_columns: usize,
-) -> i32 {
-    if writer.is_null() || columns.is_null() || num_columns == 0 {
-        return -1;
-    }
-    let writer_ref = unsafe { &*writer };
-    let pool = match GLOBAL_ENCODE_POOL.get() {
-        Some(p) => p,
-        None => {
-            eprintln!("[iceberg] encode pool not initialized; call iceberg_writer_new first");
-            return -1;
-        }
-    };
-    let arrow_schema = writer_ref.arrow_schema.clone();
-    let col_descs = unsafe { std::slice::from_raw_parts(columns, num_columns) };
-    if let Err(e) = unsafe {
-        write_gathered_inner(
-            writer_ref,
-            pool,
-            arrow_schema,
-            num_columns,
-            col_descs.iter().copied(),
-        )
-    } {
-        store_gather_error(&e);
-        store_writer_error(writer_ref, e);
-        return -1;
-    }
-    0
+        })
+        .collect();
+    unsafe { builder.append_slice(&slices) }?;
+    builder.write_and_reset(writer_ref, pool)
 }
 
 /// Synchronous write of flat column data: copies each column from Julia memory into

--- a/iceberg_rust_ffi/src/writer.rs
+++ b/iceberg_rust_ffi/src/writer.rs
@@ -1,11 +1,14 @@
 /// Writer support for iceberg_rust_ffi
 ///
-/// Encoding uses Tokio's blocking thread pool via `spawn_blocking`. A global `Semaphore`
-/// with N=available_parallelism permits bounds concurrent Parquet+ZSTD encodes. Per-writer
-/// ordering is guaranteed by the per-writer `Arc<Mutex<ConcreteDataFileWriter>>` inside
-/// WriterState: only one blocking task encodes a given writer at a time.
+/// Encoding is handled by a global pool of N=available_parallelism OS threads shared
+/// across all writers. Per-writer ordering is guaranteed by the per-writer
+/// `Arc<Mutex<ConcreteDataFileWriter>>` inside WriterState: only one pool thread encodes
+/// a given writer at a time, and the FIFO global queue ensures batches are submitted
+/// in order.
+use std::any::Any;
 use std::ffi::{c_char, c_void};
 use std::io::Cursor;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
@@ -102,41 +105,149 @@ use object_store_ffi::{
 type ConcreteDataFileWriter =
     DataFileWriter<ParquetWriterBuilder, DefaultLocationGenerator, DefaultFileNameGenerator>;
 
+/// Encode task submitted to the global worker pool.
+pub(crate) struct EncodeTask {
+    batch: RecordBatch,
+    state: Arc<WriterState>,
+}
+
+// Safety: RecordBatch is Send; WriterState fields are Send.
+unsafe impl Send for EncodeTask {}
+
 /// Shared mutable state for one IcebergDataFileWriter.
+/// Owned by the IcebergDataFileWriter and shared with pool workers via Arc.
 pub(crate) struct WriterState {
-    /// The underlying Parquet writer. Protected by a Mutex so at most one blocking task
-    /// encodes a given writer at a time. Set to None when the writer is closed or freed.
+    /// The underlying Parquet writer. Protected by a Mutex so pool workers can access it
+    /// concurrently (though at most one worker encodes a given writer at a time due to the
+    /// bounded per-writer channel). Set to None when the writer is closed or freed.
     writer: Mutex<Option<ConcreteDataFileWriter>>,
-    /// Number of encode tasks submitted but not yet completed.
+    /// Number of encode tasks submitted to the pool but not yet completed.
     pending: AtomicUsize,
-    /// Notified when `pending` drops to zero so iceberg_writer_close can wait efficiently.
+    /// Notified when `pending` drops to zero, so iceberg_writer_close can wait efficiently.
     done_notify: tokio::sync::Notify,
-    /// First encode error encountered by any task for this writer, if any.
+    /// First encode error encountered by a pool worker, if any.
     error: Mutex<Option<anyhow::Error>>,
 }
 
-// Safety: ConcreteDataFileWriter is Send.
+// Safety: ConcreteDataFileWriter is Send (verified by its use in spawn_blocking previously).
 unsafe impl Send for WriterState {}
 unsafe impl Sync for WriterState {}
 
-/// Global encode state: semaphore + Tokio handle.
-/// Captured at first writer creation (inside the Tokio runtime) so submit_batch can
-/// spawn tasks even when called from Julia's sync (non-Tokio) context.
-struct GlobalEncodeState {
-    semaphore: Arc<tokio::sync::Semaphore>,
-    handle: tokio::runtime::Handle,
+/// Global pool of N=available_parallelism encode worker threads shared across all writers.
+pub(crate) struct GlobalWorkerPool {
+    pub(crate) task_tx: tokio::sync::mpsc::Sender<EncodeTask>,
 }
 
-static GLOBAL_ENCODE_STATE: OnceLock<GlobalEncodeState> = OnceLock::new();
+pub(crate) static GLOBAL_ENCODE_POOL: OnceLock<GlobalWorkerPool> = OnceLock::new();
 
-/// Must be called from within a Tokio runtime (iceberg_writer_new satisfies this).
-fn get_or_init_encode_state() -> &'static GlobalEncodeState {
-    GLOBAL_ENCODE_STATE.get_or_init(|| {
-        let n = thread::available_parallelism().unwrap().get();
-        GlobalEncodeState {
-            semaphore: Arc::new(tokio::sync::Semaphore::new(n)),
-            handle: tokio::runtime::Handle::current(),
+/// Formats a Rust panic payload into an anyhow error, preserving the message where possible.
+fn format_panic_error(panic: Box<dyn Any + Send>) -> anyhow::Error {
+    let msg = if let Some(s) = panic.downcast_ref::<&str>() {
+        format!("encode worker panicked: {}", s)
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        format!("encode worker panicked: {}", s)
+    } else {
+        "encode worker panicked (no string payload)".to_string()
+    };
+    anyhow::anyhow!(msg)
+}
+
+/// Body of each encode worker thread: receives tasks from the shared channel and encodes them.
+fn encode_worker_loop(
+    task_rx: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<EncodeTask>>>,
+    handle: tokio::runtime::Handle,
+) {
+    loop {
+        // Acquire the shared receiver lock, then wait for a task.
+        // The lock is released as soon as recv() returns, so workers are not serialized
+        // during encoding — only during task pickup.
+        let task = {
+            let mut rx = handle.block_on(task_rx.lock());
+            match handle.block_on(rx.recv()) {
+                Some(t) => t,
+                None => break, // sender dropped → pool shutting down
+            }
+        };
+
+        // Clone state before moving task into the closure so we can always decrement
+        // pending even if the closure panics.
+        let state = task.state.clone();
+        let handle_enc = handle.clone();
+        let encode_result = catch_unwind(AssertUnwindSafe(move || {
+            let mut guard = task.state.writer.lock().unwrap_or_else(|e| e.into_inner());
+            match guard.as_mut() {
+                Some(w) => handle_enc
+                    .block_on(w.write(task.batch))
+                    .map_err(|e| anyhow::anyhow!("write batch: {}", e)),
+                None => Err(anyhow::anyhow!("writer already closed")),
+            }
+        }));
+
+        let err = match encode_result {
+            Ok(Ok(())) => None,
+            Ok(Err(e)) => Some(e),
+            Err(panic) => Some(format_panic_error(panic)),
+        };
+        if let Some(e) = err {
+            let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
+            if slot.is_none() {
+                *slot = Some(e);
+            }
         }
+
+        // Always decrement pending; notify close() if this was the last task.
+        let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
+        if prev == 1 {
+            state.done_notify.notify_one();
+        }
+    }
+}
+
+/// Desired encode worker count. 0 means "use available_parallelism".
+/// Must be set before the first iceberg_writer_new call.
+static ENCODE_WORKERS: AtomicUsize = AtomicUsize::new(0);
+
+/// Set the number of encode worker threads in the global pool.
+/// Must be called before any writer is created. Returns 0 on success, 1 if the pool is
+/// already initialized (call ignored).
+#[no_mangle]
+pub extern "C" fn iceberg_set_encode_workers(n: i32) -> i32 {
+    if GLOBAL_ENCODE_POOL.get().is_some() {
+        return 1;
+    }
+    if n > 0 {
+        ENCODE_WORKERS.store(n as usize, Ordering::Relaxed);
+    }
+    0
+}
+
+/// Initialize the global encode pool on first call.
+/// Must be called from within a Tokio runtime (iceberg_writer_new satisfies this).
+fn get_or_init_encode_pool() -> &'static GlobalWorkerPool {
+    GLOBAL_ENCODE_POOL.get_or_init(|| {
+        let configured = ENCODE_WORKERS.load(Ordering::Relaxed);
+        let n = if configured > 0 {
+            configured
+        } else {
+            // available_parallelism() only fails on unusual platforms (embedded, some sandboxes).
+            // On Linux/macOS/Windows it always succeeds, so the unwrap never fires in practice.
+            thread::available_parallelism().unwrap().get()
+        };
+        let handle = tokio::runtime::Handle::current();
+        // Buffer 2× workers — drain tasks are rarely blocked on submit.
+        let (task_tx, task_rx) = tokio::sync::mpsc::channel::<EncodeTask>(n * 2);
+        let task_rx = Arc::new(tokio::sync::Mutex::new(task_rx));
+
+        for i in 0..n {
+            let task_rx = task_rx.clone();
+            let handle = handle.clone();
+            thread::Builder::new()
+                .name(format!("iceberg-encode-{}", i))
+                .spawn(move || encode_worker_loop(task_rx, handle))
+                .expect("failed to spawn iceberg encode worker");
+        }
+
+        GlobalWorkerPool { task_tx }
     })
 }
 
@@ -162,7 +273,7 @@ pub type IcebergDataFileWriterResponse = IcebergBoxedResponse<IcebergDataFileWri
 pub type IcebergWriterCloseResponse = IcebergBoxedResponse<IcebergDataFiles>;
 
 /// Store an error in the writer state (first error wins).
-pub(crate) fn store_writer_error(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
+fn store_writer_error(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
     let mut slot = writer_ref
         .writer_state
         .error
@@ -173,68 +284,49 @@ pub(crate) fn store_writer_error(writer_ref: &IcebergDataFileWriter, e: anyhow::
     }
 }
 
-/// Submit a `RecordBatch` for async Parquet encoding via `spawn_blocking`.
-///
-/// A semaphore permit is acquired before the blocking task runs, bounding concurrent
-/// encodes to N. The caller returns immediately; errors are surfaced at close time.
-pub(crate) fn submit_batch(
-    writer_ref: &IcebergDataFileWriter,
-    batch: RecordBatch,
-) -> Result<(), anyhow::Error> {
-    let enc = match GLOBAL_ENCODE_STATE.get() {
-        Some(s) => s,
-        None => return Err(anyhow::anyhow!("encode state not initialized; call iceberg_writer_new first")),
-    };
-    let state = writer_ref.writer_state.clone();
-    let semaphore = enc.semaphore.clone();
-    let handle = enc.handle.clone();
-    state.pending.fetch_add(1, Ordering::AcqRel);
-
-    handle.clone().spawn(async move {
-        // Acquire a permit before spawning — this is the backpressure mechanism.
-        let permit = match semaphore.acquire_owned().await {
-            Ok(p) => p,
-            Err(_) => {
-                let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
-                if slot.is_none() { *slot = Some(anyhow::anyhow!("encode semaphore closed unexpectedly")); }
-                drop(slot);
-                let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
-                if prev == 1 { state.done_notify.notify_one(); }
-                return;
-            }
-        };
-
-        let state2 = state.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            let _permit = permit; // released when blocking work completes
-            let mut guard = state2.writer.lock().unwrap_or_else(|e| e.into_inner());
-            match guard.as_mut() {
-                Some(w) => handle
-                    .block_on(w.write(batch))
-                    .map_err(|e| anyhow::anyhow!("write batch: {}", e)),
-                None => Err(anyhow::anyhow!("writer already closed")),
-            }
-        })
-        .await;
-
-        let err = match result {
-            Ok(Ok(())) => None,
-            Ok(Err(e)) => Some(e),
-            Err(join_err) => Some(anyhow::anyhow!("encode task failed: {}", join_err)),
-        };
-        if let Some(e) = err {
-            let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
-            if slot.is_none() { *slot = Some(e); }
-        }
-        let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
-        if prev == 1 { state.done_notify.notify_one(); }
-    });
-
-    Ok(())
+/// Store an error in the writer state (public for batch_builder module).
+pub(crate) fn store_writer_error_pub(writer_ref: &IcebergDataFileWriter, e: anyhow::Error) {
+    store_writer_error(writer_ref, e);
 }
 
+/// Submit a `RecordBatch` to the global encode pool.
+///
+/// Increments the writer's pending count before sending and rolls it back on channel failure.
+pub(crate) fn submit_batch(
+    writer_ref: &IcebergDataFileWriter,
+    pool: &GlobalWorkerPool,
+    batch: RecordBatch,
+) -> Result<(), anyhow::Error> {
+    writer_ref
+        .writer_state
+        .pending
+        .fetch_add(1, Ordering::AcqRel);
+    let task = EncodeTask {
+        batch,
+        state: writer_ref.writer_state.clone(),
+    };
+    match pool.task_tx.blocking_send(task) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            let prev = writer_ref
+                .writer_state
+                .pending
+                .fetch_sub(1, Ordering::AcqRel);
+            if prev == 1 {
+                writer_ref.writer_state.done_notify.notify_one();
+            }
+            Err(anyhow::anyhow!("encode pool channel closed unexpectedly"))
+        }
+    }
+}
+
+/// Validates column count, converts each `ColumnDescriptor` into a single-slice `SliceRef`,
+/// routes through `ColumnBatchBuilder`, and submits the resulting `RecordBatch` to the
+/// encode pool.  Using the builder here keeps all type-conversion and null-bit logic in one
+/// place (`batch_builder.rs`) instead of duplicating it.
 unsafe fn write_columns_inner(
     writer_ref: &IcebergDataFileWriter,
+    pool: &GlobalWorkerPool,
     arrow_schema: ArrowSchemaRef,
     col_descs: &[ColumnDescriptor],
 ) -> Result<(), anyhow::Error> {
@@ -259,7 +351,7 @@ unsafe fn write_columns_inner(
         })
         .collect();
     unsafe { builder.append_slice(&slices) }?;
-    builder.write_and_reset(writer_ref)
+    builder.write_and_reset(writer_ref, pool)
 }
 
 /// Synchronous write of flat column data: copies each column from Julia memory into
@@ -278,9 +370,16 @@ pub extern "C" fn iceberg_writer_write_columns(
         return -1;
     }
     let writer_ref = unsafe { &*writer };
+    let pool = match GLOBAL_ENCODE_POOL.get() {
+        Some(p) => p,
+        None => {
+            eprintln!("[iceberg] encode pool not initialized; call iceberg_writer_new first");
+            return -1;
+        }
+    };
     let arrow_schema = writer_ref.arrow_schema.clone();
     let col_descs = unsafe { std::slice::from_raw_parts(columns, num_columns) };
-    if let Err(e) = unsafe { write_columns_inner(writer_ref, arrow_schema, col_descs) } {
+    if let Err(e) = unsafe { write_columns_inner(writer_ref, pool, arrow_schema, col_descs) } {
         store_writer_error(writer_ref, e);
         return -1;
     }
@@ -371,8 +470,8 @@ export_runtime_op!(
                 .map_err(|e| anyhow::anyhow!("Failed to convert schema to Arrow: {}", e))?
         );
 
-        // Initialize global encode state (no-op if already done).
-        get_or_init_encode_state();
+        // Initialize global pool (no-op if already running).
+        get_or_init_encode_pool();
 
         let writer_state = Arc::new(WriterState {
             writer: Mutex::new(Some(concrete_writer)),
@@ -407,6 +506,15 @@ pub extern "C" fn iceberg_writer_write(
     }
 
     let writer_ref = unsafe { &*writer };
+
+    let pool = match GLOBAL_ENCODE_POOL.get() {
+        Some(p) => p,
+        None => {
+            eprintln!("[iceberg:sync] encode pool not initialized; call iceberg_writer_new first");
+            return -1;
+        }
+    };
+
     let ipc_bytes = unsafe { std::slice::from_raw_parts(arrow_ipc_data, arrow_ipc_len).to_vec() };
 
     let cursor = Cursor::new(ipc_bytes);
@@ -426,7 +534,7 @@ pub extern "C" fn iceberg_writer_write(
                 return -1;
             }
         };
-        if let Err(e) = submit_batch(writer_ref, batch) {
+        if let Err(e) = submit_batch(writer_ref, pool, batch) {
             store_writer_error(writer_ref, e);
             return -1;
         }

--- a/iceberg_rust_ffi/src/writer.rs
+++ b/iceberg_rust_ffi/src/writer.rs
@@ -183,7 +183,11 @@ pub(crate) fn submit_batch(
 ) -> Result<(), anyhow::Error> {
     let enc = match GLOBAL_ENCODE_STATE.get() {
         Some(s) => s,
-        None => return Err(anyhow::anyhow!("encode state not initialized; call iceberg_writer_new first")),
+        None => {
+            return Err(anyhow::anyhow!(
+                "encode state not initialized; call iceberg_writer_new first"
+            ))
+        }
     };
     let state = writer_ref.writer_state.clone();
     let semaphore = enc.semaphore.clone();
@@ -196,10 +200,14 @@ pub(crate) fn submit_batch(
             Ok(p) => p,
             Err(_) => {
                 let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
-                if slot.is_none() { *slot = Some(anyhow::anyhow!("encode semaphore closed unexpectedly")); }
+                if slot.is_none() {
+                    *slot = Some(anyhow::anyhow!("encode semaphore closed unexpectedly"));
+                }
                 drop(slot);
                 let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
-                if prev == 1 { state.done_notify.notify_one(); }
+                if prev == 1 {
+                    state.done_notify.notify_one();
+                }
                 return;
             }
         };
@@ -224,10 +232,14 @@ pub(crate) fn submit_batch(
         };
         if let Some(e) = err {
             let mut slot = state.error.lock().unwrap_or_else(|e| e.into_inner());
-            if slot.is_none() { *slot = Some(e); }
+            if slot.is_none() {
+                *slot = Some(e);
+            }
         }
         let prev = state.pending.fetch_sub(1, Ordering::AcqRel);
-        if prev == 1 { state.done_notify.notify_one(); }
+        if prev == 1 {
+            state.done_notify.notify_one();
+        }
     });
 
     Ok(())

--- a/iceberg_rust_ffi/src/writer_columns.rs
+++ b/iceberg_rust_ffi/src/writer_columns.rs
@@ -1,19 +1,10 @@
 /// Column-based writer support for iceberg_rust_ffi
 ///
-/// This module provides FFI bindings for writing raw column data directly to Parquet,
-/// avoiding the overhead of Arrow IPC serialization. Julia passes raw column pointers
-/// and metadata, and Rust builds Arrow arrays directly from them.
+/// This module provides the FFI structs and column type constants shared between the
+/// flat-column write path (`iceberg_writer_write_columns`) and the incremental batch
+/// builder (`batch_builder.rs`). All Arrow array construction logic lives in
+/// `batch_builder.rs`; this file is intentionally thin.
 use std::ffi::c_void;
-use std::sync::Arc;
-
-use arrow_array::{
-    types::{
-        Date32Type, Decimal128Type, Float32Type, Float64Type, Int32Type, Int64Type,
-        TimestampMicrosecondType,
-    },
-    ArrayRef, BooleanArray, PrimitiveArray, StringArray,
-};
-use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 
 /// Column type codes (must match Julia's ColumnType enum)
 pub const COLUMN_TYPE_INT32: i32 = 0;
@@ -32,6 +23,16 @@ pub const COLUMN_TYPE_DECIMAL_INT32: i32 = 10;
 pub const COLUMN_TYPE_DECIMAL_INT64: i32 = 11;
 /// Decimal backed by Int128 (precision > 18): data is i128[] scaled integers
 pub const COLUMN_TYPE_DECIMAL_INT128: i32 = 12;
+/// Julia-epoch date: source data is i64[] of days since 0001-01-01; Rust subtracts 719163 and writes i32 Date32.
+pub const COLUMN_TYPE_JULIA_DATE: i32 = 13;
+/// Julia-epoch timestamp: source data is i64[] of ms since 0001-01-01; Rust converts to μs since Unix epoch.
+pub const COLUMN_TYPE_JULIA_TIMESTAMP: i32 = 14;
+/// Julia-epoch timestamp with UTC timezone: same conversion as JULIA_TIMESTAMP, UTC-tagged.
+pub const COLUMN_TYPE_JULIA_TIMESTAMPTZ: i32 = 15;
+/// Julia-epoch nanosecond timestamp: source data is i64[] of ms since 0001-01-01; Rust converts to ns since Unix epoch.
+pub const COLUMN_TYPE_JULIA_TIMESTAMP_NS: i32 = 16;
+/// Julia-epoch nanosecond timestamp with UTC timezone.
+pub const COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS: i32 = 17;
 
 /// Descriptor for a single column passed from Julia
 #[repr(C)]
@@ -58,12 +59,6 @@ pub struct ColumnDescriptor {
 unsafe impl Send for ColumnDescriptor {}
 unsafe impl Sync for ColumnDescriptor {}
 
-// =============================================================================
-// Scattered-gather writer: pass raw source pointers + selection indices to Rust,
-// which gathers the data directly into Arrow arrays — eliminating the Julia-side
-// staging copy for non-converting numeric column types.
-// =============================================================================
-
 /// A reference to one slice of source column data.
 /// `sel_ptr = null`  → sequential (identity) access: read data[0..len].
 /// `sel_ptr != null` → scattered access: read data[sel[i]-1] for i in 0..len (1-based Julia indices).
@@ -82,294 +77,3 @@ pub struct SliceRef {
 
 unsafe impl Send for SliceRef {}
 unsafe impl Sync for SliceRef {}
-
-/// Gathered column descriptor: gather `num_slices` SliceRefs into one Arrow column.
-/// `total_rows` must equal the sum of all `slice.len` values.
-/// Fields ordered largest-to-smallest; 3 bytes trailing padding → 32 bytes total.
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct GatheredColumnDescriptor {
-    pub slices: *const SliceRef,
-    pub num_slices: usize,
-    pub total_rows: usize,
-    pub column_type: i32,
-    pub is_nullable: bool,
-}
-
-unsafe impl Send for GatheredColumnDescriptor {}
-unsafe impl Sync for GatheredColumnDescriptor {}
-
-/// Merges the per-slice validity bitmaps from all slices into a single output bitmap.
-///
-/// Each slice contributes `slice.len` output rows. Slices with a null `validity_ptr` are
-/// all-valid. Slices with a bitmap may be misaligned relative to the output (each slice
-/// starts at a different `out` offset), so bits are copied one at a time with a shift.
-/// The selection vector (`sel_ptr`) governs which *source data* elements to read; the
-/// validity bitmap is always indexed by output row position, so sequential and scattered
-/// slices are treated identically here.
-///
-/// Returns `None` if every slice is all-valid (no null buffer needed).
-unsafe fn build_null_buffer_gathered(slices: &[SliceRef], total_rows: usize) -> Option<NullBuffer> {
-    if !slices.iter().any(|s| !s.validity_ptr.is_null()) {
-        return None;
-    }
-    let mut bits = vec![0u8; (total_rows + 7) / 8];
-    let mut out = 0usize;
-    for slice in slices {
-        if slice.validity_ptr.is_null() {
-            // All rows in this slice are valid — set one bit per output row.
-            for i in 0..slice.len {
-                bits[(out + i) / 8] |= 1u8 << ((out + i) % 8);
-            }
-        } else {
-            // Copy validity bits from the slice's bitmap into the output bitmap,
-            // re-aligning from source bit position i to output bit position (out + i).
-            for i in 0..slice.len {
-                let b = (*slice.validity_ptr.add(i / 8) >> (i % 8)) & 1;
-                bits[(out + i) / 8] |= b << ((out + i) % 8);
-            }
-        }
-        out += slice.len;
-    }
-    Some(NullBuffer::new(BooleanBuffer::new(
-        Buffer::from(bits),
-        0,
-        total_rows,
-    )))
-}
-
-/// Gather all slices for a column into an Arrow array.
-pub(crate) unsafe fn build_arrow_array_gathered(
-    desc: &GatheredColumnDescriptor,
-    schema_field: &arrow_schema::Field,
-) -> Result<ArrayRef, anyhow::Error> {
-    let slices = std::slice::from_raw_parts(desc.slices, desc.num_slices);
-    let total = desc.total_rows;
-    let null_buf = if desc.is_nullable {
-        build_null_buffer_gathered(slices, total)
-    } else {
-        None
-    };
-
-    // Macro gathers a primitive numeric type from all slices.
-    // sel_ptr=null → sequential copy; sel_ptr!=null → indirect gather (1-based indices).
-    macro_rules! gather_primitive {
-        ($T:ty, $ArrowType:ty) => {{
-            let mut values = Vec::<$T>::with_capacity(total);
-            for slice in slices {
-                let src = slice.data_ptr as *const $T;
-                if slice.sel_ptr.is_null() {
-                    values.extend_from_slice(std::slice::from_raw_parts(src, slice.len));
-                } else {
-                    for &idx in std::slice::from_raw_parts(slice.sel_ptr, slice.len) {
-                        values.push(*src.add((idx - 1) as usize));
-                    }
-                }
-            }
-            Arc::new(PrimitiveArray::<$ArrowType>::new(
-                ScalarBuffer::from(values),
-                null_buf,
-            )) as ArrayRef
-        }};
-    }
-
-    let array: ArrayRef = match desc.column_type {
-        COLUMN_TYPE_INT32 => gather_primitive!(i32, Int32Type),
-        COLUMN_TYPE_INT64 => gather_primitive!(i64, Int64Type),
-        COLUMN_TYPE_FLOAT32 => gather_primitive!(f32, Float32Type),
-        COLUMN_TYPE_FLOAT64 => gather_primitive!(f64, Float64Type),
-        COLUMN_TYPE_DATE => gather_primitive!(i32, Date32Type),
-        COLUMN_TYPE_TIMESTAMP => {
-            let mut values = Vec::<i64>::with_capacity(total);
-            for slice in slices {
-                let src = slice.data_ptr as *const i64;
-                if slice.sel_ptr.is_null() {
-                    values.extend_from_slice(std::slice::from_raw_parts(src, slice.len));
-                } else {
-                    for &idx in std::slice::from_raw_parts(slice.sel_ptr, slice.len) {
-                        values.push(*src.add((idx - 1) as usize));
-                    }
-                }
-            }
-            Arc::new(PrimitiveArray::<TimestampMicrosecondType>::new(
-                ScalarBuffer::from(values),
-                null_buf,
-            ))
-        }
-        COLUMN_TYPE_TIMESTAMPTZ => {
-            let mut values = Vec::<i64>::with_capacity(total);
-            for slice in slices {
-                let src = slice.data_ptr as *const i64;
-                if slice.sel_ptr.is_null() {
-                    values.extend_from_slice(std::slice::from_raw_parts(src, slice.len));
-                } else {
-                    for &idx in std::slice::from_raw_parts(slice.sel_ptr, slice.len) {
-                        values.push(*src.add((idx - 1) as usize));
-                    }
-                }
-            }
-            Arc::new(
-                PrimitiveArray::<TimestampMicrosecondType>::new(
-                    ScalarBuffer::from(values),
-                    null_buf,
-                )
-                .with_timezone("UTC"),
-            )
-        }
-        COLUMN_TYPE_BOOLEAN => {
-            let mut bits = vec![0u8; (total + 7) / 8];
-            let mut out = 0usize;
-            for slice in slices {
-                let src = slice.data_ptr as *const u8;
-                if slice.sel_ptr.is_null() {
-                    let data = std::slice::from_raw_parts(src, slice.len);
-                    for (i, &v) in data.iter().enumerate() {
-                        if v != 0 {
-                            bits[(out + i) / 8] |= 1 << ((out + i) % 8);
-                        }
-                    }
-                } else {
-                    for (i, &idx) in std::slice::from_raw_parts(slice.sel_ptr, slice.len)
-                        .iter()
-                        .enumerate()
-                    {
-                        if *src.add((idx - 1) as usize) != 0 {
-                            bits[(out + i) / 8] |= 1 << ((out + i) % 8);
-                        }
-                    }
-                }
-                out += slice.len;
-            }
-            Arc::new(BooleanArray::new(
-                BooleanBuffer::new(Buffer::from(bits), 0, total),
-                null_buf,
-            ))
-        }
-        COLUMN_TYPE_STRING => {
-            // String columns do not support selection vectors. Julia strings are
-            // heap-allocated with non-contiguous addresses, so the caller must build
-            // str_ptrs/str_lens arrays up-front — any row selection is already applied
-            // before add_string_slice! is called. sel_ptr is therefore always null here.
-            // data_ptr = *const *const u8, lengths_ptr = *const i64.
-            //
-            // Build the Arrow StringArray directly: one pass copies string bytes into a
-            // contiguous values buffer and tracks cumulative offsets. This avoids the
-            // intermediate Vec<Option<&str>> and skips UTF-8 validation — Julia strings
-            // are guaranteed valid UTF-8.
-            let null_buf = if desc.is_nullable {
-                build_null_buffer_gathered(slices, total)
-            } else {
-                None
-            };
-            let mut offsets = Vec::<i32>::with_capacity(total + 1);
-            offsets.push(0i32);
-            let mut values = Vec::<u8>::new();
-            for slice in slices {
-                if slice.lengths_ptr.is_null() {
-                    return Err(anyhow::anyhow!("String column requires lengths_ptr"));
-                }
-                let ptrs =
-                    std::slice::from_raw_parts(slice.data_ptr as *const *const u8, slice.len);
-                let lens = std::slice::from_raw_parts(slice.lengths_ptr, slice.len);
-                for i in 0..slice.len {
-                    let is_null = !slice.validity_ptr.is_null()
-                        && ((*slice.validity_ptr.add(i / 8) >> (i % 8)) & 1) == 0;
-                    if !is_null {
-                        values.extend_from_slice(std::slice::from_raw_parts(
-                            ptrs[i],
-                            lens[i] as usize,
-                        ));
-                    }
-                    offsets.push(values.len() as i32);
-                }
-            }
-            // SAFETY: offsets are monotonically non-decreasing by construction; values
-            // bytes come from Julia String objects (valid UTF-8) kept alive in col.preserve.
-            Arc::new(unsafe {
-                StringArray::new_unchecked(
-                    OffsetBuffer::new(ScalarBuffer::from(offsets)),
-                    Buffer::from_vec(values),
-                    null_buf,
-                )
-            })
-        }
-        COLUMN_TYPE_UUID => {
-            let mut data: Vec<u8> = Vec::with_capacity(total * 16);
-            for slice in slices {
-                let src = slice.data_ptr as *const u8;
-                if slice.sel_ptr.is_null() {
-                    data.extend_from_slice(std::slice::from_raw_parts(src, slice.len * 16));
-                } else {
-                    for &idx in std::slice::from_raw_parts(slice.sel_ptr, slice.len) {
-                        data.extend_from_slice(std::slice::from_raw_parts(
-                            src.add((idx - 1) as usize * 16),
-                            16,
-                        ));
-                    }
-                }
-            }
-            let chunks: Vec<&[u8]> = data.chunks(16).collect();
-            Arc::new(
-                arrow_array::FixedSizeBinaryArray::try_from_iter(chunks.into_iter())
-                    .map_err(|e| anyhow::anyhow!("Failed to build UUID array: {}", e))?,
-            )
-        }
-        COLUMN_TYPE_DECIMAL_INT32 | COLUMN_TYPE_DECIMAL_INT64 | COLUMN_TYPE_DECIMAL_INT128 => {
-            let (precision, scale) = match schema_field.data_type() {
-                arrow_schema::DataType::Decimal128(p, s) => (*p, *s),
-                dt => return Err(anyhow::anyhow!("Expected Decimal128, got {:?}", dt)),
-            };
-            let mut values = Vec::<i128>::with_capacity(total);
-            for slice in slices {
-                match desc.column_type {
-                    COLUMN_TYPE_DECIMAL_INT32 => {
-                        let src = slice.data_ptr as *const i32;
-                        if slice.sel_ptr.is_null() {
-                            values.extend(
-                                std::slice::from_raw_parts(src, slice.len)
-                                    .iter()
-                                    .map(|&v| v as i128),
-                            );
-                        } else {
-                            for &idx in std::slice::from_raw_parts(slice.sel_ptr, slice.len) {
-                                values.push(*src.add((idx - 1) as usize) as i128);
-                            }
-                        }
-                    }
-                    COLUMN_TYPE_DECIMAL_INT64 => {
-                        let src = slice.data_ptr as *const i64;
-                        if slice.sel_ptr.is_null() {
-                            values.extend(
-                                std::slice::from_raw_parts(src, slice.len)
-                                    .iter()
-                                    .map(|&v| v as i128),
-                            );
-                        } else {
-                            for &idx in std::slice::from_raw_parts(slice.sel_ptr, slice.len) {
-                                values.push(*src.add((idx - 1) as usize) as i128);
-                            }
-                        }
-                    }
-                    _ => {
-                        // DECIMAL_INT128: i128 layout matches Julia Int128
-                        let src = slice.data_ptr as *const i128;
-                        if slice.sel_ptr.is_null() {
-                            values.extend_from_slice(std::slice::from_raw_parts(src, slice.len));
-                        } else {
-                            for &idx in std::slice::from_raw_parts(slice.sel_ptr, slice.len) {
-                                values.push(*src.add((idx - 1) as usize));
-                            }
-                        }
-                    }
-                }
-            }
-            Arc::new(
-                PrimitiveArray::<Decimal128Type>::new(ScalarBuffer::from(values), null_buf)
-                    .with_precision_and_scale(precision, scale)
-                    .map_err(|e| anyhow::anyhow!("Decimal precision/scale: {}", e))?,
-            )
-        }
-        _ => return Err(anyhow::anyhow!("Unknown column type: {}", desc.column_type)),
-    };
-    Ok(array)
-}

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -45,7 +45,7 @@ export COLUMN_TYPE_INT32, COLUMN_TYPE_INT64, COLUMN_TYPE_FLOAT32, COLUMN_TYPE_FL
 export COLUMN_TYPE_STRING, COLUMN_TYPE_DATE, COLUMN_TYPE_TIMESTAMP, COLUMN_TYPE_TIMESTAMPTZ, COLUMN_TYPE_BOOLEAN, COLUMN_TYPE_UUID
 export COLUMN_TYPE_DECIMAL_INT32, COLUMN_TYPE_DECIMAL_INT64, COLUMN_TYPE_DECIMAL_INT128
 export julia_type_to_column_type
-export GatheredColumn, GatheredBatch, add_slice!, add_string_slice!
+export SliceRef, SliceBatch, ColumnBatchBuilder, append_slice!, free_builder!
 
 # Always use the JLL library - override via Preferences if needed for local development
 # To use a local build, set the preference:

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -38,7 +38,7 @@ export IcebergTimestampNs, IcebergTimestamptzNs
 export IcebergString, IcebergUuid, IcebergBinary, IcebergDecimal
 export Transaction, DataFiles, free_transaction!, free_data_files!, commit, transaction
 export FastAppendAction, free_fast_append_action!, add_data_files, apply, with_fast_append
-export DataFileWriter, free_writer!, close_writer, write_columns, set_encode_workers!
+export DataFileWriter, free_writer!, close_writer, write_columns
 export WriterConfig, CompressionCodec, UNCOMPRESSED, SNAPPY, GZIP, LZ4, ZSTD
 export ColumnDescriptor, ColumnBatch, ColumnType
 export COLUMN_TYPE_INT32, COLUMN_TYPE_INT64, COLUMN_TYPE_FLOAT32, COLUMN_TYPE_FLOAT64

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -38,7 +38,7 @@ export IcebergTimestampNs, IcebergTimestamptzNs
 export IcebergString, IcebergUuid, IcebergBinary, IcebergDecimal
 export Transaction, DataFiles, free_transaction!, free_data_files!, commit, transaction
 export FastAppendAction, free_fast_append_action!, add_data_files, apply, with_fast_append
-export DataFileWriter, free_writer!, close_writer, write_columns
+export DataFileWriter, free_writer!, close_writer, write_columns, set_encode_workers!
 export WriterConfig, CompressionCodec, UNCOMPRESSED, SNAPPY, GZIP, LZ4, ZSTD
 export ColumnDescriptor, ColumnBatch, ColumnType
 export COLUMN_TYPE_INT32, COLUMN_TYPE_INT64, COLUMN_TYPE_FLOAT32, COLUMN_TYPE_FLOAT64

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -146,23 +146,6 @@ function get_column_metadata(table::Table)::Dict{Symbol, Vector{Pair{String, Str
     return colmeta
 end
 
-"""
-    set_encode_workers!(n::Int)
-
-Set the number of threads in the global Parquet encode worker pool.
-
-Must be called before the first `DataFileWriter` is created (i.e. before the pool is
-initialized). Throws if the pool is already running. Defaults to `Sys.CPU_THREADS`
-if not set.
-"""
-function set_encode_workers!(n::Int)
-    n > 0 || throw(ArgumentError("n must be positive, got $n"))
-    ret = @ccall rust_lib.iceberg_set_encode_workers(n::Cint)::Int32
-    ret == 0 || throw(IcebergException(
-        "set_encode_workers! must be called before creating any DataFileWriter"
-    ))
-    return nothing
-end
 
 """
     DataFileWriter(table::Table, config::WriterConfig) -> DataFileWriter

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -146,6 +146,23 @@ function get_column_metadata(table::Table)::Dict{Symbol, Vector{Pair{String, Str
     return colmeta
 end
 
+"""
+    set_encode_workers!(n::Int)
+
+Set the number of threads in the global Parquet encode worker pool.
+
+Must be called before the first `DataFileWriter` is created (i.e. before the pool is
+initialized). Throws if the pool is already running. Defaults to `Sys.CPU_THREADS`
+if not set.
+"""
+function set_encode_workers!(n::Int)
+    n > 0 || throw(ArgumentError("n must be positive, got $n"))
+    ret = @ccall rust_lib.iceberg_set_encode_workers(n::Cint)::Int32
+    ret == 0 || throw(IcebergException(
+        "set_encode_workers! must be called before creating any DataFileWriter"
+    ))
+    return nothing
+end
 
 """
     DataFileWriter(table::Table, config::WriterConfig) -> DataFileWriter

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -512,26 +512,6 @@ struct SliceRef
 end
 
 """
-    GatheredColumnDescriptor
-
-FFI descriptor for a column to be gathered from multiple SliceRefs.
-Pass an array of these to `write_columns`.
-
-- `slices_ptr`: pointer to array of SliceRef structs
-- `num_slices`: number of SliceRef entries
-- `total_rows`: sum of all slice lengths
-- `column_type`: ColumnType enum value
-- `is_nullable`: whether the column may contain null values
-"""
-struct GatheredColumnDescriptor
-    slices_ptr::Ptr{SliceRef}
-    num_slices::Csize_t
-    total_rows::Csize_t
-    column_type::Int32
-    is_nullable::Bool
-end
-
-"""
     ColumnType
 
 Enum for column data types, matching the Rust FFI constants.
@@ -550,6 +530,13 @@ Enum for column data types, matching the Rust FFI constants.
     COLUMN_TYPE_DECIMAL_INT32 = 10  # Decimal backed by Int32 (precision ≤ 9)
     COLUMN_TYPE_DECIMAL_INT64 = 11  # Decimal backed by Int64 (precision ≤ 18)
     COLUMN_TYPE_DECIMAL_INT128 = 12 # Decimal backed by Int128 (precision > 18)
+    # Julia-epoch variants: source data uses Julia's internal epoch (0001-01-01);
+    # Rust applies the offset to produce Iceberg's Unix-epoch representation.
+    COLUMN_TYPE_JULIA_DATE = 13           # i64[] days since year 1 → i32 days since 1970-01-01
+    COLUMN_TYPE_JULIA_TIMESTAMP = 14      # i64[] ms since year 1 → i64 μs since 1970-01-01
+    COLUMN_TYPE_JULIA_TIMESTAMPTZ = 15    # same + UTC timezone
+    COLUMN_TYPE_JULIA_TIMESTAMP_NS = 16   # i64[] ms since year 1 → i64 ns since 1970-01-01
+    COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS = 17 # same + UTC timezone
 end
 
 """
@@ -615,9 +602,11 @@ iceberg_column_type(::IcebergLong) = COLUMN_TYPE_INT64
 iceberg_column_type(::IcebergFloat) = COLUMN_TYPE_FLOAT32
 iceberg_column_type(::IcebergDouble) = COLUMN_TYPE_FLOAT64
 iceberg_column_type(::IcebergString) = COLUMN_TYPE_STRING
-iceberg_column_type(::IcebergDate) = COLUMN_TYPE_DATE
-iceberg_column_type(::IcebergTimestamp) = COLUMN_TYPE_TIMESTAMP
-iceberg_column_type(::IcebergTimestamptz) = COLUMN_TYPE_TIMESTAMPTZ
+iceberg_column_type(::IcebergDate)          = COLUMN_TYPE_JULIA_DATE
+iceberg_column_type(::IcebergTimestamp)     = COLUMN_TYPE_JULIA_TIMESTAMP
+iceberg_column_type(::IcebergTimestamptz)   = COLUMN_TYPE_JULIA_TIMESTAMPTZ
+iceberg_column_type(::IcebergTimestampNs)   = COLUMN_TYPE_JULIA_TIMESTAMP_NS
+iceberg_column_type(::IcebergTimestamptzNs) = COLUMN_TYPE_JULIA_TIMESTAMPTZ_NS
 iceberg_column_type(::IcebergBoolean) = COLUMN_TYPE_BOOLEAN
 iceberg_column_type(::IcebergUuid) = COLUMN_TYPE_UUID
 function iceberg_column_type(d::IcebergDecimal)
@@ -884,108 +873,87 @@ function write_columns(writer::DataFileWriter, batch::ColumnBatch)
 end
 
 # ==========================================================================================
-# High-level gathered-column API
+# Incremental batch builder API
 # ==========================================================================================
 
 """
-    GatheredColumn
+    SliceBatch
 
-Accumulates one or more source slices for a single column. Rust gathers the data
-directly from source buffers when the batch is written, avoiding a Julia-side staging
-copy for numeric columns.
-
-Typical usage:
+Accumulates one column slice descriptor per column for a single `append_slice!` call.
+Handles `SliceRef` construction and GC preservation automatically, so callers work with
+plain Julia arrays instead of raw pointers.
 
 ```julia
-col = GatheredColumn(COLUMN_TYPE_INT64)
-add_slice!(col, src_array)                        # sequential: all rows
-add_slice!(col, src_array2; sel=sel_indices)      # scattered: rows at sel_indices
-add_slice!(col, src_array3; validity=valid_bv)    # nullable slice
-
-str_col = GatheredColumn(COLUMN_TYPE_STRING; nullable=true)
-add_string_slice!(str_col, ["a", "", "c"]; validity=BitVector([true, false, true]))
+sb = SliceBatch()
+push!(sb, ids)                                 # non-nullable numeric, sequential
+push!(sb, values; validity=valid_bv)           # nullable numeric, sequential
+push!(sb, scores; sel=sel_indices)             # non-nullable scattered
+push!(sb, tags; validity=valid_bv)             # nullable strings
+append_slice!(builder, sb)
 ```
 
-For string columns use `add_string_slice!` instead of `add_slice!`. Selection vectors
-are not supported for strings: Julia strings are non-contiguous, so the caller must
-build `str_ptrs`/`str_lens` arrays up-front — any row selection is applied on the Julia
-side before calling `add_string_slice!`.
+A `SliceBatch` is single-use: after `append_slice!` returns (Rust has copied all data),
+the source arrays may be released and the batch discarded.
 """
-mutable struct GatheredColumn
+mutable struct SliceBatch
     slices::Vector{SliceRef}
-    total_rows::Int
-    column_type::ColumnType
-    is_nullable::Bool
-    preserve::Vector{Any}   # source arrays kept alive until write
+    preserve::Vector{Any}
 end
 
-GatheredColumn(column_type::ColumnType; nullable::Bool=false) =
-    GatheredColumn(SliceRef[], 0, column_type, nullable, Any[])
+SliceBatch() = SliceBatch(SliceRef[], Any[])
 
 """
-    add_slice!(col::GatheredColumn, data::AbstractVector{T};
-               sel=nothing, validity=nothing)
+    push!(sb::SliceBatch, data::AbstractVector{T};
+          validity=nothing, sel=nothing)
 
-Append a slice of `data` to `col`.
+Add a non-string column slice to the batch.
 
-- `sel`: optional `Vector{Int64}` of 1-based row indices into `data` to select.
+- `validity`: optional `BitVector` where `true` = valid, `false` = null.
+- `sel`: optional `Vector{Int64}` of 1-based indices into `data` for scattered access.
   If omitted, all rows of `data` are used sequentially.
-- `validity`: optional `BitVector` (length = number of selected rows, `true` = valid).
-  Providing this marks the column as nullable.
 """
-function add_slice!(
-    col::GatheredColumn,
+function Base.push!(
+    sb::SliceBatch,
     data::AbstractVector{T};
-    sel::Union{Nothing, Vector{Int64}} = nothing,
     validity::Union{Nothing, BitVector} = nothing,
+    sel::Union{Nothing, Vector{Int64}} = nothing,
 ) where T
     len = sel === nothing ? length(data) : length(sel)
 
     sel_ptr = if sel !== nothing
-        push!(col.preserve, sel)
+        push!(sb.preserve, sel)
         pointer(sel)
     else
         Ptr{Int64}(C_NULL)
     end
 
     validity_ptr = if validity !== nothing
-        col.is_nullable = true
-        push!(col.preserve, validity)
+        push!(sb.preserve, validity)
         Ptr{UInt8}(pointer(validity.chunks))
     else
         Ptr{UInt8}(C_NULL)
     end
 
-    push!(col.preserve, data)
-    push!(col.slices, SliceRef(
+    push!(sb.preserve, data)
+    push!(sb.slices, SliceRef(
         Ptr{Cvoid}(pointer(data)),
-        Ptr{Int64}(C_NULL),   # lengths_ptr unused for non-string types
+        Ptr{Int64}(C_NULL),
         validity_ptr,
         sel_ptr,
         Csize_t(len),
     ))
-    col.total_rows += len
-    return col
+    return sb
 end
 
 """
-    add_string_slice!(col::GatheredColumn, strings::Vector{String}; validity=nothing)
+    push!(sb::SliceBatch, strings::Vector{String}; validity=nothing)
 
-Append a string slice to `col` from a plain `Vector{String}`.
+Add a string column slice to the batch.
 
-- `validity`: optional `BitVector` (`true` = valid, `false` = null). Marking a row null
-  does not require a placeholder in `strings`, but the vector must still be the same length.
-
-```julia
-col = GatheredColumn(COLUMN_TYPE_STRING; nullable=true)
-add_string_slice!(col, ["hello", "", "world"]; validity=BitVector([true, false, true]))
-```
-
-For performance-critical paths where pointer/length arrays are pre-allocated, use the
-lower-level `add_string_slice!(col, str_ptrs, str_lens; validity)` overload directly.
+- `validity`: optional `BitVector` where `true` = valid, `false` = null.
 """
-function add_string_slice!(
-    col::GatheredColumn,
+function Base.push!(
+    sb::SliceBatch,
     strings::Vector{String};
     validity::Union{Nothing, BitVector} = nothing,
 )
@@ -1002,160 +970,136 @@ function add_string_slice!(
             str_lens[i] = ncodeunits(strings[i])
         end
     end
-    push!(col.preserve, strings)  # keep String objects alive so pointers remain valid
-    return add_string_slice!(col, str_ptrs, str_lens; validity)
-end
-
-"""
-    add_string_slice!(col::GatheredColumn, str_ptrs, str_lens; validity=nothing)
-
-Low-level overload: append a string slice from pre-built pointer/length arrays.
-`str_ptrs` is a `Vector{Ptr{UInt8}}` of pointers to UTF-8 string data and `str_lens`
-is a `Vector{Int64}` of corresponding byte lengths. The caller is responsible for keeping
-the pointed-to string bytes alive until `write_columns` returns.
-"""
-function add_string_slice!(
-    col::GatheredColumn,
-    str_ptrs::Vector{Ptr{UInt8}},
-    str_lens::Vector{Int64};
-    validity::Union{Nothing, BitVector} = nothing,
-)
-    len = length(str_ptrs)
+    push!(sb.preserve, strings, str_ptrs, str_lens)
 
     validity_ptr = if validity !== nothing
-        col.is_nullable = true
-        push!(col.preserve, validity)
+        push!(sb.preserve, validity)
         Ptr{UInt8}(pointer(validity.chunks))
     else
         Ptr{UInt8}(C_NULL)
     end
 
-    push!(col.preserve, str_ptrs, str_lens)
-    push!(col.slices, SliceRef(
+    push!(sb.slices, SliceRef(
         Ptr{Cvoid}(pointer(str_ptrs)),
         pointer(str_lens),
         validity_ptr,
         Ptr{Int64}(C_NULL),
-        Csize_t(len),
+        Csize_t(n),
     ))
-    col.total_rows += len
-    return col
+    return sb
 end
 
 """
-    GatheredBatch
+    ColumnBatchBuilder
 
-Collects a `GatheredColumn` per output column, then writes all of them in one call.
+Opaque handle to a Rust-side incremental batch builder. Julia appends one slice per
+column per operator slice via `append_slice!`; Rust copies each slice's data immediately
+into owned typed buffers. When a coalesce window is full, `write_columns` finalises all
+columns into Arrow arrays, submits the `RecordBatch` to the async encode pool, and resets
+the builder in-place for the next window.
 
-```julia
-batch = GatheredBatch()
-push!(batch, col_int64)
-push!(batch, col_float64)
-write_columns(writer, batch)
-```
-
-You can also push a single-slice column inline without building a `GatheredColumn`
-explicitly:
-
-```julia
-batch = GatheredBatch()
-push!(batch, src_ints,   COLUMN_TYPE_INT64)
-push!(batch, src_floats, COLUMN_TYPE_FLOAT64; sel=indices, validity=valid_bv)
-write_columns(writer, batch)
-```
+Create with `ColumnBatchBuilder(writer, col_types)`. The builder is freed automatically
+by its finalizer, or explicitly with `free_builder!`.
 """
-mutable struct GatheredBatch
-    columns::Vector{GatheredColumn}
-end
+mutable struct ColumnBatchBuilder
+    ptr::Ptr{Cvoid}
 
-GatheredBatch() = GatheredBatch(GatheredColumn[])
+    function ColumnBatchBuilder(
+        writer::DataFileWriter,
+        col_types::Vector{ColumnType},
+    )
+        writer.ptr == C_NULL && throw(IcebergException("Writer has been freed"))
+        isempty(col_types) && throw(ArgumentError("col_types must not be empty"))
 
-"""
-    push!(batch::GatheredBatch, col::GatheredColumn)
+        col_type_codes = Int32[Int32(ct) for ct in col_types]
+        ptr = GC.@preserve col_type_codes begin
+            @ccall rust_lib.iceberg_batch_builder_new(
+                writer.ptr::Ptr{Cvoid},
+                pointer(col_type_codes)::Ptr{Int32},
+                length(col_type_codes)::Csize_t,
+            )::Ptr{Cvoid}
+        end
+        ptr == C_NULL && throw(IcebergException("iceberg_batch_builder_new failed"))
 
-Append an already-built `GatheredColumn` to the batch.
-"""
-Base.push!(batch::GatheredBatch, col::GatheredColumn) = (push!(batch.columns, col); batch)
-
-"""
-    push!(batch::GatheredBatch, data::AbstractVector, column_type::ColumnType;
-          sel=nothing, validity=nothing, nullable=false)
-
-Convenience: create a single-slice `GatheredColumn` from `data` and append it.
-"""
-function Base.push!(
-    batch::GatheredBatch,
-    data::AbstractVector,
-    column_type::ColumnType;
-    sel::Union{Nothing, Vector{Int64}} = nothing,
-    validity::Union{Nothing, BitVector} = nothing,
-    nullable::Bool = validity !== nothing,
-)
-    col = GatheredColumn(column_type; nullable)
-    add_slice!(col, data; sel, validity)
-    push!(batch.columns, col)
-    return batch
-end
-
-"""
-    write_columns(writer::DataFileWriter, batch::GatheredBatch[, extra_preserve])
-
-Gather column data from Julia memory synchronously, then encode asynchronously.
-
-Gathers all column data from Julia memory in the calling thread using a plain blocking
-`ccall`. Encode runs asynchronously in the global worker pool.
-
-`extra_preserve` (optional) is an additional collection of objects whose memory must
-stay alive during the gather (e.g. source string arrays for zero-copy string columns).
-
-The source data pointed to by the `GatheredBatch` slices and `extra_preserve` must be
-valid for the duration of this call. After the call returns, all Julia pointers have
-been consumed and the source data may be safely released.
-"""
-function write_columns(
-    writer::DataFileWriter,
-    batch::GatheredBatch,
-    extra_preserve = nothing,
-)
-    isempty(batch.columns) && throw(IcebergException("GatheredBatch has no columns"))
-    writer.ptr == C_NULL && throw(IcebergException("Writer has been freed"))
-
-    all_slice_arrays = Vector{Vector{SliceRef}}(undef, length(batch.columns))
-    descriptors = Vector{GatheredColumnDescriptor}(undef, length(batch.columns))
-    preserve = Any[]
-
-    for (i, col) in enumerate(batch.columns)
-        slices = col.slices
-        all_slice_arrays[i] = slices
-        append!(preserve, col.preserve)
-        push!(preserve, slices)
-        descriptors[i] = GatheredColumnDescriptor(
-            pointer(slices),
-            Csize_t(length(slices)),
-            Csize_t(col.total_rows),
-            Int32(col.column_type),
-            col.is_nullable,
-        )
+        b = new(ptr)
+        finalizer(free_builder!, b)
+        return b
     end
-    extra_preserve !== nothing && append!(preserve, extra_preserve)
+end
 
-    ret = GC.@preserve preserve all_slice_arrays descriptors begin
-        @ccall rust_lib.iceberg_writer_write_gathered_columns(
-            writer.ptr::Ptr{Cvoid},
-            pointer(descriptors)::Ptr{GatheredColumnDescriptor},
-            length(descriptors)::Csize_t,
+"""
+    free_builder!(builder::ColumnBatchBuilder)
+
+Free the builder without writing. Called automatically by the finalizer; also safe to
+call explicitly on error paths.
+"""
+function free_builder!(builder::ColumnBatchBuilder)
+    if builder.ptr != C_NULL
+        @ccall rust_lib.iceberg_batch_builder_free(builder.ptr::Ptr{Cvoid})::Cvoid
+        builder.ptr = C_NULL
+    end
+    return nothing
+end
+
+"""
+    append_slice!(builder::ColumnBatchBuilder, slices::Vector{SliceRef}, arrays_to_preserve)
+
+Append one slice per column to the builder. `slices[i]` describes column `i`'s data for
+this slice. Rust copies all data synchronously — source arrays referenced by the SliceRefs
+may be released (or overwritten) as soon as this call returns.
+
+`arrays_to_preserve` holds any Julia objects whose memory is pointed to by the SliceRefs
+(e.g. NullableVector backing arrays, string ptr/len buffers). They are GC-pinned only for
+the duration of this call.
+"""
+function append_slice!(
+    builder::ColumnBatchBuilder,
+    slices::Vector{SliceRef},
+    arrays_to_preserve,
+)
+    builder.ptr == C_NULL && throw(IcebergException("ColumnBatchBuilder has been freed"))
+    ret = GC.@preserve slices arrays_to_preserve begin
+        @ccall rust_lib.iceberg_batch_builder_append_slice(
+            builder.ptr::Ptr{Cvoid},
+            pointer(slices)::Ptr{SliceRef},
+            length(slices)::Csize_t,
         )::Int32
     end
-    if ret != 0
-        err_ptr = @ccall rust_lib.iceberg_take_gather_error()::Ptr{Cchar}
-        msg = if err_ptr != C_NULL
-            s = unsafe_string(err_ptr)
-            @ccall rust_lib.iceberg_destroy_cstring(err_ptr::Ptr{Cchar})::Cint
-            s
-        else
-            "gather failed (see writer close for details)"
-        end
-        throw(IcebergException("write_columns (gathered): $(msg)"))
-    end
+    ret == 0 || throw(IcebergException("append_slice! failed"))
+    return nothing
+end
+
+"""
+    append_slice!(builder::ColumnBatchBuilder, sb::SliceBatch)
+
+High-level overload: append one slice per column from a `SliceBatch`. Builds the
+`SliceRef` array and preserve list from the batch's accumulated column descriptors.
+
+```julia
+sb = SliceBatch()
+push!(sb, ids)
+push!(sb, values; validity=valid_bv)
+append_slice!(builder, sb)
+```
+"""
+function append_slice!(builder::ColumnBatchBuilder, sb::SliceBatch)
+    append_slice!(builder, sb.slices, sb.preserve)
+end
+
+"""
+    write_columns(writer::DataFileWriter, builder::ColumnBatchBuilder)
+
+Finalise the builder: assemble Arrow arrays from accumulated per-column buffers, build a
+`RecordBatch`, submit it to the async encode pool, and reset all column buffers for the
+next coalesce window. The builder is NOT freed and may be reused immediately.
+"""
+function write_columns(writer::DataFileWriter, builder::ColumnBatchBuilder)
+    writer.ptr == C_NULL && throw(IcebergException("Writer has been freed"))
+    builder.ptr == C_NULL && throw(IcebergException("ColumnBatchBuilder has been freed"))
+    ret = @ccall rust_lib.iceberg_batch_builder_write(
+        writer.ptr::Ptr{Cvoid},
+        builder.ptr::Ptr{Cvoid},
+    )::Int32
+    ret == 0 || throw(IcebergException("write_columns (builder) failed"))
     return nothing
 end

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -1450,14 +1450,13 @@ end
         @test tbl !== nothing
         @test length(tbl.id) == 1
 
-        row = tbl[1]
         # Arrow.jl collect() returns Dates.Date / Dates.DateTime for date/timestamp columns.
         # If the epoch offset is correct, these should round-trip to the original calendar values.
-        @test row.event_date == Dates.Date(2024, 1, 1)
-        println("✅ event_date = $(row.event_date) (expected 2024-01-01)")
+        @test tbl.event_date[1] == Dates.Date(2024, 1, 1)
+        println("✅ event_date = $(tbl.event_date[1]) (expected 2024-01-01)")
 
-        @test row.event_ts == Dates.DateTime(2024, 1, 1, 0, 0, 0)
-        println("✅ event_ts = $(row.event_ts) (expected 2024-01-01T00:00:00)")
+        @test tbl.event_ts[1] == Dates.DateTime(2024, 1, 1, 0, 0, 0)
+        println("✅ event_ts = $(tbl.event_ts[1]) (expected 2024-01-01T00:00:00)")
 
         RustyIceberg.free_table(updated_table)
 

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -1149,8 +1149,8 @@ end
     println("\n✅ write_columns decimal nullable tests completed!")
 end
 
-@testset "Writer write_columns (GatheredBatch) API" begin
-    println("Testing write_columns with GatheredBatch (gathered-column) API...")
+@testset "Writer ColumnBatchBuilder — multi-slice coalescing" begin
+    println("Testing ColumnBatchBuilder with multiple slices per column...")
 
     catalog_uri = get_catalog_uri()
     props = get_catalog_properties()
@@ -1165,7 +1165,7 @@ end
         catalog = RustyIceberg.catalog_create_rest(catalog_uri; properties=props)
         @test catalog !== nothing
 
-        test_namespace = ["test_gathered_$(round(Int, time() * 1000))"]
+        test_namespace = ["test_builder_multi_$(round(Int, time() * 1000))"]
         RustyIceberg.create_namespace(catalog, test_namespace)
 
         # Schema: id (non-nullable long), score (nullable double), tag (nullable string)
@@ -1175,60 +1175,56 @@ end
             Field(Int32(3), "tag",   IcebergString(); required=false),
         ])
 
-        table_name = "gathered_test_$(round(Int, time() * 1000))"
+        table_name = "builder_multi_$(round(Int, time() * 1000))"
         table = RustyIceberg.create_table(catalog, test_namespace, table_name, schema)
         @test table != C_NULL
         println("✅ Table created")
 
-        # --- Data layout (4 rows) ---
-        # id:    [1, 2, 3, 4]  — non-nullable, single sequential slice
-        # score: [1.1, null, 3.3, null]  — nullable; two sequential slices, each with validity
-        # tag:   ["alpha", null, "gamma", null]  — nullable string via add_string_slice!
+        # Write 4 rows across 3 separate append_slice! calls.
+        # id:    [1, 2, 3, 4]  — non-nullable; 3 slices of lengths 1, 2, 1
+        # score: [1.1, null, 3.3, null]  — nullable; 3 slices with validity
+        # tag:   ["alpha", null, "gamma", null]  — nullable string; 3 slices
+        #
+        # Slices are deliberately mis-aligned in terms of source array sizes to exercise
+        # the multi-slice accumulation path. Slice 2 for score uses a scattered sel_ptr.
+
+        col_types = RustyIceberg.ColumnType[
+            RustyIceberg.COLUMN_TYPE_INT64,
+            RustyIceberg.COLUMN_TYPE_FLOAT64,
+            RustyIceberg.COLUMN_TYPE_STRING,
+        ]
 
         data_files = RustyIceberg.with_data_file_writer(table) do writer
-            batch = RustyIceberg.GatheredBatch()
+            builder = RustyIceberg.ColumnBatchBuilder(writer, col_types)
 
-            # id: single sequential slice, no nulls
-            id_data = Int64[1, 2, 3, 4]
-            id_col = RustyIceberg.GatheredColumn(RustyIceberg.COLUMN_TYPE_INT64)
-            RustyIceberg.add_slice!(id_col, id_data)
-            push!(batch, id_col)
-            println("✅ id column built (sequential, non-nullable)")
+            # --- Slice 1: row 0 ---
+            sb1 = RustyIceberg.SliceBatch()
+            push!(sb1, Int64[1])
+            push!(sb1, Float64[1.1]; validity=BitVector([true]))
+            push!(sb1, ["alpha"])
+            RustyIceberg.append_slice!(builder, sb1)
+            println("✅ Slice 1 appended")
 
-            # score: two sequential slices, each with validity masks
-            # Slice 1 — src = [1.1, 9.9], validity = [true, false] → rows 0 (1.1) and 1 (null)
-            # Slice 2 — src = [3.3, 8.8] via selection [1] + identity [8.8] (just sequential here)
-            # Use scattered access for slice 2: src=[99.9, 3.3, 88.8], sel=[2] → picks 3.3
-            score_src1 = Float64[1.1, 9.9]
-            score_valid1 = BitVector([true, false])
+            # --- Slice 2: rows 1-2 (score uses a scattered selection) ---
+            # score_src: [99.9, 3.3, 88.8], sel=[2,1] → values [3.3, 99.9], valid=[true,false]
+            sb2 = RustyIceberg.SliceBatch()
+            push!(sb2, Int64[2, 3])
+            push!(sb2, Float64[99.9, 3.3, 88.8];
+                sel=Int64[2, 1], validity=BitVector([true, false]))
+            push!(sb2, ["", "gamma"]; validity=BitVector([false, true]))
+            RustyIceberg.append_slice!(builder, sb2)
+            println("✅ Slice 2 appended (scattered score, nullable strings)")
 
-            score_src2 = Float64[99.9, 3.3, 88.8]
-            score_sel2 = Int64[2]       # picks index 2 → 3.3 (1-based)
-            score_valid2 = BitVector([true])
+            # --- Slice 3: row 3 ---
+            sb3 = RustyIceberg.SliceBatch()
+            push!(sb3, Int64[4])
+            push!(sb3, Float64[0.0]; validity=BitVector([false]))
+            push!(sb3, [""]; validity=BitVector([false]))
+            RustyIceberg.append_slice!(builder, sb3)
+            println("✅ Slice 3 appended")
 
-            score_src3 = Float64[7.7, 8.8]
-            score_valid3 = BitVector([false])  # null for row 3
-
-            score_col = RustyIceberg.GatheredColumn(RustyIceberg.COLUMN_TYPE_FLOAT64; nullable=true)
-            RustyIceberg.add_slice!(score_col, score_src1; validity=score_valid1)
-            RustyIceberg.add_slice!(score_col, score_src2; sel=score_sel2, validity=score_valid2)
-            RustyIceberg.add_slice!(score_col, score_src3; sel=Int64[1], validity=score_valid3)
-            push!(batch, score_col)
-            println("✅ score column built (scattered + nullable)")
-
-            # tag: string column via the high-level add_string_slice! overload
-            # Row 0: "alpha", row 1: null, row 2: "gamma", row 3: null
-            tag_col = RustyIceberg.GatheredColumn(RustyIceberg.COLUMN_TYPE_STRING; nullable=true)
-            RustyIceberg.add_string_slice!(
-                tag_col,
-                ["alpha", "", "gamma", ""];
-                validity=BitVector([true, false, true, false])
-            )
-            push!(batch, tag_col)
-            println("✅ tag column built (string via add_string_slice!)")
-
-            RustyIceberg.write_columns(writer, batch)
-            println("✅ Batch written via write_columns (GatheredBatch)")
+            RustyIceberg.write_columns(writer, builder)
+            println("✅ Builder flushed via write_columns")
         end
         @test data_files !== nothing && data_files.ptr != C_NULL
         println("✅ Writer closed")
@@ -1247,22 +1243,19 @@ end
         println("✅ Read $(length(tbl.id)) rows")
 
         perm = sortperm(tbl.id)
-        sorted_ids   = tbl.id[perm]
+        sorted_ids    = tbl.id[perm]
         sorted_scores = tbl.score[perm]
-        sorted_tags  = tbl.tag[perm]
+        sorted_tags   = tbl.tag[perm]
 
-        # Verify id column (non-nullable, sequential)
         @test sorted_ids == Int64[1, 2, 3, 4]
         println("✅ id values correct")
 
-        # Verify score column (nullable, scattered slices)
         @test !ismissing(sorted_scores[1]) && sorted_scores[1] ≈ 1.1
         @test ismissing(sorted_scores[2])
         @test !ismissing(sorted_scores[3]) && sorted_scores[3] ≈ 3.3
         @test ismissing(sorted_scores[4])
-        println("✅ score values correct (including nulls)")
+        println("✅ score values correct (including nulls and scattered access)")
 
-        # Verify tag column (nullable string)
         @test !ismissing(sorted_tags[1]) && sorted_tags[1] == "alpha"
         @test ismissing(sorted_tags[2])
         @test !ismissing(sorted_tags[3]) && sorted_tags[3] == "gamma"
@@ -1289,7 +1282,201 @@ end
         end
     end
 
-    println("\n✅ write_columns (GatheredBatch) API tests completed!")
+    println("\n✅ ColumnBatchBuilder multi-slice tests completed!")
+end
+
+@testset "Writer ColumnBatchBuilder — reuse across windows" begin
+    println("Testing ColumnBatchBuilder reuse: two write_columns calls on one builder...")
+
+    catalog_uri = get_catalog_uri()
+    props = get_catalog_properties()
+
+    catalog = nothing
+    table = C_NULL
+    data_files = nothing
+    test_namespace = nothing
+    table_name = nothing
+
+    try
+        catalog = RustyIceberg.catalog_create_rest(catalog_uri; properties=props)
+        @test catalog !== nothing
+
+        test_namespace = ["test_builder_reuse_$(round(Int, time() * 1000))"]
+        RustyIceberg.create_namespace(catalog, test_namespace)
+
+        schema = Schema([
+            Field(Int32(1), "id",    IcebergLong();   required=true),
+            Field(Int32(2), "value", IcebergDouble(); required=false),
+        ])
+
+        table_name = "builder_reuse_$(round(Int, time() * 1000))"
+        table = RustyIceberg.create_table(catalog, test_namespace, table_name, schema)
+        @test table != C_NULL
+        println("✅ Table created")
+
+        col_types = RustyIceberg.ColumnType[
+            RustyIceberg.COLUMN_TYPE_INT64,
+            RustyIceberg.COLUMN_TYPE_FLOAT64,
+        ]
+
+        data_files = RustyIceberg.with_data_file_writer(table) do writer
+            builder = RustyIceberg.ColumnBatchBuilder(writer, col_types)
+
+            # Window 1: rows [1, 2]
+            sb1 = RustyIceberg.SliceBatch()
+            push!(sb1, Int64[1, 2])
+            push!(sb1, Float64[10.0, 20.0])
+            RustyIceberg.append_slice!(builder, sb1)
+            RustyIceberg.write_columns(writer, builder)   # flushes window 1, resets builder
+            println("✅ Window 1 written")
+
+            # Window 2: rows [3, 4, 5] — builder reused in-place
+            sb2 = RustyIceberg.SliceBatch()
+            push!(sb2, Int64[3, 4, 5])
+            push!(sb2, Float64[30.0, 40.0, 50.0])
+            RustyIceberg.append_slice!(builder, sb2)
+            RustyIceberg.write_columns(writer, builder)   # flushes window 2
+            println("✅ Window 2 written")
+        end
+        @test data_files !== nothing && data_files.ptr != C_NULL
+        println("✅ Writer closed")
+
+        updated_table = RustyIceberg.with_transaction(table, catalog) do tx
+            RustyIceberg.with_fast_append(tx) do action
+                RustyIceberg.add_data_files(action, data_files)
+            end
+        end
+        @test updated_table != C_NULL
+        println("✅ Transaction committed")
+
+        tbl = read_table_data(updated_table)
+        @test tbl !== nothing
+        @test length(tbl.id) == 5
+        println("✅ Read $(length(tbl.id)) rows")
+
+        perm = sortperm(tbl.id)
+        @test tbl.id[perm]    == Int64[1, 2, 3, 4, 5]
+        @test tbl.value[perm] == Float64[10.0, 20.0, 30.0, 40.0, 50.0]
+        println("✅ Data from both windows correct")
+
+        RustyIceberg.free_table(updated_table)
+
+    finally
+        if data_files !== nothing && data_files.ptr != C_NULL
+            RustyIceberg.free_data_files!(data_files)
+        end
+        if table != C_NULL
+            RustyIceberg.free_table(table)
+        end
+        if table_name !== nothing && test_namespace !== nothing && catalog !== nothing
+            RustyIceberg.drop_table(catalog, test_namespace, table_name)
+        end
+        if test_namespace !== nothing && catalog !== nothing
+            RustyIceberg.drop_namespace(catalog, test_namespace)
+        end
+        if catalog !== nothing
+            RustyIceberg.free_catalog!(catalog)
+        end
+    end
+
+    println("\n✅ ColumnBatchBuilder reuse tests completed!")
+end
+
+@testset "Writer ColumnBatchBuilder — date and timestamp epoch conversion" begin
+    println("Testing ColumnBatchBuilder date/timestamp epoch conversion...")
+
+    catalog_uri = get_catalog_uri()
+    props = get_catalog_properties()
+
+    catalog = nothing
+    table = C_NULL
+    data_files = nothing
+    test_namespace = nothing
+    table_name = nothing
+
+    try
+        catalog = RustyIceberg.catalog_create_rest(catalog_uri; properties=props)
+        @test catalog !== nothing
+
+        test_namespace = ["test_builder_dates_$(round(Int, time() * 1000))"]
+        RustyIceberg.create_namespace(catalog, test_namespace)
+
+        schema = Schema([
+            Field(Int32(1), "id",         IcebergLong();      required=true),
+            Field(Int32(2), "event_date", IcebergDate();      required=true),
+            Field(Int32(3), "event_ts",   IcebergTimestamp(); required=true),
+        ])
+
+        table_name = "builder_dates_$(round(Int, time() * 1000))"
+        table = RustyIceberg.create_table(catalog, test_namespace, table_name, schema)
+        @test table != C_NULL
+        println("✅ Table created")
+
+        # 2024-01-01 in Julia Date internal representation (Rata Die days, 1-based)
+        # Dates.value(Date(2024,1,1)) = 738886
+        # Expected Iceberg Date32 (days since 1970-01-01) = 738886 - 719163 = 19723
+        # Expected Iceberg timestamp (μs since 1970-01-01) = 19723 * 86400 * 1_000_000 = 1_704_067_200_000_000
+        julia_date_val = Dates.value(Dates.Date(2024, 1, 1))   # 738886
+        julia_ts_val   = Dates.value(Dates.DateTime(2024, 1, 1, 0, 0, 0))  # ms since year 1
+
+        col_types = RustyIceberg.ColumnType[
+            RustyIceberg.COLUMN_TYPE_INT64,
+            RustyIceberg.COLUMN_TYPE_JULIA_DATE,
+            RustyIceberg.COLUMN_TYPE_JULIA_TIMESTAMP,
+        ]
+
+        data_files = RustyIceberg.with_data_file_writer(table) do writer
+            builder = RustyIceberg.ColumnBatchBuilder(writer, col_types)
+
+            sb = RustyIceberg.SliceBatch()
+            push!(sb, Int64[1])
+            push!(sb, Int64[julia_date_val])
+            push!(sb, Int64[julia_ts_val])
+            RustyIceberg.append_slice!(builder, sb)
+            RustyIceberg.write_columns(writer, builder)
+            println("✅ Date/timestamp slice written")
+        end
+        @test data_files !== nothing && data_files.ptr != C_NULL
+
+        updated_table = RustyIceberg.with_transaction(table, catalog) do tx
+            RustyIceberg.with_fast_append(tx) do action
+                RustyIceberg.add_data_files(action, data_files)
+            end
+        end
+        @test updated_table != C_NULL
+
+        tbl = read_table_data(updated_table)
+        @test tbl !== nothing
+        @test length(tbl.id) == 1
+
+        row = tbl[1]
+        @test Int64(row.event_date.x) == 19723
+        println("✅ event_date = $(row.event_date.x) (expected 19723)")
+
+        @test row.event_ts.x == 1_704_067_200_000_000
+        println("✅ event_ts = $(row.event_ts.x) (expected 1_704_067_200_000_000 μs)")
+
+        RustyIceberg.free_table(updated_table)
+
+    finally
+        if data_files !== nothing && data_files.ptr != C_NULL
+            RustyIceberg.free_data_files!(data_files)
+        end
+        if table != C_NULL
+            RustyIceberg.free_table(table)
+        end
+        if table_name !== nothing && test_namespace !== nothing && catalog !== nothing
+            RustyIceberg.drop_table(catalog, test_namespace, table_name)
+        end
+        if test_namespace !== nothing && catalog !== nothing
+            RustyIceberg.drop_namespace(catalog, test_namespace)
+        end
+        if catalog !== nothing
+            RustyIceberg.free_catalog!(catalog)
+        end
+    end
+
+    println("\n✅ ColumnBatchBuilder date/timestamp tests completed!")
 end
 
 @testset "Writer WriterConfig parquet properties" begin

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -1250,9 +1250,10 @@ end
         @test sorted_ids == Int64[1, 2, 3, 4]
         println("✅ id values correct")
 
+        # sel=[2,1] on [99.9, 3.3, 88.8] → row0=src[2]=3.3 (valid), row1=src[1]=99.9 (null)
         @test !ismissing(sorted_scores[1]) && sorted_scores[1] ≈ 1.1
-        @test ismissing(sorted_scores[2])
-        @test !ismissing(sorted_scores[3]) && sorted_scores[3] ≈ 3.3
+        @test !ismissing(sorted_scores[2]) && sorted_scores[2] ≈ 3.3
+        @test ismissing(sorted_scores[3])
         @test ismissing(sorted_scores[4])
         println("✅ score values correct (including nulls and scattered access)")
 
@@ -1450,11 +1451,13 @@ end
         @test length(tbl.id) == 1
 
         row = tbl[1]
-        @test Int64(row.event_date.x) == 19723
-        println("✅ event_date = $(row.event_date.x) (expected 19723)")
+        # Arrow.jl collect() returns Dates.Date / Dates.DateTime for date/timestamp columns.
+        # If the epoch offset is correct, these should round-trip to the original calendar values.
+        @test row.event_date == Dates.Date(2024, 1, 1)
+        println("✅ event_date = $(row.event_date) (expected 2024-01-01)")
 
-        @test row.event_ts.x == 1_704_067_200_000_000
-        println("✅ event_ts = $(row.event_ts.x) (expected 1_704_067_200_000_000 μs)")
+        @test row.event_ts == Dates.DateTime(2024, 1, 1, 0, 0, 0)
+        println("✅ event_ts = $(row.event_ts) (expected 2024-01-01T00:00:00)")
 
         RustyIceberg.free_table(updated_table)
 

--- a/test/writer_tests.jl
+++ b/test/writer_tests.jl
@@ -1450,13 +1450,13 @@ end
         @test tbl !== nothing
         @test length(tbl.id) == 1
 
-        # Arrow.jl collect() returns Dates.Date / Dates.DateTime for date/timestamp columns.
-        # If the epoch offset is correct, these should round-trip to the original calendar values.
-        @test tbl.event_date[1] == Dates.Date(2024, 1, 1)
-        println("✅ event_date = $(tbl.event_date[1]) (expected 2024-01-01)")
+        # Arrow.jl returns Arrow.Date / Arrow.Timestamp wrappers with a raw integer in .x.
+        # Check the raw values directly to verify the Julia→Unix epoch offset is correct.
+        @test tbl.event_date[1].x == Int32(19723)     # 2024-01-01 = day 19723 since 1970-01-01
+        println("✅ event_date.x = $(tbl.event_date[1].x) (expected 19723)")
 
-        @test tbl.event_ts[1] == Dates.DateTime(2024, 1, 1, 0, 0, 0)
-        println("✅ event_ts = $(tbl.event_ts[1]) (expected 2024-01-01T00:00:00)")
+        @test tbl.event_ts[1].x == Int64(1_704_067_200_000_000)  # 2024-01-01T00:00:00 in μs
+        println("✅ event_ts.x = $(tbl.event_ts[1].x) (expected 1_704_067_200_000_000)")
 
         RustyIceberg.free_table(updated_table)
 


### PR DESCRIPTION
## Summary

- **Retire `GatheredColumn`/`GatheredBatch` API** — removed ~350 lines of Julia and Rust code. The old gather API accumulated slices in Julia memory before writing; all callers now use `ColumnBatchBuilder` directly.
- **Route `ColumnBatch` writes through `ColumnBatchBuilder` internally** — `write_columns_inner` in Rust now uses the builder instead of the retired `build_arrow_array_gathered` path, making `ColumnBatchBuilder` the single canonical copy path.
- **New `SliceBatch` Julia API** — high-level wrapper that constructs `SliceRef` structs from plain Julia arrays, so users don't need to manage raw pointers.
- **New writer tests** — three integration tests covering multi-slice coalescing, builder reuse across windows, and Julia→Unix epoch conversion for date/timestamp columns.
- **`batch_builder.rs` cleanup** — extracted `append_primitive!` and `append_transform!` macros, reducing `append_numeric` from 147 to 35 lines; merged duplicate `JULIA_DATE`/`JULIA_TIMESTAMP`/`JULIA_TIMESTAMPTZ` finalize arms with their non-Julia counterparts (−67 lines total).