### PR TITLE
Update CI to run FFI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,3 +34,31 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
         working-directory: iceberg_rust_ffi
+
+  rust-clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./iceberg_rust_ffi
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -D warnings
+        working-directory: iceberg_rust_ffi
+
+  rust-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./iceberg_rust_ffi
+      - name: Run Rust unit tests
+        # --no-default-features skips the `julia` feature, which declares
+        # extern "C" Julia symbols that require the Julia runtime to link.
+        run: cargo test --no-default-features
+        working-directory: iceberg_rust_ffi

--- a/iceberg_rust_ffi/src/catalog.rs
+++ b/iceberg_rust_ffi/src/catalog.rs
@@ -207,7 +207,6 @@ pub struct IcebergCatalog {
 unsafe impl Send for IcebergCatalog {}
 unsafe impl Sync for IcebergCatalog {}
 
-
 impl IcebergCatalog {
     /// Create and initialize a REST catalog with optional authenticator
     pub async fn create_rest(

--- a/iceberg_rust_ffi/src/catalog.rs
+++ b/iceberg_rust_ffi/src/catalog.rs
@@ -185,6 +185,7 @@ enum CatalogKind {
 /// Opaque catalog handle for FFI.
 /// Stores the catalog backend plus any pre-creation configuration (authenticator,
 /// credentials-loader flag).
+#[derive(Default)]
 pub struct IcebergCatalog {
     /// `None` while the catalog is being configured (before `create_rest` /
     /// `create_memory` is called). Using `Option` here rather than adding an
@@ -206,15 +207,6 @@ pub struct IcebergCatalog {
 unsafe impl Send for IcebergCatalog {}
 unsafe impl Sync for IcebergCatalog {}
 
-impl Default for IcebergCatalog {
-    fn default() -> Self {
-        IcebergCatalog {
-            kind: None,
-            authenticator: None,
-            use_credentials_loader: false,
-        }
-    }
-}
 
 impl IcebergCatalog {
     /// Create and initialize a REST catalog with optional authenticator
@@ -433,6 +425,7 @@ impl IcebergCatalog {
 
     /// Internal method to create a table with optional credential vending
     /// Create a new table in the catalog with optional credential vending
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_table(
         &self,
         namespace_parts: Vec<String>,

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -121,18 +121,10 @@ impl RawResponse for IcebergResponse {
 }
 
 // Simple config for iceberg - only what we need
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 #[repr(C)]
 pub struct IcebergStaticConfig {
     n_threads: usize,
-}
-
-impl Default for IcebergStaticConfig {
-    fn default() -> Self {
-        IcebergStaticConfig {
-            n_threads: 0, // 0 means use tokio's default
-        }
-    }
 }
 
 // FFI structure for passing key-value properties
@@ -201,7 +193,7 @@ pub extern "C" fn iceberg_init_runtime(
     result_callback: ResultCallback,
 ) -> CResult {
     // Set the result callback
-    if let Err(_) = RESULT_CB.set(result_callback) {
+    if RESULT_CB.set(result_callback).is_err() {
         return CResult::Error; // Already initialized
     }
 

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -148,7 +148,6 @@ impl RawResponse for IcebergFileScanResponse {
 }
 
 /// Synchronous operations for table and batch management
-
 /// Free a table
 #[no_mangle]
 pub extern "C" fn iceberg_table_free(table: *mut IcebergTable) {

--- a/iceberg_rust_ffi/src/writer_columns.rs
+++ b/iceberg_rust_ffi/src/writer_columns.rs
@@ -113,7 +113,7 @@ unsafe fn build_null_buffer_gathered(slices: &[SliceRef], total_rows: usize) -> 
     if !slices.iter().any(|s| !s.validity_ptr.is_null()) {
         return None;
     }
-    let mut bits = vec![0u8; (total_rows + 7) / 8];
+    let mut bits = vec![0u8; total_rows.div_ceil(8)];
     let mut out = 0usize;
     for slice in slices {
         if slice.validity_ptr.is_null() {
@@ -217,7 +217,7 @@ pub(crate) unsafe fn build_arrow_array_gathered(
             )
         }
         COLUMN_TYPE_BOOLEAN => {
-            let mut bits = vec![0u8; (total + 7) / 8];
+            let mut bits = vec![0u8; total.div_ceil(8)];
             let mut out = 0usize;
             for slice in slices {
                 let src = slice.data_ptr as *const u8;


### PR DESCRIPTION
We missed to run the Rust FFI tests as of a short time ago there simply were none. This executes FFI tests during CI builds. Also adds clippy runs and fixes clippy errors