### PR TITLE
Bump iceberg_rust_ffi_jll compat to 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Arrow = "2.0"
 FunctionWrappers = "1"
 JSON = "0.21"
 Preferences = "1.3"
-iceberg_rust_ffi_jll = "0.7"
+iceberg_rust_ffi_jll = "0.8"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

- Bumps `iceberg_rust_ffi_jll` compat from `"0.7"` to `"0.8"` now that `v0.8.0+0` is published in the registry
- This unblocks `make test` (non-dev) and the `release.yml` / `TagBot.yml` workflows which test against the published JLL rather than a local build

## Test plan

- [ ] CI passes with `build_rust: true` (existing behaviour)
- [ ] `make test` resolves and runs against the published `0.8.0+0` JLL

🤖 Generated with [Claude Code](https://claude.com/claude-code)