### PR TITLE
Consolidate scan tuning params into one IcebergPerfConfig (by-value)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustyIceberg"
 uuid = "390bdf5b-b624-43dc-a846-0ef7a3405804"
-version = "0.8.3"
+version = "0.9.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
@@ -15,7 +15,7 @@ Arrow = "2.0"
 FunctionWrappers = "1"
 JSON = "0.21"
 Preferences = "1.3"
-iceberg_rust_ffi_jll = "0.8"
+iceberg_rust_ffi_jll = "0.9"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This package wraps the iceberg_rust_ffi interface with Julia bindings, providing
 ## Scan tuning (`IcebergPerfConfig`)
 
 All scan tuning knobs (batch size, manifest concurrency, file prefetch depth,
-serialization concurrency) live in a single struct, [`IcebergPerfConfig`], which is
-**the authoritative source of every tuning default**. It is passed by value at scan
-construction:
+serialization concurrency, and per-file output-buffer limits) live in a single struct,
+[`IcebergPerfConfig`], which is **the authoritative source of every tuning default**.
+It is passed by value at scan construction:
 
 ```julia
 scan = new_scan(table, IcebergPerfConfig())                 # all defaults

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ A Julia package that provides bindings on top of Iceberg Rust crate, allowing yo
 
 This package wraps the iceberg_rust_ffi interface with Julia bindings, providing Julia interfaces for working with Iceberg tables. It supports reading data from Iceberg tables in full-scan and incremental-scan modes.
 
+## Scan tuning (`IcebergPerfConfig`)
+
+All scan tuning knobs (batch size, manifest concurrency, file prefetch depth,
+serialization concurrency) live in a single struct, [`IcebergPerfConfig`], which is
+**the authoritative source of every tuning default**. It is passed by value at scan
+construction:
+
+```julia
+scan = new_scan(table, IcebergPerfConfig())                 # all defaults
+scan = new_scan(table, IcebergPerfConfig(batch_size=1024))  # override one knob
+inc  = new_incremental_scan(table, from, to, IcebergPerfConfig())
+```
+
+There are no per-knob `with_*!` setters and no hidden defaults on the Rust side: the
+configuration is fixed at construction and the Rust layer consumes whatever Julia
+supplies. See the `IcebergPerfConfig` docstring for the full per-parameter
+documentation and the pipeline architecture. The struct is binary-compatible with the
+Rust `IcebergPerfConfigFFI` mirror; a round-trip test (`perf_config_tests.jl`) guards
+the layout.
+
 ## Installation
 1. Install the package in Julia:
 ```julia

--- a/iceberg_rust_ffi/Cargo.lock
+++ b/iceberg_rust_ffi/Cargo.lock
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg_rust_ffi"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceberg_rust_ffi"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/iceberg_rust_ffi/docs/pipeline-unification.md
+++ b/iceberg_rust_ffi/docs/pipeline-unification.md
@@ -43,7 +43,7 @@ called `with_batch_size!` before scanning.
 
 | File | Role |
 |---|---|
-| `src/nested_pipeline.rs` | Shared core: `create_nested_pipeline<S, Src>`, `spawn_file_task<S, BSF>`, `process_file`, `serialize_and_forward_batches`, `make_file_stream`, `build_reader`, `BufferedBatch`, `FileScan`, the `FileToScan<S>` handoff struct, constants (`MAX_PREFETCH_BUFFERS_OF_WAITING_FILE=1`, `MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE=8`), and orchestration tests (which feed `FileToScan` values with an empty batch-stream builder). |
+| `src/nested_pipeline.rs` | Shared core: `create_nested_pipeline<S, Src>`, `spawn_file_task<S, BSF>`, `process_file`, `serialize_and_forward_batches`, `make_file_stream`, `build_reader`, `BufferedBatch`, `FileScan`, the `FileToScan<S>` handoff struct, the `BufferLimits` carrier (per-scan byte budget + waiting/active slot budgets, supplied by Julia via `IcebergPerfConfig`), and orchestration tests (which feed `FileToScan` values with an empty batch-stream builder). |
 | `src/full_pipeline.rs` | Full-scan entries: `create_full_scan_pipeline` (nested FFI) and `create_pipeline` (legacy flat-FFI wrapper = nested + `try_flatten` + inline `slot_sem` promotion). Per-file helper `read_one_full_scan_file`. Real-parquet end-to-end tests live here. |
 | `src/incremental_pipeline.rs` | Incremental-append entry: `create_incremental_nested_pipeline`. Pulls the same shared helpers, adds `read_one_append_file` + delete-stream glue. Real-parquet tests live here. |
 
@@ -207,10 +207,10 @@ Now genuinely *shared* (one body, called by both):
 * `build_reader` — `ArrowReaderBuilder` with the configured `batch_size`
   and per-file concurrency pinned to 1.
 * `BufferedBatch`, `FileScan` — the in-flight types.
-* `MAX_PREFETCH_BUFFERS_OF_WAITING_FILE` / `MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE`
-  — the two-tier slot cap, including the FFI handoff promotion at
-  `IcebergFileScanResponse::set_payload`.
-* `MAX_BUFFERED_BYTES_PER_TASK` (in `pipeline_stats.rs`) — the byte_sem cap.
+* `BufferLimits` — per-scan tuning, supplied by Julia via `IcebergPerfConfig`
+  and threaded through `create_nested_pipeline`/`spawn_file_task`:
+  the waiting/active two-tier slot budget (including the FFI handoff promotion
+  at `IcebergFileScanResponse::set_payload`) and the `byte_sem` cap.
 * Stats counters: every `STATS.*` field is written from the shared code, so
   the incremental pipeline now correctly populates `reader_setup_ns`,
   `peak_concurrency`, `buffered_bytes`, etc. (At master, three of these
@@ -251,17 +251,19 @@ and not yet drained. With one serial consumer, `M = 1` and the cap is
 `create_full_scan_pipeline_caps_in_flight_at_prefetch_depth_plus_one`
 pins this down). Julia's `ICEBERG_FILE_TASK_GROUP` uses `M = nthreads()`.
 
-Memory per file is capped at ~100 MB by `byte_sem`. Slot count per file is
-capped at `MAX_PREFETCH_BUFFERS_OF_WAITING_FILE = 1` while waiting in the
-outer buffer (only one batch ahead before the FFI consumer picks the file
-up), promoted to `MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE = 8` once the FFI
-consumer has called `iceberg_next_file_scan`. The promotion prevents
+Memory per file is capped by `byte_sem` at `BufferLimits::max_buffered_bytes_per_task`
+(default 100 MB). Slot count per file is capped at
+`BufferLimits::max_prefetch_buffers_of_waiting_file` (default 1) while waiting in
+the outer buffer (only one batch ahead before the FFI consumer picks the file
+up), promoted to `BufferLimits::max_prefetch_buffers_of_active_file` (default 8)
+once the FFI consumer has called `iceberg_next_file_scan`. The promotion prevents
 serialized bytes from accumulating in front of files that may never get
-drained (e.g. cancelled scans, slow consumers).
+drained (e.g. cancelled scans, slow consumers). All three are per-scan knobs
+supplied by Julia via `IcebergPerfConfig`.
 
 ### Backpressure clamp for oversized batches
 
-The byte semaphore has `MAX_BUFFERED_BYTES_PER_TASK` permits. A single
+The byte semaphore has `BufferLimits::max_buffered_bytes_per_task` permits. A single
 serialized batch larger than that would deadlock `byte_sem.acquire_many`,
 since the requested permit count can never be reached. To prevent that,
 `serialize_and_forward_batches` clamps the per-batch backpressure cost
@@ -331,8 +333,8 @@ serialized Arrow IPC in its per-file mpsc.
 Net consequences:
 
 * **Memory was much higher than the knob suggested.** Each alive
-  `process_file` task can buffer up to `MAX_BUFFERED_BYTES_PER_TASK`
-  (100 MB) of serialized IPC. With the master defaults, peak in-flight
+  `process_file` task can buffer up to `max_buffered_bytes_per_task`
+  (default 100 MB) of serialized IPC. With the master defaults, peak in-flight
   bytes were on the order of `(concurrency + prefetch_depth) × 100 MB`
   ≈ ~1.2 GB on a 4-thread default — not the `concurrency × 100 MB` a
   reader would infer.
@@ -534,13 +536,12 @@ These are not done on this branch; flagging them for future work.
   flat wrapper would simplify `full_pipeline.rs` by deleting
   `create_pipeline` and the inline `slot_sem` promotion. Blocked on
   confirming no out-of-tree consumers.
-* **Expose `byte_budget` and the slot constants as FFI-tunable knobs.**
-  `byte_budget` is already a parameter on `serialize_and_forward_batches`
-  / `process_file` / `process_file_inner` (so the oversized-batch
-  regression test can use a tiny budget), but `spawn_file_task` still
-  hardcodes it to `MAX_BUFFERED_BYTES_PER_TASK`. The slot constants are
-  still compile-time. Some Julia workloads (very wide schemas, small
-  batch sizes) might benefit from a different mix.
+* ~~**Expose `byte_budget` and the slot constants as FFI-tunable knobs.**~~
+  *Done (RAI-50776):* the byte budget and both slot budgets are now per-scan
+  fields on `BufferLimits`, supplied by Julia via `IcebergPerfConfig`
+  (`max_buffered_bytes_per_task`, `max_prefetch_buffers_of_waiting_file`,
+  `max_prefetch_buffers_of_active_file`) and threaded through
+  `create_nested_pipeline` → `spawn_file_task`. No compile-time constants remain.
 * **Per-pipeline stats namespaces.** Right now `STATS` is process-global
   and reset inside `create_nested_pipeline`. If two scans run concurrently
   in the same process the counters interleave. Currently irrelevant

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -14,8 +14,11 @@ use object_store_ffi::{
 };
 
 /// Holds state for a full table scan across its lifecycle:
-///   1. Construction: `builder` is set, everything else is None/0.
-///   2. Configuration: Julia calls with_* methods that transform `builder`.
+///   1. Construction: `builder` is set from the table + perf config; the perf
+///      fields (`batch_size`, `file_prefetch_depth`, `serialization_concurrency`)
+///      are stored on the struct.
+///   2. Configuration: Julia calls non-perf with_* methods (select, file/pos
+///      column, snapshot id) that transform `builder`.
 ///   3. Build: `builder` is consumed → `scan` is populated.
 ///   4. Stream: `scan` + `file_io` + `batch_size` are consumed by
 ///      `iceberg_arrow_stream` to create the file-parallel pipeline.
@@ -23,57 +26,58 @@ use object_store_ffi::{
 pub struct IcebergScan {
     pub builder: Option<TableScanBuilder<'static>>,
     pub scan: Option<TableScan>,
-    /// Dead field kept for FFI ABI compatibility and shape-symmetry with
-    /// `IncrementalScan` (whose twin *is* still used, but only for the
-    /// incremental delete-stream's parallel serialization — the per-file
-    /// append/full pipeline uses `tokio::task::spawn_blocking` directly,
-    /// with parallelism implicitly bounded by `file_prefetch_depth`).
-    /// The FFI setter `iceberg_scan_with_serialization_concurrency_limit`
-    /// writes this field, but nothing reads it.
+    /// Dead field kept for shape-symmetry with `IncrementalScan` (whose twin
+    /// *is* still used, but only for the incremental delete-stream's parallel
+    /// serialization — the per-file append/full pipeline uses
+    /// `tokio::task::spawn_blocking` directly, with parallelism implicitly
+    /// bounded by `file_prefetch_depth`). Populated from the perf config at
+    /// construction, but nothing reads it on the full-scan path.
     pub serialization_concurrency: usize,
     /// Cloned from the Table at construction time. Passed to the pipeline so
     /// each per-file ArrowReader can open its own parquet file.
     pub file_io: FileIO,
-    /// Set by Julia via `iceberg_scan_with_batch_size`. Required: the FFI
-    /// stream ops error out if this is still `None` at stream-creation time.
-    /// Forwarded to each per-file `ArrowReaderBuilder` inside the pipeline.
-    pub batch_size: Option<usize>,
-    /// Dead field kept for FFI ABI compatibility and shape-symmetry with
-    /// `IncrementalScan` (whose `file_concurrency` is likewise dead — both
-    /// pipelines are now bounded by `file_prefetch_depth` alone via
-    /// `Stream::buffered`). The FFI setter
-    /// `iceberg_scan_with_data_file_concurrency_limit` is a no-op and
-    /// does not write here; nothing reads this. Removing it would force
-    /// `scan_common.rs` macros to switch to functional-record-update
-    /// just to skip one field on one of the two structs they handle.
-    pub file_concurrency: usize,
+    /// Set from the perf config at construction. Forwarded to each per-file
+    /// `ArrowReaderBuilder` inside the pipeline.
+    pub batch_size: usize,
     /// How many FileScan items the full-scan pipeline keeps in flight (i.e.
-    /// `Stream::buffered(prefetch_depth)`). 0 = auto (= cpu_count()). This is
-    /// the only concurrency knob; see `nested_pipeline`'s module-level
-    /// "Concurrency invariant" doc for the cap on alive `process_file` tasks.
+    /// `Stream::buffered(prefetch_depth)`). Supplied verbatim by Julia (the
+    /// single source of tuning defaults) and used as-is. See `nested_pipeline`'s
+    /// module-level "Concurrency invariant" doc for the cap on alive
+    /// `process_file` tasks.
     pub file_prefetch_depth: usize,
 }
 
 unsafe impl Send for IcebergScan {}
 
-/// Create a new scan builder from an opened table.
-/// Captures `file_io` from the table for later use by the pipeline.
+/// Create a new scan from an opened table and a complete `IcebergPerfConfigFFI`
+/// (supplied by Julia — the single source of tuning defaults). The manifest
+/// concurrency knobs and batch size are applied to the iceberg-rs builder here;
+/// `batch_size` / `file_prefetch_depth` / `serialization_concurrency` are also
+/// stored on the struct for the pipeline to read. Captures `file_io` from the
+/// table for later use by the pipeline.
 #[no_mangle]
-pub extern "C" fn iceberg_new_scan(table: *mut IcebergTable) -> *mut IcebergScan {
+pub extern "C" fn iceberg_new_scan(
+    table: *mut IcebergTable,
+    perf: IcebergPerfConfigFFI,
+) -> *mut IcebergScan {
     if table.is_null() {
         return ptr::null_mut();
     }
     let table_ref = unsafe { &*table };
     let file_io = table_ref.table.file_io().clone();
-    let scan_builder = table_ref.table.scan();
+    let scan_builder = table_ref
+        .table
+        .scan()
+        .with_batch_size(Some(perf.batch_size as usize))
+        .with_manifest_file_concurrency_limit(perf.manifest_file_concurrency_limit as usize)
+        .with_manifest_entry_concurrency_limit(perf.manifest_entry_concurrency_limit as usize);
     Box::into_raw(Box::new(IcebergScan {
         builder: Some(scan_builder),
         scan: None,
-        serialization_concurrency: 0,
+        serialization_concurrency: perf.serialization_concurrency_limit as usize,
         file_io,
-        batch_size: None,
-        file_concurrency: 0,
-        file_prefetch_depth: 0,
+        batch_size: perf.batch_size as usize,
+        file_prefetch_depth: perf.file_prefetch_depth as usize,
     }))
 }
 
@@ -81,51 +85,11 @@ pub extern "C" fn iceberg_new_scan(table: *mut IcebergTable) -> *mut IcebergScan
 
 impl_select_columns!(iceberg_select_columns, IcebergScan);
 
-/// FFI-stable no-op kept for API compatibility with Julia callers. The
-/// full-scan pipeline used to take this as a separate concurrency cap, but
-/// it overlapped with `file_prefetch_depth` and is now replaced by
-/// `Stream::buffered(prefetch_depth)`. The iceberg-rs scan builder's own
-/// `with_data_file_concurrency_limit` only affects `to_arrow()` (which we
-/// don't call — we use `plan_files()` directly), so forwarding is unnecessary.
-#[no_mangle]
-pub extern "C" fn iceberg_scan_with_data_file_concurrency_limit(
-    scan: &mut *mut IcebergScan,
-    _n: usize,
-) -> CResult {
-    if scan.is_null() || (*scan).is_null() {
-        return CResult::Error;
-    }
-    CResult::Ok
-}
-
-impl_scan_builder_method!(
-    iceberg_scan_with_manifest_file_concurrency_limit,
-    IcebergScan,
-    with_manifest_file_concurrency_limit,
-    n: usize
-);
-
-impl_scan_builder_method!(
-    iceberg_scan_with_manifest_entry_concurrency_limit,
-    IcebergScan,
-    with_manifest_entry_concurrency_limit,
-    n: usize
-);
-
-impl_with_batch_size!(iceberg_scan_with_batch_size, IcebergScan);
-
 impl_scan_builder_method!(iceberg_scan_with_file_column, IcebergScan, with_file_column);
 
 impl_scan_builder_method!(iceberg_scan_with_pos_column, IcebergScan, with_pos_column);
 
 impl_scan_build!(iceberg_scan_build, IcebergScan);
-
-impl_with_serialization_concurrency_limit!(
-    iceberg_scan_with_serialization_concurrency_limit,
-    IcebergScan
-);
-
-impl_with_file_prefetch_depth!(iceberg_scan_with_file_prefetch_depth, IcebergScan);
 
 impl_scan_builder_method!(
     iceberg_scan_with_snapshot_id,
@@ -145,20 +109,15 @@ impl_scan_builder_method!(
 //      yields batches in strict file-then-row order.
 
 /// Resolve the pipeline tuning parameters from a configured scan.
-/// Returns `(prefetch_depth, file_io, batch_size)`. A stored
-/// `file_prefetch_depth` of 0 means "auto" → defaults to `cpu_count()`.
-/// `batch_size` must have been set via `iceberg_scan_with_batch_size`;
-/// otherwise the FFI op returns an error.
+/// Returns `(prefetch_depth, file_io, batch_size)`. Both `file_prefetch_depth`
+/// and `batch_size` are supplied verbatim by Julia at construction (the single
+/// source of tuning defaults) and used as-is — there is no "0 = auto" fallback.
 fn resolve_pipeline_params(scan: &IcebergScan) -> anyhow::Result<(usize, FileIO, usize)> {
-    let prefetch_depth = if scan.file_prefetch_depth == 0 {
-        crate::cpu_count()
-    } else {
-        scan.file_prefetch_depth
-    };
-    let batch_size = scan.batch_size.ok_or_else(|| {
-        anyhow::anyhow!("batch_size not set; call iceberg_scan_with_batch_size before scan")
-    })?;
-    Ok((prefetch_depth, scan.file_io.clone(), batch_size))
+    Ok((
+        scan.file_prefetch_depth,
+        scan.file_io.clone(),
+        scan.batch_size,
+    ))
 }
 
 export_runtime_op!(

--- a/iceberg_rust_ffi/src/full.rs
+++ b/iceberg_rust_ffi/src/full.rs
@@ -45,6 +45,12 @@ pub struct IcebergScan {
     /// module-level "Concurrency invariant" doc for the cap on alive
     /// `process_file` tasks.
     pub file_prefetch_depth: usize,
+    /// Per-scan buffer limits (byte budget + waiting/active prefetch slot
+    /// counts), populated from the perf config at construction and threaded
+    /// into the nested pipeline. Internal Rust struct (not repr(C)); Julia
+    /// only ever holds `IcebergScan` as an opaque `*mut` and never reads its
+    /// layout.
+    pub(crate) buffer_limits: crate::nested_pipeline::BufferLimits,
 }
 
 unsafe impl Send for IcebergScan {}
@@ -78,6 +84,12 @@ pub extern "C" fn iceberg_new_scan(
         file_io,
         batch_size: perf.batch_size as usize,
         file_prefetch_depth: perf.file_prefetch_depth as usize,
+        buffer_limits: crate::nested_pipeline::BufferLimits {
+            max_buffered_bytes_per_task: perf.max_buffered_bytes_per_task as usize,
+            max_prefetch_buffers_of_waiting_file: perf.max_prefetch_buffers_of_waiting_file
+                as usize,
+            max_prefetch_buffers_of_active_file: perf.max_prefetch_buffers_of_active_file as usize,
+        },
     }))
 }
 
@@ -109,14 +121,17 @@ impl_scan_builder_method!(
 //      yields batches in strict file-then-row order.
 
 /// Resolve the pipeline tuning parameters from a configured scan.
-/// Returns `(prefetch_depth, file_io, batch_size)`. Both `file_prefetch_depth`
-/// and `batch_size` are supplied verbatim by Julia at construction (the single
-/// source of tuning defaults) and used as-is — there is no "0 = auto" fallback.
-fn resolve_pipeline_params(scan: &IcebergScan) -> anyhow::Result<(usize, FileIO, usize)> {
+/// Returns `(prefetch_depth, file_io, batch_size, buffer_limits)`. All values
+/// are supplied verbatim by Julia at construction (the single source of tuning
+/// defaults) and used as-is — there is no "0 = auto" fallback.
+fn resolve_pipeline_params(
+    scan: &IcebergScan,
+) -> anyhow::Result<(usize, FileIO, usize, crate::nested_pipeline::BufferLimits)> {
     Ok((
         scan.file_prefetch_depth,
         scan.file_io.clone(),
         scan.batch_size,
+        scan.buffer_limits,
     ))
 }
 
@@ -132,12 +147,12 @@ export_runtime_op!(
         if scan_ref.is_none() {
             return Err(classified_error(IcebergErrorCode::STATE_RESOURCE_FREED, "Resource has been freed", "Scan not initialized"));
         }
-        let (prefetch_depth, file_io, batch_size) = resolve_pipeline_params(scan_ptr)?;
-        Ok((scan_ref.as_ref().unwrap(), prefetch_depth, file_io, batch_size))
+        let (prefetch_depth, file_io, batch_size, buffer_limits) = resolve_pipeline_params(scan_ptr)?;
+        Ok((scan_ref.as_ref().unwrap(), prefetch_depth, file_io, batch_size, buffer_limits))
     },
     result_tuple,
     async {
-        let (scan_ref, prefetch_depth, file_io, batch_size) = result_tuple;
+        let (scan_ref, prefetch_depth, file_io, batch_size, buffer_limits) = result_tuple;
 
         // Hand off to the file-parallel pipeline. We pass the planner's
         // task stream directly — no `try_collect` into a `Vec`, since the
@@ -145,7 +160,7 @@ export_runtime_op!(
         // `Stream::buffered(prefetch_depth)`.
         let tasks = scan_ref.plan_files().await.map_err(|e| classify_iceberg(e))?;
         let stream = crate::full_pipeline::create_pipeline(
-            tasks, file_io, batch_size, prefetch_depth,
+            tasks, file_io, batch_size, prefetch_depth, buffer_limits,
         )
         .await;
 
@@ -175,17 +190,17 @@ export_runtime_op!(
         if scan_ref.is_none() {
             return Err(classified_error(IcebergErrorCode::STATE_RESOURCE_FREED, "Resource has been freed", "Scan not initialized"));
         }
-        let (prefetch_depth, file_io, batch_size) = resolve_pipeline_params(scan_ptr)?;
-        Ok((scan_ref.as_ref().unwrap(), prefetch_depth, file_io, batch_size))
+        let (prefetch_depth, file_io, batch_size, buffer_limits) = resolve_pipeline_params(scan_ptr)?;
+        Ok((scan_ref.as_ref().unwrap(), prefetch_depth, file_io, batch_size, buffer_limits))
     },
     result_tuple,
     async {
-        let (scan_ref, prefetch_depth, file_io, batch_size) = result_tuple;
+        let (scan_ref, prefetch_depth, file_io, batch_size, buffer_limits) = result_tuple;
 
         // Pass the planner's task stream directly into the pipeline.
         let tasks = scan_ref.plan_files().await.map_err(|e| classify_iceberg(e))?;
         let stream = crate::full_pipeline::create_full_scan_pipeline(
-            tasks, file_io, batch_size, prefetch_depth,
+            tasks, file_io, batch_size, prefetch_depth, buffer_limits,
         )
         .await;
 

--- a/iceberg_rust_ffi/src/full_pipeline.rs
+++ b/iceberg_rust_ffi/src/full_pipeline.rs
@@ -20,10 +20,7 @@ use iceberg::io::FileIO;
 use iceberg::scan::{FileScanTask, FileScanTaskStream};
 use tokio::sync::Mutex as AsyncMutex;
 
-use crate::nested_pipeline::{
-    build_reader, create_nested_pipeline, FileToScan, MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE,
-    MAX_PREFETCH_BUFFERS_OF_WAITING_FILE,
-};
+use crate::nested_pipeline::{build_reader, create_nested_pipeline, BufferLimits, FileToScan};
 use crate::table::{IcebergArrowStream, IcebergFileScanStream};
 use crate::unexpected;
 
@@ -47,6 +44,7 @@ pub async fn create_full_scan_pipeline(
     file_io: FileIO,
     batch_size: usize,
     prefetch_depth: usize,
+    buffer_limits: BufferLimits,
 ) -> IcebergFileScanStream {
     let files = tasks.map_ok(move |task: FileScanTask| {
         let filename = task.data_file_path().to_string();
@@ -60,7 +58,7 @@ pub async fn create_full_scan_pipeline(
             }),
         }
     });
-    create_nested_pipeline(files, prefetch_depth).await
+    create_nested_pipeline(files, prefetch_depth, buffer_limits).await
 }
 
 /// Build the flat (concatenated) per-batch stream used by the legacy
@@ -69,8 +67,9 @@ pub async fn create_full_scan_pipeline(
 /// applies unchanged.
 ///
 /// The flat path bypasses `iceberg_next_file_scan`, which is the FFI
-/// handoff that promotes `slot_sem` from `MAX_PREFETCH_BUFFERS_OF_WAITING_FILE`
-/// to `MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE` (see
+/// handoff that promotes `slot_sem` from the waiting-file slot budget
+/// (`BufferLimits::max_prefetch_buffers_of_waiting_file`) to the active-file
+/// slot budget (`BufferLimits::max_prefetch_buffers_of_active_file`) (see
 /// `IcebergFileScanResponse::set_payload` in `table.rs`). Without an explicit
 /// promotion here every flat-path producer would stay capped at the
 /// waiting-file budget — correct but slow. Since the flat path always
@@ -81,14 +80,16 @@ pub async fn create_pipeline(
     file_io: FileIO,
     batch_size: usize,
     prefetch_depth: usize,
+    buffer_limits: BufferLimits,
 ) -> IcebergArrowStream {
-    let nested = create_full_scan_pipeline(tasks, file_io, batch_size, prefetch_depth).await;
+    let nested =
+        create_full_scan_pipeline(tasks, file_io, batch_size, prefetch_depth, buffer_limits).await;
     let flat = nested
         .stream
         .into_inner()
         .map_ok(|fs| {
             fs.slot_sem.add_permits(
-                MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE - MAX_PREFETCH_BUFFERS_OF_WAITING_FILE,
+                fs.max_prefetch_buffers_of_active_file - fs.max_prefetch_buffers_of_waiting_file,
             );
             fs.stream.stream.into_inner()
         })
@@ -105,6 +106,16 @@ mod tests {
     use crate::nested_pipeline::PIPELINE_TEST_LOCK;
     use crate::pipeline_stats::{nanos_since_process_start, STATS};
     use std::sync::atomic::Ordering;
+
+    /// `BufferLimits` built from the production-default consts, so these tests
+    /// keep their previous behavior.
+    // Mirrors the production defaults in RustyIceberg.jl `IcebergPerfConfig`
+    // (100 MiB / 1 / 8); kept inline so tests do not depend on named consts.
+    const TEST_LIMITS: BufferLimits = BufferLimits {
+        max_buffered_bytes_per_task: 100 * 1024 * 1024,
+        max_prefetch_buffers_of_waiting_file: 1,
+        max_prefetch_buffers_of_active_file: 8,
+    };
 
     #[tokio::test]
     async fn full_pipeline_reads_parquet_file() {
@@ -183,7 +194,7 @@ mod tests {
         //   (reader setup, fetch/decode, serialize IPC, semaphore acquire)
         //   → make_file_stream (semaphore release)
         let tasks = Box::pin(futures::stream::iter(vec![Ok::<_, iceberg::Error>(task)]));
-        let nested = create_full_scan_pipeline(tasks, file_io, 1024, 1).await;
+        let nested = create_full_scan_pipeline(tasks, file_io, 1024, 1, TEST_LIMITS).await;
 
         // ── 6. Drain outer FileScanStream ──────────────────────────────────
         let mut outer = nested.stream.lock().await;
@@ -320,7 +331,7 @@ mod tests {
         let tasks = Box::pin(futures::stream::iter(
             tasks.into_iter().map(Ok::<_, iceberg::Error>),
         ));
-        let flat = create_pipeline(tasks, file_io, 1, 2).await;
+        let flat = create_pipeline(tasks, file_io, 1, 2, TEST_LIMITS).await;
 
         // Drain all batches and verify total row count via C Data Interface row count field.
         let mut stream = flat.stream.lock().await;
@@ -362,7 +373,7 @@ mod tests {
         // pass via fast complete-and-exit timing), we use multi-batch files:
         // batch_size=1 turns each 3-row file into 3 batches, so after batch 1
         // each waiting-file producer parks on `slot_sem.acquire()`
-        // (MAX_PREFETCH_BUFFERS_OF_WAITING_FILE=1).
+        // (waiting-file slot budget = 1).
         // We pull the first FileScan to activate it but never drain its inner
         // stream, so the active file's producer also stays alive. With all
         // producers parked, the peak reflects the actual structural cap.
@@ -435,23 +446,24 @@ mod tests {
 
         let prefetch_depth = 2;
         // batch_size=1 → 3 batches/file → producers actually park on slot_sem
-        // (MAX_PREFETCH_BUFFERS_OF_WAITING_FILE=1) after batch 1 instead of
+        // (waiting-file slot budget = 1) after batch 1 instead of
         // finishing instantly.
         let tasks = Box::pin(futures::stream::iter(
             tasks.into_iter().map(Ok::<_, iceberg::Error>),
         ));
-        let nested = create_full_scan_pipeline(tasks, file_io, 1, prefetch_depth).await;
+        let nested =
+            create_full_scan_pipeline(tasks, file_io, 1, prefetch_depth, TEST_LIMITS).await;
 
         // Pull the first FileScan (the "+1"). Don't drain its inner stream —
         // its producer stays alive parked on slot_sem after one
-        // MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE batch (8 batches > 3-row file,
-        // but the consumer never recv()s, so the producer stays alive until
-        // the file's batches all queue or MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE
-        // is hit; for our 3-batch file it queues all then hits
+        // active-file slot budget batch (active-file slot budget = 8 batches >
+        // 3-row file, but the consumer never recv()s, so the producer stays
+        // alive until the file's batches all queue or the active-file slot
+        // budget is hit; for our 3-batch file it queues all then hits
         // batch_stream.next() returning None and exits — which is acceptable:
         // peak is observed during the stable window before that producer
-        // exits). Subsequent files' producers stay parked at
-        // MAX_PREFETCH_BUFFERS_OF_WAITING_FILE=1 → 0 after batch 1.
+        // exits). Subsequent files' producers stay parked at the
+        // waiting-file slot budget = 1 → 0 after batch 1.
         let mut outer = nested.stream.lock().await;
         let _first_file = outer.next().await.unwrap().unwrap();
 

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -22,15 +22,16 @@ const SNAPSHOT_ID_NONE: i64 = -1;
 pub struct IcebergIncrementalScan {
     pub builder: Option<IncrementalTableScanBuilder<'static>>,
     pub scan: Option<IncrementalTableScan>,
-    /// 0 = auto-detect (num_cpus)
+    /// Parallelism for the delete-stream IPC serialization fan-out. Supplied
+    /// verbatim by Julia (the single source of tuning defaults) and used as-is.
     pub serialization_concurrency: usize,
     // Present for macro compatibility with IcebergScan; unused for incremental.
     pub file_io: Option<iceberg::io::FileIO>,
-    /// Set by Julia via `iceberg_incremental_scan_with_batch_size`. Required:
-    /// the FFI stream op errors out if this is still `None` at stream-creation
-    /// time. Forwarded to the per-file `ArrowReaderBuilder` inside the pipeline.
-    pub batch_size: Option<usize>,
-    pub file_concurrency: usize,
+    /// Set from the perf config at construction. Forwarded to the per-file
+    /// `ArrowReaderBuilder` inside the pipeline.
+    pub batch_size: usize,
+    /// `Stream::buffered(prefetch_depth)` width for the append pipeline.
+    /// Supplied verbatim by Julia and used as-is.
     pub file_prefetch_depth: usize,
 }
 
@@ -83,11 +84,13 @@ impl RawResponse for IcebergUnzippedStreamsResponse {
 /// * `table` - The table to scan
 /// * `from_snapshot_id` - Starting snapshot ID, or `SNAPSHOT_ID_NONE` (-1) to scan from the root (oldest) snapshot
 /// * `to_snapshot_id` - Ending snapshot ID, or `SNAPSHOT_ID_NONE` (-1) to scan to the current (latest) snapshot
+/// * `perf` - Complete tuning config supplied by Julia (the single source of tuning defaults).
 #[no_mangle]
 pub extern "C" fn iceberg_new_incremental_scan(
     table: *mut IcebergTable,
     from_snapshot_id: i64,
     to_snapshot_id: i64,
+    perf: IcebergPerfConfigFFI,
 ) -> *mut IcebergIncrementalScan {
     if table.is_null() {
         return ptr::null_mut();
@@ -107,63 +110,27 @@ pub extern "C" fn iceberg_new_incremental_scan(
         Some(to_snapshot_id)
     };
 
-    let scan_builder = table_ref.table.incremental_scan(from_id, to_id);
+    let scan_builder = table_ref
+        .table
+        .incremental_scan(from_id, to_id)
+        .with_batch_size(Some(perf.batch_size as usize))
+        .with_manifest_file_concurrency_limit(perf.manifest_file_concurrency_limit as usize)
+        .with_manifest_entry_concurrency_limit(perf.manifest_entry_concurrency_limit as usize);
     Box::into_raw(Box::new(IcebergIncrementalScan {
         builder: Some(scan_builder),
         scan: None,
-        serialization_concurrency: 0,
+        serialization_concurrency: perf.serialization_concurrency_limit as usize,
         file_io: Some(table_ref.table.file_io().clone()),
-        batch_size: None,
-        file_concurrency: 0,
-        file_prefetch_depth: 0,
+        batch_size: perf.batch_size as usize,
+        file_prefetch_depth: perf.file_prefetch_depth as usize,
     }))
 }
 
-// Use macros from scan_common for shared functionality
+// Use macros from scan_common for shared functionality. Perf knobs (batch size,
+// manifest concurrency, prefetch depth, serialization concurrency) are applied at
+// construction from the `IcebergPerfConfigFFI`; only the non-perf builder methods
+// remain as separate setters.
 impl_select_columns!(iceberg_incremental_select_columns, IcebergIncrementalScan);
-
-impl_with_file_prefetch_depth!(
-    iceberg_incremental_scan_with_file_prefetch_depth,
-    IcebergIncrementalScan
-);
-
-impl_scan_builder_method!(
-    iceberg_incremental_scan_with_manifest_file_concurrency_limit,
-    IcebergIncrementalScan,
-    with_manifest_file_concurrency_limit,
-    n: usize
-);
-
-/// FFI-stable no-op kept for API compatibility with Julia callers. Same
-/// rationale as the full-scan twin (`iceberg_scan_with_data_file_concurrency_limit`):
-/// the incremental nested pipeline is now bounded by `file_prefetch_depth`
-/// alone, and the iceberg-rs scan builder's own
-/// `with_data_file_concurrency_limit` only affects `to_arrow()` /
-/// `to_unzipped_arrow()` (which we don't call — we use `plan_files()` +
-/// our own per-file `ArrowReader`s pinned to concurrency 1), so forwarding
-/// would have no effect anyway.
-#[no_mangle]
-pub extern "C" fn iceberg_incremental_scan_with_data_file_concurrency_limit(
-    scan: &mut *mut IcebergIncrementalScan,
-    _n: usize,
-) -> CResult {
-    if scan.is_null() || (*scan).is_null() {
-        return CResult::Error;
-    }
-    CResult::Ok
-}
-
-impl_scan_builder_method!(
-    iceberg_incremental_scan_with_manifest_entry_concurrency_limit,
-    IcebergIncrementalScan,
-    with_manifest_entry_concurrency_limit,
-    n: usize
-);
-
-impl_with_batch_size!(
-    iceberg_incremental_scan_with_batch_size,
-    IcebergIncrementalScan
-);
 
 impl_scan_builder_method!(
     iceberg_incremental_scan_with_file_column,
@@ -178,11 +145,6 @@ impl_scan_builder_method!(
 );
 
 impl_scan_build!(iceberg_incremental_scan_build, IcebergIncrementalScan);
-
-impl_with_serialization_concurrency_limit!(
-    iceberg_incremental_scan_with_serialization_concurrency_limit,
-    IcebergIncrementalScan
-);
 
 // Legacy unzipped FFI: returns two separate flat IcebergArrowStreams
 // (inserts + deletes) via iceberg-rs's own `to_unzipped_arrow()`. This
@@ -204,12 +166,9 @@ export_runtime_op!(
             return Err(classified_error(IcebergErrorCode::STATE_RESOURCE_FREED, "Resource has been freed", "Incremental scan not initialized"));
         }
 
-        // Determine concurrency (0 = auto-detect)
-        let serialization_concurrency = if scan_ptr.serialization_concurrency == 0 {
-            crate::cpu_count()
-        } else {
-            scan_ptr.serialization_concurrency
-        };
+        // Concurrency is supplied verbatim by Julia (the single source of tuning
+        // defaults); used as-is, no auto-detect.
+        let serialization_concurrency = scan_ptr.serialization_concurrency;
 
         Ok((scan_ref.as_ref().unwrap(), serialization_concurrency))
     },
@@ -241,27 +200,13 @@ export_runtime_op!(
     scan: *mut IcebergIncrementalScan
 );
 
-/// Resolve pipeline tuning knobs from an IncrementalScan. Same `0 = auto`
-/// convention as `resolve_pipeline_params` in `full.rs`, applied here to
-/// the two knobs that the incremental path actually consults: `prefetch_depth`
-/// (the append-pipeline's `Stream::buffered` width) and
-/// `serialization_concurrency` (parallelism for the delete-stream IPC fan-out).
-/// `file_concurrency` is stored on the struct for FFI ABI compatibility but
-/// is no longer consulted: the nested-append pipeline is bounded by
-/// `prefetch_depth` alone, matching the full-scan shape.
+/// Resolve pipeline tuning knobs from an IncrementalScan. Both knobs are
+/// supplied verbatim by Julia (the single source of tuning defaults) and used
+/// as-is — there is no "0 = auto" fallback. The two knobs the incremental path
+/// consults are `prefetch_depth` (the append-pipeline's `Stream::buffered` width)
+/// and `serialization_concurrency` (parallelism for the delete-stream IPC fan-out).
 fn resolve_incremental_pipeline_params(scan: &IcebergIncrementalScan) -> (usize, usize) {
-    let n = crate::cpu_count();
-    let prefetch_depth = if scan.file_prefetch_depth == 0 {
-        n
-    } else {
-        scan.file_prefetch_depth
-    };
-    let serialization_concurrency = if scan.serialization_concurrency == 0 {
-        n
-    } else {
-        scan.serialization_concurrency
-    };
-    (prefetch_depth, serialization_concurrency)
+    (scan.file_prefetch_depth, scan.serialization_concurrency)
 }
 
 /// Response for iceberg_incremental_file_scan_stream.
@@ -327,11 +272,7 @@ export_runtime_op!(
             .ok_or_else(|| classified_error(IcebergErrorCode::STATE_RESOURCE_FREED, "Resource has been freed", "FileIO not available; create scan from table"))?;
         let (prefetch_depth, serialization_concurrency) =
             resolve_incremental_pipeline_params(scan_ptr);
-        let batch_size = scan_ptr.batch_size.ok_or_else(|| {
-            anyhow::anyhow!(
-                "batch_size not set; call iceberg_incremental_scan_with_batch_size before scan"
-            )
-        })?;
+        let batch_size = scan_ptr.batch_size;
 
         Ok((
             scan_ref.as_ref().unwrap(),

--- a/iceberg_rust_ffi/src/incremental.rs
+++ b/iceberg_rust_ffi/src/incremental.rs
@@ -33,6 +33,12 @@ pub struct IcebergIncrementalScan {
     /// `Stream::buffered(prefetch_depth)` width for the append pipeline.
     /// Supplied verbatim by Julia and used as-is.
     pub file_prefetch_depth: usize,
+    /// Per-scan buffer limits (byte budget + waiting/active prefetch slot
+    /// counts), populated from the perf config at construction and threaded
+    /// into the nested append pipeline. Internal Rust struct (not repr(C));
+    /// Julia only ever holds this scan as an opaque `*mut` and never reads
+    /// its layout.
+    pub(crate) buffer_limits: crate::nested_pipeline::BufferLimits,
 }
 
 unsafe impl Send for IcebergIncrementalScan {}
@@ -123,6 +129,12 @@ pub extern "C" fn iceberg_new_incremental_scan(
         file_io: Some(table_ref.table.file_io().clone()),
         batch_size: perf.batch_size as usize,
         file_prefetch_depth: perf.file_prefetch_depth as usize,
+        buffer_limits: crate::nested_pipeline::BufferLimits {
+            max_buffered_bytes_per_task: perf.max_buffered_bytes_per_task as usize,
+            max_prefetch_buffers_of_waiting_file: perf.max_prefetch_buffers_of_waiting_file
+                as usize,
+            max_prefetch_buffers_of_active_file: perf.max_prefetch_buffers_of_active_file as usize,
+        },
     }))
 }
 
@@ -273,6 +285,7 @@ export_runtime_op!(
         let (prefetch_depth, serialization_concurrency) =
             resolve_incremental_pipeline_params(scan_ptr);
         let batch_size = scan_ptr.batch_size;
+        let buffer_limits = scan_ptr.buffer_limits;
 
         Ok((
             scan_ref.as_ref().unwrap(),
@@ -280,11 +293,12 @@ export_runtime_op!(
             serialization_concurrency,
             batch_size,
             file_io,
+            buffer_limits,
         ))
     },
     result_tuple,
     async {
-        let (scan_ref, prefetch_depth, serialization_concurrency, batch_size, file_io) =
+        let (scan_ref, prefetch_depth, serialization_concurrency, batch_size, file_io, buffer_limits) =
             result_tuple;
 
         let (append_tasks, delete_tasks) = scan_ref.plan_files().await.map_err(|e| classify_iceberg(e))?;
@@ -297,6 +311,7 @@ export_runtime_op!(
                 batch_size,
                 prefetch_depth,
                 serialization_concurrency,
+                buffer_limits,
             )
             .await?;
 

--- a/iceberg_rust_ffi/src/incremental_pipeline.rs
+++ b/iceberg_rust_ffi/src/incremental_pipeline.rs
@@ -22,7 +22,7 @@ use iceberg::io::FileIO;
 use iceberg::scan::incremental::{AppendedFileScanTask, DeleteScanTask};
 use tokio::sync::Mutex as AsyncMutex;
 
-use crate::nested_pipeline::{build_reader, create_nested_pipeline, FileToScan};
+use crate::nested_pipeline::{build_reader, create_nested_pipeline, BufferLimits, FileToScan};
 use crate::table::{IcebergArrowStream, IcebergFileScanStream};
 use crate::unexpected;
 
@@ -60,6 +60,7 @@ pub async fn create_incremental_nested_pipeline(
     batch_size: usize,
     prefetch_depth: usize,
     serialization_concurrency: usize,
+    buffer_limits: BufferLimits,
 ) -> anyhow::Result<(IcebergFileScanStream, IcebergArrowStream)> {
     let reader = build_reader(file_io.clone(), batch_size);
 
@@ -76,7 +77,7 @@ pub async fn create_incremental_nested_pipeline(
             }),
         }
     });
-    let append_stream = create_nested_pipeline(files, prefetch_depth).await;
+    let append_stream = create_nested_pipeline(files, prefetch_depth, buffer_limits).await;
 
     // Delete stream: StreamsInto with empty append stream routes all delete
     // tasks through the iceberg reader machinery.
@@ -123,6 +124,16 @@ mod tests {
 
     use super::*;
     use crate::nested_pipeline::PIPELINE_TEST_LOCK;
+
+    /// `BufferLimits` built from the production-default consts, so these tests
+    /// keep their previous behavior.
+    // Mirrors the production defaults in RustyIceberg.jl `IcebergPerfConfig`
+    // (100 MiB / 1 / 8); kept inline so tests do not depend on named consts.
+    const TEST_LIMITS: BufferLimits = BufferLimits {
+        max_buffered_bytes_per_task: 100 * 1024 * 1024,
+        max_prefetch_buffers_of_waiting_file: 1,
+        max_prefetch_buffers_of_active_file: 8,
+    };
 
     // ── Shared setup helpers ──────────────────────────────────────────────
 
@@ -221,6 +232,7 @@ mod tests {
             1024,
             1,
             1,
+            TEST_LIMITS,
         )
         .await;
         assert!(result.is_ok());
@@ -248,6 +260,7 @@ mod tests {
             1024,
             1,
             1,
+            TEST_LIMITS,
         )
         .await
         .unwrap();
@@ -316,6 +329,7 @@ mod tests {
             1024,
             1,
             1,
+            TEST_LIMITS,
         )
         .await
         .unwrap();

--- a/iceberg_rust_ffi/src/lib.rs
+++ b/iceberg_rust_ffi/src/lib.rs
@@ -5,12 +5,6 @@ pub(crate) fn unexpected(msg: impl std::fmt::Display) -> iceberg::Error {
     iceberg::Error::new(iceberg::ErrorKind::Unexpected, msg.to_string())
 }
 
-pub(crate) fn cpu_count() -> usize {
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1)
-}
-
 use anyhow::Result;
 use arrow_array::{ffi as arrow_ffi, Array, RecordBatch, StructArray};
 

--- a/iceberg_rust_ffi/src/nested_pipeline.rs
+++ b/iceberg_rust_ffi/src/nested_pipeline.rs
@@ -55,7 +55,8 @@
 //! checks the `prefetch_depth + 1` lower bound directly.
 //!
 //! # Memory bounding
-//! Each file task has its own Semaphore(MAX_BUFFERED_BYTES_PER_TASK). After
+//! Each file task has its own Semaphore sized to the per-file byte budget
+//! (`BufferLimits::max_buffered_bytes_per_task`). After
 //! serializing a batch, the task acquires clamped_byte_len permits. If the budget is
 //! exhausted, the task yields (async, not blocking) until the consumer drains
 //! batches and releases permits. This caps each file's buffered output to
@@ -71,7 +72,7 @@ use iceberg::arrow::{ArrowReader, ArrowReaderBuilder};
 use iceberg::io::FileIO;
 use tokio::sync::{mpsc, Mutex as AsyncMutex, Semaphore};
 
-use crate::pipeline_stats::{MAX_BUFFERED_BYTES_PER_TASK, STATS};
+use crate::pipeline_stats::STATS;
 use crate::table::{ArrowBatch, IcebergArrowStream, IcebergFileScanStream};
 use crate::unexpected;
 
@@ -117,30 +118,48 @@ pub(crate) struct BufferedBatch {
     pub(crate) slot_sem: Arc<Semaphore>,
 }
 
-/// Initial batch-slot budget for a *waiting* file — one whose `FileScan`
-/// has been produced by the outer pipeline but not yet picked up by
-/// `iceberg_next_file_scan`. The producer can fill at most this many
-/// batches before parking on `slot_sem.acquire()`. Promoted to
-/// `MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE` at the FFI handoff site (see
-/// `IcebergFileScanResponse::set_payload`).
-pub(crate) const MAX_PREFETCH_BUFFERS_OF_WAITING_FILE: usize = 1;
-/// Full batch-slot budget for an *active* file — one whose `FileScan` has
-/// been handed off to a Julia consumer. Matches the per-file mpsc capacity,
-/// so once active the slot semaphore stops being the binding constraint
-/// and the existing 100 MB byte budget is what throttles.
-pub(crate) const MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE: usize = 8;
+/// Per-scan buffer limits, supplied by Julia via `IcebergPerfConfigFFI` (the
+/// single source of tuning defaults). Threaded into each per-file task to size
+/// the byte semaphore, the waiting/active slot budgets, and the per-file mpsc
+/// capacity. Invariant: `max_prefetch_buffers_of_waiting_file <=
+/// max_prefetch_buffers_of_active_file` (the FFI handoff promotes the slot
+/// budget from waiting to active by their difference).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BufferLimits {
+    /// Per-file output-buffer cap in bytes; the producer parks once this much
+    /// undrained batch data is buffered for one file.
+    pub(crate) max_buffered_bytes_per_task: usize,
+    /// Initial batch-slot budget for a *waiting* file — one whose `FileScan`
+    /// has been produced by the outer pipeline but not yet picked up by
+    /// `iceberg_next_file_scan`. Promoted to the active budget at the FFI
+    /// handoff site (see `IcebergFileScanResponse::set_payload`).
+    pub(crate) max_prefetch_buffers_of_waiting_file: usize,
+    /// Full batch-slot budget (and per-file mpsc capacity) for an *active*
+    /// file — one handed off to a Julia consumer. Once active the slot
+    /// semaphore stops being the binding constraint and the byte budget throttles.
+    pub(crate) max_prefetch_buffers_of_active_file: usize,
+}
 
 /// Internal per-file scan result: filename, record count, prefetched inner
 /// batch stream, and the per-file slot semaphore. The slot semaphore is
 /// carried through the outer channel so the FFI handoff site can promote
-/// it from `MAX_PREFETCH_BUFFERS_OF_WAITING_FILE` to
-/// `MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE` with one `add_permits` call —
+/// it from the waiting-file slot budget
+/// (`BufferLimits::max_prefetch_buffers_of_waiting_file`) to the active-file
+/// slot budget (`BufferLimits::max_prefetch_buffers_of_active_file`) with one
+/// `add_permits` call —
 /// no separate plumbing through the orchestrator.
 pub struct FileScan {
     pub filename: String,
     pub record_count: i64,
     pub stream: IcebergArrowStream,
     pub(crate) slot_sem: Arc<Semaphore>,
+    /// Carried from this scan's `BufferLimits` so the FFI handoff site
+    /// (`IcebergFileScanResponse::set_payload`) and the flat-path promotion
+    /// in `full_pipeline::create_pipeline` can top up `slot_sem` by
+    /// `max_prefetch_buffers_of_active_file - max_prefetch_buffers_of_waiting_file`
+    /// without reading the global consts.
+    pub(crate) max_prefetch_buffers_of_waiting_file: usize,
+    pub(crate) max_prefetch_buffers_of_active_file: usize,
 }
 
 /// Handoff shape between a per-pipeline planner adapter and the orchestrator.
@@ -215,6 +234,7 @@ pub(crate) fn make_file_stream(
 pub(crate) async fn create_nested_pipeline<S, Src>(
     source: Src,
     prefetch_depth: usize,
+    limits: BufferLimits,
 ) -> IcebergFileScanStream
 where
     S: Stream<Item = iceberg::Result<RecordBatch>> + Send + Unpin + 'static,
@@ -225,6 +245,7 @@ where
     // Single reset site for both pipelines. `pipeline_start_ns` is captured
     // inside `reset()` so wall-time accounting starts here.
     STATS.reset();
+    STATS.set_byte_budget_per_task(limits.max_buffered_bytes_per_task as u64);
 
     // Each inner future does the sync `spawn_file_task` (which itself
     // `tokio::spawn`s the `process_file` task) *when polled*, so `buffered`'s
@@ -232,8 +253,8 @@ where
     // kicked off ahead of the consumer. Doing the spawn in `.map` directly
     // would fire it as soon as the source is polled, bypassing the bound.
     let buffered = source
-        .map(|res| async move {
-            res.map(|f| spawn_file_task(f.filename, f.record_count, f.build_batch_stream))
+        .map(move |res| async move {
+            res.map(|f| spawn_file_task(f.filename, f.record_count, f.build_batch_stream, limits))
         })
         .buffered(prefetch_depth);
 
@@ -269,22 +290,23 @@ pub(crate) fn spawn_file_task<S, BSF>(
     filename: String,
     record_count: i64,
     build_batch_stream: BSF,
+    limits: BufferLimits,
 ) -> FileScan
 where
     BSF: FnOnce() -> iceberg::Result<S> + Send + 'static,
     S: Stream<Item = iceberg::Result<RecordBatch>> + Send + Unpin + 'static,
 {
-    let byte_sem = Arc::new(Semaphore::new(MAX_BUFFERED_BYTES_PER_TASK));
+    let byte_sem = Arc::new(Semaphore::new(limits.max_buffered_bytes_per_task));
     // Start at the waiting-file prefetch floor; the FFI handoff site
     // (`IcebergFileScanResponse::set_payload`) tops up to the active-file
     // budget.
-    let slot_sem = Arc::new(Semaphore::new(MAX_PREFETCH_BUFFERS_OF_WAITING_FILE));
-    let (file_tx, file_rx) = mpsc::channel(MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE);
+    let slot_sem = Arc::new(Semaphore::new(limits.max_prefetch_buffers_of_waiting_file));
+    let (file_tx, file_rx) = mpsc::channel(limits.max_prefetch_buffers_of_active_file);
 
     tokio::spawn(process_file(
         build_batch_stream,
         byte_sem,
-        MAX_BUFFERED_BYTES_PER_TASK,
+        limits.max_buffered_bytes_per_task,
         slot_sem.clone(),
         file_tx,
     ));
@@ -294,6 +316,8 @@ where
         record_count,
         stream: make_file_stream(file_rx),
         slot_sem,
+        max_prefetch_buffers_of_waiting_file: limits.max_prefetch_buffers_of_waiting_file,
+        max_prefetch_buffers_of_active_file: limits.max_prefetch_buffers_of_active_file,
     }
 }
 
@@ -415,16 +439,17 @@ pub(crate) async fn serialize_and_forward_batches(
         // ("consumer hasn't drained enough"):
         //   (a) byte budget — `byte_sem.acquire_many(clamped_byte_len)`
         //       blocks if this file's outstanding buffered bytes exceed
-        //       MAX_BUFFERED_BYTES_PER_TASK (100 MB).
+        //       the per-file byte budget
+        //       (`BufferLimits::max_buffered_bytes_per_task`, 100 MB).
         //   (b) batch-slot budget — `slot_sem.acquire()` blocks if the file
         //       has hit its current batch-count cap. Needed *in addition to*
         //       the byte budget so a still-waiting file (Julia hasn't picked
         //       it up yet) doesn't fetch too far into the future (we want to
         //       prioritize prefetching of buffers on active files!):
-        //       cap is MAX_PREFETCH_BUFFERS_OF_WAITING_FILE while waiting,
-        //       MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE once active.
+        //       cap is the waiting-file slot budget while waiting,
+        //       the active-file slot budget once active.
         //   (c) channel-capacity safety — `tx.send(...)` blocks if the
-        //       mpsc is full. With slot_sem ≤ MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE
+        //       mpsc is full. With slot_sem ≤ the active-file slot budget
         //       = mpsc capacity, this is a redundant safety net.
         //
         // Each `.acquire()` is wrapped in a `tokio::select!` with `tx.closed()`,
@@ -489,6 +514,16 @@ mod tests {
     use super::*;
     use futures::TryStreamExt;
 
+    /// `BufferLimits` built from the production-default consts, so tests that
+    /// drive the pipeline keep their previous behavior.
+    // Mirrors the production defaults in RustyIceberg.jl `IcebergPerfConfig`
+    // (100 MiB / 1 / 8); kept inline so tests do not depend on named consts.
+    const TEST_LIMITS: BufferLimits = BufferLimits {
+        max_buffered_bytes_per_task: 100 * 1024 * 1024,
+        max_prefetch_buffers_of_waiting_file: 1,
+        max_prefetch_buffers_of_active_file: 8,
+    };
+
     // ── Orchestration tests (empty-batch-stream builder — no real I/O) ──
     //
     // These tests exercise `create_nested_pipeline`'s plumbing
@@ -525,7 +560,7 @@ mod tests {
         let _guard = PIPELINE_TEST_LOCK.lock().await;
         let source = futures::stream::iter(items)
             .map_ok(|(name, rc): (String, i64)| fake_file_to_scan(name, rc));
-        let nested = create_nested_pipeline(source, prefetch_depth).await;
+        let nested = create_nested_pipeline(source, prefetch_depth, TEST_LIMITS).await;
         let mut out = vec![];
         let mut stream = nested.stream.lock().await;
         while let Some(item) = stream.next().await {
@@ -635,6 +670,7 @@ mod tests {
                     "reader setup failed",
                 ))
             },
+            TEST_LIMITS,
         );
         let mut inner = fs.stream.stream.lock().await;
         // First item: the error from the builder closure, forwarded by
@@ -664,7 +700,7 @@ mod tests {
             .collect();
         let source = futures::stream::iter(items)
             .map_ok(|(name, rc): (String, i64)| fake_file_to_scan(name, rc));
-        let nested = create_nested_pipeline(source, 4).await;
+        let nested = create_nested_pipeline(source, 4, TEST_LIMITS).await;
         drop(nested);
     }
 
@@ -701,7 +737,7 @@ mod tests {
         // Two batches; the second will block the producer on slot_sem.
         let batches = futures::stream::iter(vec![make_batch(), make_batch()]);
 
-        let byte_sem = Arc::new(Semaphore::new(MAX_BUFFERED_BYTES_PER_TASK));
+        let byte_sem = Arc::new(Semaphore::new(TEST_LIMITS.max_buffered_bytes_per_task));
         let slot_sem = Arc::new(Semaphore::new(1));
         let (tx, mut rx) = mpsc::channel::<Result<BufferedBatch, iceberg::Error>>(8);
 
@@ -714,7 +750,7 @@ mod tests {
                 batches,
                 &byte_sem_for_drain,
                 &slot_sem_for_drain,
-                MAX_BUFFERED_BYTES_PER_TASK,
+                TEST_LIMITS.max_buffered_bytes_per_task,
                 &tx,
             )
             .await

--- a/iceberg_rust_ffi/src/pipeline_stats.rs
+++ b/iceberg_rust_ffi/src/pipeline_stats.rs
@@ -8,8 +8,6 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::LazyLock;
 use std::time::Instant;
 
-pub(crate) const MAX_BUFFERED_BYTES_PER_TASK: usize = 100 * 1024 * 1024;
-
 /// Process-monotonic origin used as a common reference point for the
 /// `pipeline_start_ns` / `pipeline_end_ns` timestamps. We can't store
 /// `Instant` directly in atomics, so each timestamp is encoded as
@@ -77,6 +75,9 @@ pub(crate) struct PipelineStats {
     pub buffered_bytes: AtomicU64,
     /// High-water mark of buffered_bytes.
     pub peak_buffered_bytes: AtomicU64,
+    /// Per-file byte budget in effect for this scan (from the scan's
+    /// `BufferLimits`); recorded once at pipeline start, for the stats display.
+    pub byte_budget_per_task: AtomicU64,
 }
 
 impl PipelineStats {
@@ -97,6 +98,7 @@ impl PipelineStats {
             consumer_file_wait_ns: AtomicU64::new(0),
             buffered_bytes: AtomicU64::new(0),
             peak_buffered_bytes: AtomicU64::new(0),
+            byte_budget_per_task: AtomicU64::new(0),
         }
     }
 
@@ -120,6 +122,14 @@ impl PipelineStats {
         self.consumer_file_wait_ns.store(0, Ordering::Relaxed);
         self.buffered_bytes.store(0, Ordering::Relaxed);
         self.peak_buffered_bytes.store(0, Ordering::Relaxed);
+        self.byte_budget_per_task.store(0, Ordering::Relaxed);
+    }
+
+    /// Record the per-file byte budget for this scan, for the stats display.
+    /// Called once at pipeline start (the value comes from the scan's
+    /// `BufferLimits`).
+    pub(crate) fn set_byte_budget_per_task(&self, bytes: u64) {
+        self.byte_budget_per_task.store(bytes, Ordering::Relaxed);
     }
 
     /// Mark the pipeline-end timestamp. Called from `make_file_stream` when a
@@ -216,7 +226,7 @@ impl PipelineStats {
         } else {
             0.0
         };
-        let limit_mb = MAX_BUFFERED_BYTES_PER_TASK / (1024 * 1024);
+        let limit_mb = self.byte_budget_per_task.load(Ordering::Relaxed) / (1024 * 1024);
 
         // Per-batch averages help distinguish "more parallel producers" from
         // "each batch got slower". Sum-across-producers lines double when

--- a/iceberg_rust_ffi/src/scan_common.rs
+++ b/iceberg_rust_ffi/src/scan_common.rs
@@ -1,4 +1,5 @@
-/// Common macros for scan builder methods shared between regular and incremental scans
+// Common scan utilities (the `IcebergPerfConfigFFI` wire struct + builder-method
+// macros) shared between regular and incremental scans.
 
 /// FFI mirror of RustyIceberg.jl's `IcebergPerfConfig`. This struct intentionally
 /// has NO `Default` impl and NO default values — every field is supplied by Julia,
@@ -15,48 +16,29 @@ pub struct IcebergPerfConfigFFI {
     pub manifest_entry_concurrency_limit: u64,
     pub file_prefetch_depth: u64,
     pub serialization_concurrency_limit: u64,
+    pub max_buffered_bytes_per_task: u64,
+    pub max_prefetch_buffers_of_waiting_file: u64,
+    pub max_prefetch_buffers_of_active_file: u64,
 }
 
-/// Test-only: echo each field of an `IcebergPerfConfigFFI` back into `out[0..5]`
+/// Test-only: echo each field of an `IcebergPerfConfigFFI` back into `out[0..8]`
 /// so a Julia unit test can assert the by-value struct layout agrees across the
 /// FFI boundary (field order, padding, calling convention). `out` must point to
-/// at least 5 `u64`s.
+/// at least 8 `u64`s.
 #[no_mangle]
 pub extern "C" fn iceberg_perf_config_roundtrip(p: IcebergPerfConfigFFI, out: *mut u64) {
     if out.is_null() {
         return;
     }
-    let out = unsafe { std::slice::from_raw_parts_mut(out, 5) };
+    let out = unsafe { std::slice::from_raw_parts_mut(out, 8) };
     out[0] = p.batch_size;
     out[1] = p.manifest_file_concurrency_limit;
     out[2] = p.manifest_entry_concurrency_limit;
     out[3] = p.file_prefetch_depth;
     out[4] = p.serialization_concurrency_limit;
-}
-
-#[cfg(test)]
-mod perf_config_abi_tests {
-    use super::IcebergPerfConfigFFI;
-    use std::mem::{align_of, size_of};
-
-    #[test]
-    fn iceberg_perf_config_abi_is_stable() {
-        assert_eq!(size_of::<IcebergPerfConfigFFI>(), 5 * 8); // 5 × u64
-        assert_eq!(align_of::<IcebergPerfConfigFFI>(), 8);
-        let p = IcebergPerfConfigFFI {
-            batch_size: 0,
-            manifest_file_concurrency_limit: 0,
-            manifest_entry_concurrency_limit: 0,
-            file_prefetch_depth: 0,
-            serialization_concurrency_limit: 0,
-        };
-        let base = &p as *const _ as usize;
-        assert_eq!((&p.batch_size as *const _ as usize) - base, 0);
-        assert_eq!((&p.manifest_file_concurrency_limit as *const _ as usize) - base, 8);
-        assert_eq!((&p.manifest_entry_concurrency_limit as *const _ as usize) - base, 16);
-        assert_eq!((&p.file_prefetch_depth as *const _ as usize) - base, 24);
-        assert_eq!((&p.serialization_concurrency_limit as *const _ as usize) - base, 32);
-    }
+    out[5] = p.max_buffered_bytes_per_task;
+    out[6] = p.max_prefetch_buffers_of_waiting_file;
+    out[7] = p.max_prefetch_buffers_of_active_file;
 }
 
 /// Macro to generate select_columns function for any scan type
@@ -101,6 +83,7 @@ macro_rules! impl_select_columns {
                 file_io: scan_ref.file_io,
                 batch_size: scan_ref.batch_size,
                 file_prefetch_depth: scan_ref.file_prefetch_depth,
+                buffer_limits: scan_ref.buffer_limits,
             }));
 
             CResult::Ok
@@ -150,6 +133,7 @@ macro_rules! impl_scan_builder_method {
                 file_io: scan_ref.file_io,
                 batch_size: scan_ref.batch_size,
                 file_prefetch_depth: scan_ref.file_prefetch_depth,
+                buffer_limits: scan_ref.buffer_limits,
             }));
 
             CResult::Ok
@@ -188,6 +172,7 @@ macro_rules! impl_scan_build {
                         file_io: scan_ref.file_io,
                         batch_size: scan_ref.batch_size,
                         file_prefetch_depth: scan_ref.file_prefetch_depth,
+                        buffer_limits: scan_ref.buffer_limits,
                     }));
                     CResult::Ok
                 }
@@ -235,3 +220,52 @@ pub(crate) use impl_scan_build;
 pub(crate) use impl_scan_builder_method;
 pub(crate) use impl_scan_free;
 pub(crate) use impl_select_columns;
+
+#[cfg(test)]
+mod perf_config_abi_tests {
+    use super::IcebergPerfConfigFFI;
+    use std::mem::{align_of, size_of};
+
+    #[test]
+    fn iceberg_perf_config_abi_is_stable() {
+        assert_eq!(size_of::<IcebergPerfConfigFFI>(), 8 * 8); // 8 × u64
+        assert_eq!(align_of::<IcebergPerfConfigFFI>(), 8);
+        let p = IcebergPerfConfigFFI {
+            batch_size: 0,
+            manifest_file_concurrency_limit: 0,
+            manifest_entry_concurrency_limit: 0,
+            file_prefetch_depth: 0,
+            serialization_concurrency_limit: 0,
+            max_buffered_bytes_per_task: 0,
+            max_prefetch_buffers_of_waiting_file: 0,
+            max_prefetch_buffers_of_active_file: 0,
+        };
+        let base = &p as *const _ as usize;
+        assert_eq!((&p.batch_size as *const _ as usize) - base, 0);
+        assert_eq!(
+            (&p.manifest_file_concurrency_limit as *const _ as usize) - base,
+            8
+        );
+        assert_eq!(
+            (&p.manifest_entry_concurrency_limit as *const _ as usize) - base,
+            16
+        );
+        assert_eq!((&p.file_prefetch_depth as *const _ as usize) - base, 24);
+        assert_eq!(
+            (&p.serialization_concurrency_limit as *const _ as usize) - base,
+            32
+        );
+        assert_eq!(
+            (&p.max_buffered_bytes_per_task as *const _ as usize) - base,
+            40
+        );
+        assert_eq!(
+            (&p.max_prefetch_buffers_of_waiting_file as *const _ as usize) - base,
+            48
+        );
+        assert_eq!(
+            (&p.max_prefetch_buffers_of_active_file as *const _ as usize) - base,
+            56
+        );
+    }
+}

--- a/iceberg_rust_ffi/src/scan_common.rs
+++ b/iceberg_rust_ffi/src/scan_common.rs
@@ -1,4 +1,64 @@
 /// Common macros for scan builder methods shared between regular and incremental scans
+
+/// FFI mirror of RustyIceberg.jl's `IcebergPerfConfig`. This struct intentionally
+/// has NO `Default` impl and NO default values — every field is supplied by Julia,
+/// which is the single source of truth for tuning defaults. It is passed by value
+/// into `iceberg_new_scan` / `iceberg_new_incremental_scan`; its layout must match
+/// the Julia struct field-for-field (all `u64`, declared order). The
+/// `iceberg_perf_config_abi_is_stable` test (size/align/offsets) and the
+/// `iceberg_perf_config_roundtrip` FFI fn (driven by a Julia unit test) guard this.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct IcebergPerfConfigFFI {
+    pub batch_size: u64,
+    pub manifest_file_concurrency_limit: u64,
+    pub manifest_entry_concurrency_limit: u64,
+    pub file_prefetch_depth: u64,
+    pub serialization_concurrency_limit: u64,
+}
+
+/// Test-only: echo each field of an `IcebergPerfConfigFFI` back into `out[0..5]`
+/// so a Julia unit test can assert the by-value struct layout agrees across the
+/// FFI boundary (field order, padding, calling convention). `out` must point to
+/// at least 5 `u64`s.
+#[no_mangle]
+pub extern "C" fn iceberg_perf_config_roundtrip(p: IcebergPerfConfigFFI, out: *mut u64) {
+    if out.is_null() {
+        return;
+    }
+    let out = unsafe { std::slice::from_raw_parts_mut(out, 5) };
+    out[0] = p.batch_size;
+    out[1] = p.manifest_file_concurrency_limit;
+    out[2] = p.manifest_entry_concurrency_limit;
+    out[3] = p.file_prefetch_depth;
+    out[4] = p.serialization_concurrency_limit;
+}
+
+#[cfg(test)]
+mod perf_config_abi_tests {
+    use super::IcebergPerfConfigFFI;
+    use std::mem::{align_of, size_of};
+
+    #[test]
+    fn iceberg_perf_config_abi_is_stable() {
+        assert_eq!(size_of::<IcebergPerfConfigFFI>(), 5 * 8); // 5 × u64
+        assert_eq!(align_of::<IcebergPerfConfigFFI>(), 8);
+        let p = IcebergPerfConfigFFI {
+            batch_size: 0,
+            manifest_file_concurrency_limit: 0,
+            manifest_entry_concurrency_limit: 0,
+            file_prefetch_depth: 0,
+            serialization_concurrency_limit: 0,
+        };
+        let base = &p as *const _ as usize;
+        assert_eq!((&p.batch_size as *const _ as usize) - base, 0);
+        assert_eq!((&p.manifest_file_concurrency_limit as *const _ as usize) - base, 8);
+        assert_eq!((&p.manifest_entry_concurrency_limit as *const _ as usize) - base, 16);
+        assert_eq!((&p.file_prefetch_depth as *const _ as usize) - base, 24);
+        assert_eq!((&p.serialization_concurrency_limit as *const _ as usize) - base, 32);
+    }
+}
+
 /// Macro to generate select_columns function for any scan type
 macro_rules! impl_select_columns {
     ($fn_name:ident, $scan_type:ident) => {
@@ -40,7 +100,6 @@ macro_rules! impl_select_columns {
                 serialization_concurrency: scan_ref.serialization_concurrency,
                 file_io: scan_ref.file_io,
                 batch_size: scan_ref.batch_size,
-                file_concurrency: scan_ref.file_concurrency,
                 file_prefetch_depth: scan_ref.file_prefetch_depth,
             }));
 
@@ -56,10 +115,10 @@ macro_rules! impl_select_columns {
 /// With single parameter:
 /// ```ignore
 /// impl_scan_builder_method!(
-///     iceberg_scan_with_data_file_concurrency_limit,
+///     iceberg_scan_with_snapshot_id,
 ///     IcebergScan,
-///     with_data_file_concurrency_limit,
-///     n: usize
+///     snapshot_id,
+///     snapshot_id: i64
 /// );
 /// ```
 ///
@@ -90,43 +149,6 @@ macro_rules! impl_scan_builder_method {
                 serialization_concurrency: scan_ref.serialization_concurrency,
                 file_io: scan_ref.file_io,
                 batch_size: scan_ref.batch_size,
-                file_concurrency: scan_ref.file_concurrency,
-                file_prefetch_depth: scan_ref.file_prefetch_depth,
-            }));
-
-            CResult::Ok
-        }
-    };
-}
-
-/// Macro to generate with_batch_size function for any scan type.
-///
-/// Writes `n` into the FFI struct's `batch_size` field (read by the nested
-/// pipeline's `ArrowReaderBuilder`) AND calls `b.with_batch_size(Some(n))` on
-/// the scan builder so that the legacy `to_unzipped_arrow()` path (incremental
-/// flat scans) also respects the requested batch size.
-macro_rules! impl_with_batch_size {
-    ($fn_name:ident, $scan_type:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(scan: &mut *mut $scan_type, n: usize) -> CResult {
-            if scan.is_null() || (*scan).is_null() {
-                return CResult::Error;
-            }
-            let scan_ref = unsafe { Box::from_raw(*scan) };
-
-            if scan_ref.builder.is_none() {
-                return CResult::Error;
-            }
-
-            assert!(scan_ref.scan.is_none());
-
-            *scan = Box::into_raw(Box::new($scan_type {
-                builder: scan_ref.builder.map(|b| b.with_batch_size(Some(n))),
-                scan: None,
-                serialization_concurrency: scan_ref.serialization_concurrency,
-                file_io: scan_ref.file_io,
-                batch_size: Some(n),
-                file_concurrency: scan_ref.file_concurrency,
                 file_prefetch_depth: scan_ref.file_prefetch_depth,
             }));
 
@@ -165,7 +187,6 @@ macro_rules! impl_scan_build {
                         serialization_concurrency: scan_ref.serialization_concurrency,
                         file_io: scan_ref.file_io,
                         batch_size: scan_ref.batch_size,
-                        file_concurrency: scan_ref.file_concurrency,
                         file_prefetch_depth: scan_ref.file_prefetch_depth,
                     }));
                     CResult::Ok
@@ -209,43 +230,8 @@ macro_rules! impl_scan_free {
     };
 }
 
-/// Macro to generate with_serialization_concurrency_limit function for any scan type
-macro_rules! impl_with_serialization_concurrency_limit {
-    ($fn_name:ident, $scan_type:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(scan: &mut *mut $scan_type, n: usize) -> CResult {
-            if scan.is_null() || (*scan).is_null() {
-                return CResult::Error;
-            }
-            let mut scan_ref = unsafe { Box::from_raw(*scan) };
-            scan_ref.serialization_concurrency = n;
-            *scan = Box::into_raw(scan_ref);
-            CResult::Ok
-        }
-    };
-}
-
-/// Macro to generate with_file_prefetch_depth function for any scan type
-macro_rules! impl_with_file_prefetch_depth {
-    ($fn_name:ident, $scan_type:ident) => {
-        #[no_mangle]
-        pub extern "C" fn $fn_name(scan: &mut *mut $scan_type, n: usize) -> CResult {
-            if scan.is_null() || (*scan).is_null() {
-                return CResult::Error;
-            }
-            let mut scan_ref = unsafe { Box::from_raw(*scan) };
-            scan_ref.file_prefetch_depth = n;
-            *scan = Box::into_raw(scan_ref);
-            CResult::Ok
-        }
-    };
-}
-
 // Re-export macros for use in other modules
 pub(crate) use impl_scan_build;
 pub(crate) use impl_scan_builder_method;
 pub(crate) use impl_scan_free;
 pub(crate) use impl_select_columns;
-pub(crate) use impl_with_batch_size;
-pub(crate) use impl_with_file_prefetch_depth;
-pub(crate) use impl_with_serialization_concurrency_limit;

--- a/iceberg_rust_ffi/src/table.rs
+++ b/iceberg_rust_ffi/src/table.rs
@@ -148,14 +148,14 @@ impl RawResponse for IcebergFileScanResponse {
         match payload.flatten() {
             Some(fs) => {
                 // Promote: this file is now active (a Julia consumer has
-                // picked it up). Lift the prefetch budget from
-                // MAX_PREFETCH_BUFFERS_OF_WAITING_FILE to
-                // MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE so the producer can
-                // fully fill the per-file mpsc. See `BufferedBatch::slot_sem`
-                // for the policy.
+                // picked it up). Lift the prefetch budget from the per-scan
+                // waiting-file count to the active-file count (both carried on
+                // the FileScan from its BufferLimits) so the producer can fully
+                // fill the per-file mpsc. See `BufferedBatch::slot_sem` for the
+                // policy.
                 fs.slot_sem.add_permits(
-                    crate::nested_pipeline::MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE
-                        - crate::nested_pipeline::MAX_PREFETCH_BUFFERS_OF_WAITING_FILE,
+                    fs.max_prefetch_buffers_of_active_file
+                        - fs.max_prefetch_buffers_of_waiting_file,
                 );
                 let filename = std::ffi::CString::new(fs.filename)
                     .unwrap_or_default()
@@ -456,24 +456,21 @@ pub extern "C" fn iceberg_table_schema(table: *mut IcebergTable) -> *mut c_char 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nested_pipeline::{
-        FileScan, MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE, MAX_PREFETCH_BUFFERS_OF_WAITING_FILE,
-    };
+    use crate::nested_pipeline::FileScan;
     use std::sync::Arc;
     use tokio::sync::{mpsc, Semaphore};
 
     /// `IcebergFileScanResponse::set_payload(Some(Some(fs)))` is the FFI
     /// handoff that promotes a per-file producer's slot budget from
-    /// `MAX_PREFETCH_BUFFERS_OF_WAITING_FILE` to
-    /// `MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE`. The empty `None` variant
-    /// must not touch the slot_sem.
+    /// the waiting-file slot budget
+    /// (`BufferLimits::max_prefetch_buffers_of_waiting_file`) to the
+    /// active-file slot budget
+    /// (`BufferLimits::max_prefetch_buffers_of_active_file`). The empty
+    /// `None` variant must not touch the slot_sem.
     #[test]
     fn set_payload_promotes_slot_sem_to_attached_on_handoff() {
-        let slot_sem = Arc::new(Semaphore::new(MAX_PREFETCH_BUFFERS_OF_WAITING_FILE));
-        assert_eq!(
-            slot_sem.available_permits(),
-            MAX_PREFETCH_BUFFERS_OF_WAITING_FILE
-        );
+        let slot_sem = Arc::new(Semaphore::new(1));
+        assert_eq!(slot_sem.available_permits(), 1);
 
         // Build a minimal FileScan with an empty inner stream. We only
         // care about the slot_sem promotion here, not stream draining.
@@ -484,6 +481,8 @@ mod tests {
             record_count: 0,
             stream: crate::nested_pipeline::make_file_stream(rx),
             slot_sem: slot_sem.clone(),
+            max_prefetch_buffers_of_waiting_file: 1,
+            max_prefetch_buffers_of_active_file: 8,
         };
 
         // Construct an empty response and hand off the FileScan.
@@ -495,10 +494,7 @@ mod tests {
         });
         resp.set_payload(Some(Some(fs)));
 
-        assert_eq!(
-            slot_sem.available_permits(),
-            MAX_PREFETCH_BUFFERS_OF_ACTIVE_FILE
-        );
+        assert_eq!(slot_sem.available_permits(), 8);
 
         // Free the FFI-owned bits we allocated via set_payload so the
         // test doesn't leak (CString filename + boxed IcebergFileScan +
@@ -518,7 +514,7 @@ mod tests {
     /// its prefetch window.
     #[test]
     fn set_payload_does_not_promote_on_end_of_stream() {
-        let slot_sem = Arc::new(Semaphore::new(MAX_PREFETCH_BUFFERS_OF_WAITING_FILE));
+        let slot_sem = Arc::new(Semaphore::new(1));
         let mut resp = IcebergFileScanResponse(IcebergBoxedResponse {
             result: CResult::default(),
             value: ptr::null_mut(),
@@ -528,15 +524,9 @@ mod tests {
         // Both `None` (outer "no payload") and `Some(None)` (stream
         // returned `None` from try_next) must skip the promotion.
         resp.set_payload(Some(None));
-        assert_eq!(
-            slot_sem.available_permits(),
-            MAX_PREFETCH_BUFFERS_OF_WAITING_FILE
-        );
+        assert_eq!(slot_sem.available_permits(), 1);
         resp.set_payload(None);
-        assert_eq!(
-            slot_sem.available_permits(),
-            MAX_PREFETCH_BUFFERS_OF_WAITING_FILE
-        );
+        assert_eq!(slot_sem.available_permits(), 1);
         assert!(resp.0.value.is_null());
     }
 }

--- a/src/RustyIceberg.jl
+++ b/src/RustyIceberg.jl
@@ -24,8 +24,9 @@ export new_incremental_scan, free_incremental_scan!
 export scan_incremental_nested!, nested_incremental_arrow_stream
 export table_open, free_table, new_scan, free_scan!
 export table_location, table_uuid, table_format_version, table_last_sequence_number, table_last_updated_ms, table_current_snapshot_id, table_schema
-export select_columns!, with_batch_size!, with_snapshot_id!, with_data_file_concurrency_limit!, with_manifest_entry_concurrency_limit!
-export with_file_column!, with_pos_column!, with_file_prefetch_depth!
+export IcebergPerfConfig
+export select_columns!, with_snapshot_id!
+export with_file_column!, with_pos_column!
 export scan!, next_batch, next_arrow_batch, foreach_arrow_batch, free_batch, free_stream
 export scan_nested!, nested_arrow_stream, next_file_scan
 export FileScanStream, file_scan_record_count, file_scan_filename, file_scan_arrow_stream
@@ -57,10 +58,27 @@ export COLUMN_TYPE_STRING, COLUMN_TYPE_DATE, COLUMN_TYPE_TIMESTAMP, COLUMN_TYPE_
 export COLUMN_TYPE_DECIMAL_INT32, COLUMN_TYPE_DECIMAL_INT64, COLUMN_TYPE_DECIMAL_INT128
 export julia_type_to_column_type
 
-# Always use the JLL library - override via Preferences if needed for local development
-# To use a local build, set the preference:
-#   using Preferences; set_preferences!("iceberg_rust_ffi_jll", "libiceberg_rust_ffi_path" => "/path/to/target/release/")
-const rust_lib = iceberg_rust_ffi_jll.libiceberg_rust_ffi
+# Resolve the FFI library, in priority order:
+#   1. ENV["ICEBERG_RUST_FFI_LIB"] — local-dev override that propagates to subprocesses
+#      (e.g. ReTestItems workers, which run in a temp test env that does NOT inherit a
+#      `LocalPreferences.toml` override). Set it to either the full path of the dylib or
+#      the directory containing it (e.g. `iceberg_rust_ffi/target/release`). Read at
+#      precompile time (`ccall` needs a `const`), so restart Julia / recompile after changing.
+#   2. The `iceberg_rust_ffi_jll` artifact, optionally redirected via Preferences:
+#      using Preferences; set_preferences!("iceberg_rust_ffi_jll", "libiceberg_rust_ffi_path" => "/path/to/libiceberg_rust_ffi.dylib"; force=true)
+const rust_lib = if haskey(ENV, "ICEBERG_RUST_FFI_LIB")
+    p = ENV["ICEBERG_RUST_FFI_LIB"]
+    lib_path = isfile(p) ? p : joinpath(p, "libiceberg_rust_ffi.$(Base.Libc.Libdl.dlext)")
+    lib_path = realpath(lib_path)
+    @warn """
+        Using unreleased iceberg_rust_ffi library (via ENV["ICEBERG_RUST_FFI_LIB"]):
+            $(repr(lib_path))
+        This is only intended for local development and should not be used in production.
+        """
+    lib_path
+else
+    iceberg_rust_ffi_jll.libiceberg_rust_ffi
+end
 
 """
     struct StaticConfig

--- a/src/full.jl
+++ b/src/full.jl
@@ -12,9 +12,8 @@ to build the scan and obtain an Arrow stream.
 # Example
 ```julia
 table = table_open("s3://path/to/table/metadata.json")
-scan = new_scan(table)
+scan = new_scan(table, IcebergPerfConfig(batch_size=1024))
 select_columns!(scan, ["col1", "col2"])
-with_batch_size!(scan, UInt(1024))
 stream = scan!(scan)
 # ... process batches from stream
 free_stream(stream)
@@ -27,12 +26,17 @@ mutable struct Scan
 end
 
 """
-    new_scan(table::Table) -> Scan
+    new_scan(table::Table, perf::IcebergPerfConfig) -> Scan
 
-Create a scan for the given table.
+Create a scan for the given table, configured with the tuning parameters in `perf`.
+
+`perf` is passed by value across the FFI and is the single source of every tuning
+default (batch size, manifest concurrency, prefetch depth, serialization concurrency).
+There are no per-field setters: the configuration is fixed at construction.
 """
-function new_scan(table::Table)
-    scan_ptr = @ccall rust_lib.iceberg_new_scan(table::Table)::Ptr{Cvoid}
+function new_scan(table::Table, perf::IcebergPerfConfig)
+    scan_ptr = @ccall rust_lib.iceberg_new_scan(
+        table::Table, perf::IcebergPerfConfig)::Ptr{Cvoid}
     return Scan(scan_ptr)
 end
 
@@ -61,79 +65,6 @@ function select_columns!(scan::Scan, column_names::Vector{String})
 end
 
 """
-    with_data_file_concurrency_limit!(scan::Scan, n::UInt)
-
-No-op (kept for API stability). The full-scan pipeline derives its
-concurrency from `with_file_prefetch_depth!` only.
-"""
-with_data_file_concurrency_limit!(::Scan, ::UInt) = nothing
-
-"""
-    with_manifest_file_concurrency_limit!(scan::Scan, n::UInt)
-
-Sets the manifest file concurrency level for the full scan.
-"""
-function with_manifest_file_concurrency_limit!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_manifest_file_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_scan_with_manifest_file_concurrency_limit returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
-    with_manifest_entry_concurrency_limit!(scan::Scan, n::UInt)
-
-Sets the manifest entry concurrency level for the scan.
-"""
-function with_manifest_entry_concurrency_limit!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_manifest_entry_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_scan_with_manifest_entry_concurrency_limit returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
-    with_batch_size!(scan::Scan, n::UInt)
-
-Sets the batch size for the scan. **Required**: must be called before
-`scan!` / streaming the scan; otherwise the Rust FFI will error out
-with "batch_size not set".
-"""
-function with_batch_size!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_batch_size(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_scan_with_batch_size returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
     with_file_column!(scan::Scan)
 
 Add the _file metadata column to the scan.
@@ -143,7 +74,7 @@ tracking which data files contain specific rows.
 
 # Example
 ```julia
-scan = new_scan(table)
+scan = new_scan(table, IcebergPerfConfig())
 with_file_column!(scan)
 stream = scan!(scan)
 ```
@@ -173,7 +104,7 @@ be useful for tracking row locations and debugging.
 
 # Example
 ```julia
-scan = new_scan(table)
+scan = new_scan(table, IcebergPerfConfig())
 with_pos_column!(scan)
 stream = scan!(scan)
 ```
@@ -194,64 +125,6 @@ function with_pos_column!(scan::Scan)
 end
 
 """
-    with_serialization_concurrency_limit!(scan::Scan, n::UInt)
-
-Set the serialization concurrency limit for the scan.
-
-This controls how many RecordBatch serializations can happen in parallel.
-- `n = 0`: Auto-detect based on CPU cores (default)
-- `n > 0`: Use exactly n concurrent serializations
-
-Higher values improve throughput for scans with many batches, but use more memory.
-
-# Example
-```julia
-scan = new_scan(table)
-with_serialization_concurrency_limit!(scan, UInt(8))  # Serialize up to 8 batches in parallel
-stream = scan!(scan)
-```
-"""
-function with_serialization_concurrency_limit!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_serialization_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_scan_with_serialization_concurrency_limit returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
-    with_file_prefetch_depth!(scan::Scan, n::UInt)
-
-Set the width of the full-scan pipeline's `Stream::buffered(prefetch_depth)`
-window. Higher values keep the consumer busy and overlap manifest planning
-with reading, but use more memory. `0` = auto (= `cpu_count()`). Full-scan
-only. See the Rust crate's `nested_pipeline` module-level docs for the
-exact cap on alive `process_file` tasks.
-"""
-function with_file_prefetch_depth!(scan::Scan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_scan_with_file_prefetch_depth(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_scan_with_file_prefetch_depth returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
     with_snapshot_id!(scan::Scan, snapshot_id::Int64)
 
 Set the snapshot ID for the scan.
@@ -264,7 +137,7 @@ comparing data across different points in time.
 ```julia
 table = table_open("s3://path/to/table/metadata.json")
 # List available snapshots (if method is available)
-scan = new_scan(table)
+scan = new_scan(table, IcebergPerfConfig())
 with_snapshot_id!(scan, Int64(123))  # Scan snapshot with ID 123
 stream = scan!(scan)
 ```

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -15,8 +15,7 @@ with builder methods, and call `scan!` to obtain separate Arrow streams for inse
 # Example
 ```julia
 table = table_open("s3://path/to/table/metadata.json")
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-with_batch_size!(scan, UInt(1024))
+scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, IcebergPerfConfig(batch_size=1024))
 inserts_stream, deletes_stream = scan!(scan)
 # ... process batches from both streams
 free_stream(inserts_stream)
@@ -52,31 +51,35 @@ mutable struct UnzippedStreamsResponse
 end
 
 """
-    new_incremental_scan(table::Table, from_snapshot_id::Union{Int64,Nothing}, to_snapshot_id::Union{Int64,Nothing}) -> IncrementalScan
+    new_incremental_scan(table::Table, from_snapshot_id::Union{Int64,Nothing}, to_snapshot_id::Union{Int64,Nothing}, perf::IcebergPerfConfig) -> IncrementalScan
 
-Create an incremental scan for the given table between two snapshots.
+Create an incremental scan for the given table between two snapshots, configured with
+the tuning parameters in `perf`.
 
 # Arguments
 - `table::Table`: The Iceberg table to scan
 - `from_snapshot_id`: Starting snapshot ID, or `nothing` to scan from the root (oldest) snapshot
 - `to_snapshot_id`: Ending snapshot ID, or `nothing` to scan to the current (latest) snapshot
+- `perf::IcebergPerfConfig`: Tuning parameters, passed by value (the single source of
+  every tuning default). There are no per-field setters: configuration is fixed at
+  construction.
 
 # Examples
 ```julia
 # Scan full history (root to current)
-scan = new_incremental_scan(table, nothing, nothing)
+scan = new_incremental_scan(table, nothing, nothing, IcebergPerfConfig())
 
 # Scan from root to specific snapshot
-scan = new_incremental_scan(table, nothing, snapshot_id)
+scan = new_incremental_scan(table, nothing, snapshot_id, IcebergPerfConfig())
 
 # Scan from specific snapshot to current
-scan = new_incremental_scan(table, snapshot_id, nothing)
+scan = new_incremental_scan(table, snapshot_id, nothing, IcebergPerfConfig())
 
 # Scan between specific snapshots
-scan = new_incremental_scan(table, from_id, to_id)
+scan = new_incremental_scan(table, from_id, to_id, IcebergPerfConfig())
 ```
 """
-function new_incremental_scan(table::Table, from_snapshot_id::Union{Int64,Nothing}, to_snapshot_id::Union{Int64,Nothing})
+function new_incremental_scan(table::Table, from_snapshot_id::Union{Int64,Nothing}, to_snapshot_id::Union{Int64,Nothing}, perf::IcebergPerfConfig)
     # Convert nothing to SNAPSHOT_ID_NONE for C API
     from_id = from_snapshot_id === nothing ? SNAPSHOT_ID_NONE : from_snapshot_id
     to_id = to_snapshot_id === nothing ? SNAPSHOT_ID_NONE : to_snapshot_id
@@ -84,7 +87,8 @@ function new_incremental_scan(table::Table, from_snapshot_id::Union{Int64,Nothin
     scan_ptr = @ccall rust_lib.iceberg_new_incremental_scan(
         table::Table,
         from_id::Int64,
-        to_id::Int64
+        to_id::Int64,
+        perf::IcebergPerfConfig
     )::Ptr{Cvoid}
     return IncrementalScan(scan_ptr)
 end
@@ -114,79 +118,6 @@ function select_columns!(scan::IncrementalScan, column_names::Vector{String})
 end
 
 """
-    with_manifest_file_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-Sets the manifest file concurrency level for the incremental scan.
-"""
-function with_manifest_file_concurrency_limit!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_manifest_file_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_incremental_scan_with_manifest_file_concurrency_limit returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
-    with_data_file_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-No-op (kept for API stability). The incremental pipeline derives its
-concurrency from `with_file_prefetch_depth!` only.
-"""
-with_data_file_concurrency_limit!(::IncrementalScan, ::UInt) = nothing
-
-"""
-    with_manifest_entry_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-Sets the manifest entry concurrency level for the incremental scan.
-"""
-function with_manifest_entry_concurrency_limit!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_manifest_entry_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_incremental_scan_with_manifest_entry_concurrency_limit returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
-    with_batch_size!(scan::IncrementalScan, n::UInt)
-
-Sets the batch size for the incremental scan. **Required**: must be called
-before streaming the scan; otherwise the Rust FFI will error out with
-"batch_size not set".
-"""
-function with_batch_size!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_batch_size(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_incremental_scan_with_batch_size returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
     with_file_column!(scan::IncrementalScan)
 
 Add the _file metadata column to the incremental scan.
@@ -196,7 +127,7 @@ tracking which data files contain specific rows during incremental scans.
 
 # Example
 ```julia
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, IcebergPerfConfig())
 with_file_column!(scan)
 inserts_stream, deletes_stream = scan!(scan)
 ```
@@ -217,62 +148,6 @@ function with_file_column!(scan::IncrementalScan)
 end
 
 """
-    with_serialization_concurrency_limit!(scan::IncrementalScan, n::UInt)
-
-Set the serialization concurrency limit for the incremental scan.
-
-This controls how many RecordBatch serializations can happen in parallel for each stream.
-- `n = 0`: Auto-detect based on CPU cores (default)
-- `n > 0`: Use exactly n concurrent serializations per stream
-
-Note: Incremental scans have two separate streams (inserts and deletes), so total
-concurrency can be up to 2×n.
-
-# Example
-```julia
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-with_serialization_concurrency_limit!(scan, UInt(8))  # Each stream serializes up to 8 batches in parallel
-inserts_stream, deletes_stream = scan!(scan)
-```
-"""
-function with_serialization_concurrency_limit!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_serialization_concurrency_limit(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_incremental_scan_with_serialization_concurrency_limit returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
-    with_file_prefetch_depth!(scan::IncrementalScan, n::UInt)
-
-Set how many FileScan tasks are queued ahead in the outer FileScanStream.
-Higher values keep the Julia consumer busy but use more memory.
-"""
-function with_file_prefetch_depth!(scan::IncrementalScan, n::UInt)
-    result = GC.@preserve scan @ccall rust_lib.iceberg_incremental_scan_with_file_prefetch_depth(
-        convert(Ptr{Ptr{Cvoid}}, pointer_from_objref(scan))::Ptr{Ptr{Cvoid}},
-        n::Csize_t
-    )::Cint
-    if result != 0
-        throw(IcebergException(
-            STATE_RESOURCE_FREED,
-            "Resource has been freed",
-            "iceberg_scan_with_file_prefetch_depth returned $result",
-        ))
-    end
-    return nothing
-end
-
-"""
     with_pos_column!(scan::IncrementalScan)
 
 Add the _pos metadata column to the incremental scan.
@@ -282,7 +157,7 @@ be useful for tracking row locations during incremental scans.
 
 # Example
 ```julia
-scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, IcebergPerfConfig())
 with_pos_column!(scan)
 inserts_stream, deletes_stream = scan!(scan)
 ```

--- a/src/scan_common.jl
+++ b/src/scan_common.jl
@@ -1,6 +1,84 @@
 # Common scan utilities shared between full and incremental scans
 
 """
+    IcebergPerfConfig
+
+Scan pipeline & tuning parameters. **This is the single authoritative home for every
+scan tuning default.** It is passed by value across the FFI into [`new_scan`](@ref) /
+[`new_incremental_scan`](@ref); its memory layout must stay in lock-step with the Rust
+`IcebergPerfConfigFFI` helper struct (see `scan_common.rs`). The Rust struct has no
+defaults of its own — every field is supplied from here. A binary-compatibility test
+(`iceberg_perf_config_roundtrip`) guards the layout agreement.
+
+The fields are `UInt64` so the struct is `isbits` and passes by value to `@ccall` with
+no conversion (mirroring the C `u64` fields exactly).
+
+# Pipeline architecture
+
+Reading proceeds in three pipelined stages that overlap concurrently:
+
+  1. Manifest planning (metadata only, no data bytes read)
+     - Fetches manifest list from object storage (one small file per snapshot)
+     - Fetches manifest files concurrently (small Avro files, one per write batch)
+     - Processes manifest entries to build FileScanTask structs, each containing:
+       file path, byte range, record count, projected field IDs, bound predicate,
+       associated delete file list, partition metadata
+     - No Parquet data is opened at this stage
+
+  2. File Scan Task buffering (prefetch window)
+     - Both full and incremental scans run `Stream::buffered(file_prefetch_depth)` over
+       the planned per-file tasks. See the `nested_pipeline` module docs for the exact
+       cap on alive `process_file` tasks.
+     - Upstream is iceberg-rust's own internal channel (capacity =
+       manifest_entry_concurrency_limit).
+     - Purpose: hide manifest fetch latency (S3 round trips ~5–50ms each) behind data
+       read time.
+
+  3. Data reading
+     - Each per-file task opens one Parquet file, applies column projection and predicate,
+       loads associated delete files (full scan) or merges position deletes (incremental),
+       and streams Arrow record batches.
+     - Batches are serialized to Arrow IPC via tokio::task::spawn_blocking on both paths.
+
+# Tuning parameters
+
+  batch_size
+    Number of rows per Arrow record batch. Smaller batches reduce memory pressure;
+    larger batches reduce per-batch overhead. Applies to both data and delete file reads.
+
+  manifest_file_concurrency_limit
+    Per scan cap on how many manifest files are fetched from object storage concurrently.
+    All manifests for the snapshot share one pool.
+
+  manifest_entry_concurrency_limit
+    Per scan cap on how many manifest entries are processed concurrently — total across
+    all in-flight manifests, not per-manifest. Also sets the internal task channel
+    capacity, so it influences pipeline lookahead.
+
+  file_prefetch_depth
+    Width of the pipeline's `Stream::buffered(file_prefetch_depth)` window. Higher
+    values allow manifest planning to run further ahead of consumption, smoothing
+    bursts of object-storage latency. Each buffered reader holds open one file
+    and may have deserialized Arrow batches in memory, so this parameter also
+    bounds how much batch memory the FFI layer holds at once. Applies to both the
+    full-scan and incremental pipelines (both consume the value verbatim).
+
+  serialization_concurrency_limit
+    No-op for full scans (Arrow IPC serialization is dispatched per batch via
+    tokio::task::spawn_blocking inside the shared per-file pipeline, with parallelism
+    implicitly bounded by file_prefetch_depth). Incremental scans still honour it on
+    the delete-stream fan-out side (position deletes are flat-stream-serialized). The
+    legacy iterator-API path also honours it via its own spawn_blocking fan-out.
+"""
+Base.@kwdef struct IcebergPerfConfig
+    batch_size::UInt64 = 64 * 1024
+    manifest_file_concurrency_limit::UInt64 = Threads.nthreads() * 2
+    manifest_entry_concurrency_limit::UInt64 = Threads.nthreads() * 2
+    file_prefetch_depth::UInt64 = 1
+    serialization_concurrency_limit::UInt64 = Threads.nthreads()
+end
+
+"""
     ArrowStream
 
 Opaque pointer type representing an Arrow stream from the Rust FFI layer.
@@ -20,7 +98,7 @@ column in Iceberg tables.
 # Example
 ```julia
 # Select specific columns including the file path
-scan = new_scan(table)
+scan = new_scan(table, IcebergPerfConfig())
 select_columns!(scan, ["id", "name", FILE_COLUMN])
 stream = scan!(scan)
 ```
@@ -39,7 +117,7 @@ column in Iceberg tables, which represents the row's position within its data fi
 # Example
 ```julia
 # Select specific columns including the position
-scan = new_scan(table)
+scan = new_scan(table, IcebergPerfConfig())
 select_columns!(scan, ["id", "name", POS_COLUMN])
 stream = scan!(scan)
 ```

--- a/src/scan_common.jl
+++ b/src/scan_common.jl
@@ -69,6 +69,30 @@ Reading proceeds in three pipelined stages that overlap concurrently:
     implicitly bounded by file_prefetch_depth). Incremental scans still honour it on
     the delete-stream fan-out side (position deletes are flat-stream-serialized). The
     legacy iterator-API path also honours it via its own spawn_blocking fan-out.
+
+== Per-file output buffering ==
+
+These bound how much already-read batch data the FFI layer holds in memory per data
+file, independently of `file_prefetch_depth` (which bounds how many *files* are in
+flight). Together with `file_prefetch_depth` they cap the pipeline's peak memory.
+
+  max_buffered_bytes_per_task
+    Per-file output-buffer cap in bytes. Each file's producer task parks once this
+    much undrained batch data is buffered for that file, resuming as the Julia
+    consumer drains batches. Larger = more read-ahead per file (smoother throughput)
+    at higher peak memory.
+
+  max_prefetch_buffers_of_waiting_file
+    Batch-slot budget for a *waiting* file — one whose per-file scan has been produced
+    by the outer pipeline but not yet picked up by the consumer. Kept small so waiting
+    files don't hoard memory before they are actively drained. Must be
+    `<= max_prefetch_buffers_of_active_file`.
+
+  max_prefetch_buffers_of_active_file
+    Batch-slot budget (and the per-file channel capacity) for an *active* file — one
+    handed off to the Julia consumer. Promoted from the waiting budget at hand-off.
+    Once active, this slot budget is typically slack and `max_buffered_bytes_per_task`
+    is the binding constraint.
 """
 Base.@kwdef struct IcebergPerfConfig
     batch_size::UInt64 = 64 * 1024
@@ -76,6 +100,9 @@ Base.@kwdef struct IcebergPerfConfig
     manifest_entry_concurrency_limit::UInt64 = Threads.nthreads() * 2
     file_prefetch_depth::UInt64 = 1
     serialization_concurrency_limit::UInt64 = Threads.nthreads()
+    max_buffered_bytes_per_task::UInt64 = 100 * 1024 * 1024
+    max_prefetch_buffers_of_waiting_file::UInt64 = 1
+    max_prefetch_buffers_of_active_file::UInt64 = 8
 end
 
 """

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -571,11 +571,9 @@ end
 
         # Create a scan on the loaded table
         println("Creating scan on loaded customer table...")
-        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig())
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         @test scan != C_NULL
         println("✅ Scan created successfully on loaded table")
-
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
 
         # Select specific columns to verify table structure
         println("Selecting specific columns from customer table...")
@@ -660,11 +658,9 @@ end
 
         # Create a scan on the loaded table
         println("Creating scan on loaded customer table...")
-        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig())
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         @test scan != C_NULL
         println("✅ Scan created successfully on loaded table")
-
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
 
         # Select specific columns
         println("Selecting specific columns from customer table...")
@@ -809,11 +805,9 @@ end
 
             # Create a scan on the loaded table
             println("Creating scan on loaded customer table...")
-            scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig())
+            scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
             @test scan != C_NULL
             println("✅ Scan created successfully on loaded table")
-
-            RustyIceberg.with_batch_size!(scan, UInt(1024))
 
             # Select specific columns
             println("Selecting specific columns from customer table...")
@@ -891,15 +885,10 @@ end
         to_snapshot_id = Int64(6832180054960511692)
 
         println("Creating incremental scan on catalog-loaded table...")
-        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig())
+        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig(batch_size=10))
         @test scan isa RustyIceberg.IncrementalScan
         @test scan.ptr != C_NULL
         println("✅ Incremental scan created successfully on catalog-loaded table")
-
-        # Configure scan with batch size
-        println("Configuring incremental scan...")
-        RustyIceberg.with_batch_size!(scan, UInt(10))
-        println("✅ Batch size configured")
 
         # Execute the scan to get streams
         println("Executing incremental scan on catalog-loaded table...")

--- a/test/catalog_tests.jl
+++ b/test/catalog_tests.jl
@@ -571,7 +571,7 @@ end
 
         # Create a scan on the loaded table
         println("Creating scan on loaded customer table...")
-        scan = RustyIceberg.new_scan(table)
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig())
         @test scan != C_NULL
         println("✅ Scan created successfully on loaded table")
 
@@ -660,7 +660,7 @@ end
 
         # Create a scan on the loaded table
         println("Creating scan on loaded customer table...")
-        scan = RustyIceberg.new_scan(table)
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig())
         @test scan != C_NULL
         println("✅ Scan created successfully on loaded table")
 
@@ -742,8 +742,7 @@ end
             credential_error_caught = false
             try
                 table = RustyIceberg.load_table(catalog, ["tpch.sf01"], "customer"; load_credentials=false)
-                scan = RustyIceberg.new_scan(table)
-                RustyIceberg.with_batch_size!(scan, UInt(1024))
+                scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
                 RustyIceberg.select_columns!(scan, ["c_custkey"])
                 stream = RustyIceberg.scan!(scan)
                 RustyIceberg.next_batch(stream)
@@ -810,7 +809,7 @@ end
 
             # Create a scan on the loaded table
             println("Creating scan on loaded customer table...")
-            scan = RustyIceberg.new_scan(table)
+            scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig())
             @test scan != C_NULL
             println("✅ Scan created successfully on loaded table")
 
@@ -892,7 +891,7 @@ end
         to_snapshot_id = Int64(6832180054960511692)
 
         println("Creating incremental scan on catalog-loaded table...")
-        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = RustyIceberg.new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig())
         @test scan isa RustyIceberg.IncrementalScan
         @test scan.ptr != C_NULL
         println("✅ Incremental scan created successfully on catalog-loaded table")

--- a/test/error_tests.jl
+++ b/test/error_tests.jl
@@ -189,8 +189,7 @@ end
                     rm(f)
                 end
 
-                scan = new_scan(updated_table)
-                with_batch_size!(scan, UInt(1024))
+                scan = new_scan(updated_table, IcebergPerfConfig(batch_size=1024))
                 stream = C_NULL
                 error_caught = false
                 try
@@ -254,8 +253,7 @@ end
                     end
                 end
 
-                scan = new_scan(updated_table)
-                with_batch_size!(scan, UInt(1024))
+                scan = new_scan(updated_table, IcebergPerfConfig(batch_size=1024))
                 stream = C_NULL
                 error_caught = false
                 try
@@ -308,7 +306,7 @@ end
                     end
                 end
 
-                scan = new_scan(updated_table)
+                scan = new_scan(updated_table, IcebergPerfConfig())
                 with_snapshot_id!(scan, Int64(999_999_999_999))  # non-existent
                 with_batch_size!(scan, UInt(1024))
                 stream = C_NULL
@@ -628,8 +626,7 @@ end
             try
                 create_namespace(cat, ["ns"])
                 tbl = create_table(cat, ["ns"], "loc_scan", _err_schema())
-                scan = new_scan(tbl)
-                with_batch_size!(scan, UInt(1024))
+                scan = new_scan(tbl, IcebergPerfConfig(batch_size=1024))
                 # Do NOT call build!(scan) — leaves scan.scan as None on the Rust side.
                 exc = try
                     RustyIceberg.arrow_stream(scan)  # "Scan not initialized" guard

--- a/test/error_tests.jl
+++ b/test/error_tests.jl
@@ -306,9 +306,8 @@ end
                     end
                 end
 
-                scan = new_scan(updated_table, IcebergPerfConfig())
+                scan = new_scan(updated_table, IcebergPerfConfig(batch_size=1024))
                 with_snapshot_id!(scan, Int64(999_999_999_999))  # non-existent
-                with_batch_size!(scan, UInt(1024))
                 stream = C_NULL
                 exc = try
                     stream = scan!(scan)

--- a/test/perf_config_tests.jl
+++ b/test/perf_config_tests.jl
@@ -1,0 +1,32 @@
+# Binary-compatibility tests for IcebergPerfConfig <-> IcebergPerfConfigFFI.
+#
+# IcebergPerfConfig (Julia) is passed BY VALUE across the FFI into new_scan /
+# new_incremental_scan, where Rust reinterprets the bytes as its repr(C)
+# IcebergPerfConfigFFI struct. A silent layout drift would corrupt scans, so we
+# guard the layout here. These tests are server-free (no catalog / object store):
+# `iceberg_perf_config_roundtrip` is a pure synchronous FFI echo.
+
+@testset "IcebergPerfConfig FFI binary compatibility" begin
+    # The struct must be isbits (so it passes by value with no conversion) and
+    # exactly 5 × UInt64 wide, matching the Rust `#[repr(C)]` struct of 5 × u64.
+    @test isbitstype(RustyIceberg.IcebergPerfConfig)
+    @test sizeof(RustyIceberg.IcebergPerfConfig) == 5 * sizeof(UInt64)
+
+    # Round-trip through the real FFI with five DISTINCT sentinel values so a
+    # transposed pair of fields is detected (not just a size mismatch).
+    cfg = RustyIceberg.IcebergPerfConfig(;
+        batch_size = 11,
+        manifest_file_concurrency_limit = 22,
+        manifest_entry_concurrency_limit = 33,
+        file_prefetch_depth = 44,
+        serialization_concurrency_limit = 55,
+    )
+    out = zeros(UInt64, 5)
+    GC.@preserve out @ccall RustyIceberg.rust_lib.iceberg_perf_config_roundtrip(
+        cfg::RustyIceberg.IcebergPerfConfig,
+        out::Ptr{UInt64},
+    )::Cvoid
+    @test out == UInt64[11, 22, 33, 44, 55]
+
+    println("✅ IcebergPerfConfig FFI binary compatibility verified")
+end

--- a/test/perf_config_tests.jl
+++ b/test/perf_config_tests.jl
@@ -8,11 +8,11 @@
 
 @testset "IcebergPerfConfig FFI binary compatibility" begin
     # The struct must be isbits (so it passes by value with no conversion) and
-    # exactly 5 × UInt64 wide, matching the Rust `#[repr(C)]` struct of 5 × u64.
+    # exactly 8 × UInt64 wide, matching the Rust `#[repr(C)]` struct of 8 × u64.
     @test isbitstype(RustyIceberg.IcebergPerfConfig)
-    @test sizeof(RustyIceberg.IcebergPerfConfig) == 5 * sizeof(UInt64)
+    @test sizeof(RustyIceberg.IcebergPerfConfig) == 8 * sizeof(UInt64)
 
-    # Round-trip through the real FFI with five DISTINCT sentinel values so a
+    # Round-trip through the real FFI with eight DISTINCT sentinel values so a
     # transposed pair of fields is detected (not just a size mismatch).
     cfg = RustyIceberg.IcebergPerfConfig(;
         batch_size = 11,
@@ -20,13 +20,16 @@
         manifest_entry_concurrency_limit = 33,
         file_prefetch_depth = 44,
         serialization_concurrency_limit = 55,
+        max_buffered_bytes_per_task = 66,
+        max_prefetch_buffers_of_waiting_file = 77,
+        max_prefetch_buffers_of_active_file = 88,
     )
-    out = zeros(UInt64, 5)
+    out = zeros(UInt64, 8)
     GC.@preserve out @ccall RustyIceberg.rust_lib.iceberg_perf_config_roundtrip(
         cfg::RustyIceberg.IcebergPerfConfig,
         out::Ptr{UInt64},
     )::Cvoid
-    @test out == UInt64[11, 22, 33, 44, 55]
+    @test out == UInt64[11, 22, 33, 44, 55, 66, 77, 88]
 
     println("✅ IcebergPerfConfig FFI binary compatibility verified")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,9 @@ include("test_helpers.jl")
 # Include schema tests
 include("schema_tests.jl")
 
+# Binary-compatibility tests for the perf-config FFI struct (server-free)
+include("perf_config_tests.jl")
+
 @testset "Runtime Initialization" begin
     # Test runtime initialization - this should work
     @test_nowarn init_runtime()

--- a/test/scan_tests.jl
+++ b/test/scan_tests.jl
@@ -17,12 +17,10 @@ using Tables
     println("✅ Table opened successfully")
 
     # Create scan
-    scan = RustyIceberg.new_scan(table)
+    scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
     @test scan isa RustyIceberg.Scan
     @test scan.ptr != C_NULL
     println("✅ Scan created successfully")
-
-    RustyIceberg.with_batch_size!(scan, UInt(1024))
 
     # Build and get stream
     stream = RustyIceberg.scan!(scan)
@@ -91,9 +89,8 @@ using Tables
             selected_columns = names(first_df)[1:min(2, length(names(first_df)))]
 
             table2 = RustyIceberg.table_open(snapshot_path)
-            scan2 = RustyIceberg.new_scan(table2)
+            scan2 = RustyIceberg.new_scan(table2, RustyIceberg.IcebergPerfConfig(batch_size=8))
             RustyIceberg.select_columns!(scan2, selected_columns)
-            RustyIceberg.with_batch_size!(scan2, UInt(8))
             stream2 = RustyIceberg.scan!(scan2)
 
             try
@@ -147,8 +144,7 @@ end
     println("Testing reading nations table...")
 
     table = RustyIceberg.table_open(nations_snapshot_path)
-    scan = RustyIceberg.new_scan(table)
-    RustyIceberg.with_batch_size!(scan, UInt(5))
+    scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=5))
     stream = RustyIceberg.scan!(scan)
 
     rows = Tuple[]
@@ -219,8 +215,7 @@ end
     nations_snapshot_path = "s3://warehouse/tpch.sf01/nation/metadata/00001-44f668fe-3688-49d5-851f-36e75d143321.metadata.json"
 
     table = RustyIceberg.table_open(nations_snapshot_path)
-    scan = RustyIceberg.new_scan(table)
-    RustyIceberg.with_batch_size!(scan, UInt(5))
+    scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=5))
     stream = RustyIceberg.scan!(scan)
 
     rows = Tuple[]
@@ -260,13 +255,10 @@ end
     to_snapshot_id = Int64(6832180054960511692)
 
     @testset "Incremental Scan E2E Test" begin
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig(batch_size=50))
         @test scan isa RustyIceberg.IncrementalScan
         @test scan.ptr != C_NULL
         println("✅ Incremental scan created (from snapshot $from_snapshot_id to $to_snapshot_id)")
-
-        # Test builder methods
-        @test_nowarn RustyIceberg.with_batch_size!(scan, UInt(50))
         println("✅ Batch size configured")
 
         # Build and get streams
@@ -372,7 +364,7 @@ end
     end
 
     @testset "Incremental Scan with Column Selection" begin
-        scan2 = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan2 = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig())
 
         # Select only the "n" column
         RustyIceberg.select_columns!(scan2, ["n"])
@@ -405,15 +397,10 @@ end
 
     @testset "Incremental Scan with nothing for both snapshot IDs" begin
         # Test scanning from root (nothing) to current (nothing) - full history
-        scan3 = new_incremental_scan(table, nothing, nothing)
+        scan3 = new_incremental_scan(table, nothing, nothing, RustyIceberg.IcebergPerfConfig(manifest_file_concurrency_limit=2, manifest_entry_concurrency_limit=256, batch_size=50))
         @test scan3 isa RustyIceberg.IncrementalScan
         @test scan3.ptr != C_NULL
         println("✅ Incremental scan created with nothing for both snapshot IDs")
-
-        RustyIceberg.with_manifest_file_concurrency_limit!(scan3, UInt(2))
-        RustyIceberg.with_manifest_entry_concurrency_limit!(scan3, UInt(256))
-        RustyIceberg.with_data_file_concurrency_limit!(scan3, UInt(1024))
-        RustyIceberg.with_batch_size!(scan3, UInt(50))
 
         inserts_stream3, deletes_stream3 = RustyIceberg.scan!(scan3)
         @test inserts_stream3 != C_NULL
@@ -514,8 +501,7 @@ end
 
     @testset "select_columns! - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
 
         # Select specific columns
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
@@ -545,7 +531,7 @@ end
 
     @testset "select_columns! - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig())
 
         RustyIceberg.select_columns!(scan, ["n"])
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
@@ -573,12 +559,10 @@ end
         end
     end
 
-    @testset "with_batch_size! - Full Scan" begin
+    @testset "batch_size via IcebergPerfConfig - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-
-        # Set small batch size
-        RustyIceberg.with_batch_size!(scan, UInt(10))
+        # Set small batch size via perf config
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=10))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -594,7 +578,7 @@ end
                 RustyIceberg.free_batch(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_batch_size! test passed for full scan")
+            println("✅ batch_size via IcebergPerfConfig test passed for full scan")
         finally
             RustyIceberg.free_stream(stream)
             RustyIceberg.free_scan!(scan)
@@ -602,11 +586,10 @@ end
         end
     end
 
-    @testset "with_batch_size! - Incremental Scan" begin
+    @testset "batch_size via IcebergPerfConfig - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig(batch_size=10))
 
-        RustyIceberg.with_batch_size!(scan, UInt(10))
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -621,7 +604,7 @@ end
                 RustyIceberg.free_batch(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ with_batch_size! test passed for incremental scan")
+            println("✅ batch_size via IcebergPerfConfig test passed for incremental scan")
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
@@ -630,13 +613,9 @@ end
         end
     end
 
-    @testset "with_data_file_concurrency_limit! - Full Scan" begin
+    @testset "full scan basic" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
-
-        # Set concurrency limit (should not error)
-        @test_nowarn RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(4))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -645,7 +624,7 @@ end
                 RustyIceberg.free_batch(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_data_file_concurrency_limit! test passed for full scan")
+            println("✅ full scan basic test passed")
         finally
             RustyIceberg.free_stream(stream)
             RustyIceberg.free_scan!(scan)
@@ -653,11 +632,10 @@ end
         end
     end
 
-    @testset "with_data_file_concurrency_limit! - Incremental Scan" begin
+    @testset "incremental scan basic" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig())
 
-        @test_nowarn RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(4))
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -666,7 +644,7 @@ end
                 RustyIceberg.free_batch(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ with_data_file_concurrency_limit! test passed for incremental scan")
+            println("✅ incremental scan basic test passed")
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
@@ -675,13 +653,10 @@ end
         end
     end
 
-    @testset "with_manifest_entry_concurrency_limit! - Full Scan" begin
+    @testset "manifest_entry_concurrency_limit via IcebergPerfConfig - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
-
-        # Set concurrency limit (should not error)
-        @test_nowarn RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(4))
+        # Set concurrency limit via perf config
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024, manifest_entry_concurrency_limit=4))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -690,7 +665,7 @@ end
                 RustyIceberg.free_batch(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_manifest_entry_concurrency_limit! test passed for full scan")
+            println("✅ manifest_entry_concurrency_limit via IcebergPerfConfig test passed for full scan")
         finally
             RustyIceberg.free_stream(stream)
             RustyIceberg.free_scan!(scan)
@@ -698,13 +673,10 @@ end
         end
     end
 
-    @testset "with_manifest_file_concurrency_limit! - Full Scan" begin
+    @testset "manifest_file_concurrency_limit via IcebergPerfConfig - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
-
-        # Set concurrency limit (should not error)
-        @test_nowarn RustyIceberg.with_manifest_file_concurrency_limit!(scan, UInt(4))
+        # Set concurrency limit via perf config
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024, manifest_file_concurrency_limit=4))
         stream = RustyIceberg.scan!(scan)
 
         try
@@ -713,7 +685,7 @@ end
                 RustyIceberg.free_batch(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(stream)
             end
-            println("✅ with_manifest_file_concurrency_limit! test passed for full scan")
+            println("✅ manifest_file_concurrency_limit via IcebergPerfConfig test passed for full scan")
         finally
             RustyIceberg.free_stream(stream)
             RustyIceberg.free_scan!(scan)
@@ -721,11 +693,10 @@ end
         end
     end
 
-    @testset "with_manifest_entry_concurrency_limit! - Incremental Scan" begin
+    @testset "manifest_entry_concurrency_limit via IcebergPerfConfig - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig(manifest_entry_concurrency_limit=4))
 
-        @test_nowarn RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(4))
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
         try
@@ -734,7 +705,7 @@ end
                 RustyIceberg.free_batch(batch_ptr)
                 batch_ptr = RustyIceberg.next_batch(inserts_stream)
             end
-            println("✅ with_manifest_entry_concurrency_limit! test passed for incremental scan")
+            println("✅ manifest_entry_concurrency_limit via IcebergPerfConfig test passed for incremental scan")
         finally
             RustyIceberg.free_stream(inserts_stream)
             RustyIceberg.free_stream(deletes_stream)
@@ -745,14 +716,10 @@ end
 
     @testset "Combined Builder Methods - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=5, manifest_entry_concurrency_limit=2, serialization_concurrency_limit=2))
 
         # Combine multiple builder methods
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", "c_address"])
-        RustyIceberg.with_batch_size!(scan, UInt(5))
-        RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_serialization_concurrency_limit!(scan, UInt(2))
 
         stream = RustyIceberg.scan!(scan)
 
@@ -782,15 +749,10 @@ end
 
     @testset "Combined Builder Methods - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig(batch_size=5, manifest_file_concurrency_limit=2, manifest_entry_concurrency_limit=2, serialization_concurrency_limit=2))
 
         # Combine multiple builder methods
         RustyIceberg.select_columns!(scan, ["n"])
-        RustyIceberg.with_batch_size!(scan, UInt(5))
-        RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_manifest_file_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_manifest_entry_concurrency_limit!(scan, UInt(2))
-        RustyIceberg.with_serialization_concurrency_limit!(scan, UInt(2))
 
         inserts_stream, deletes_stream = RustyIceberg.scan!(scan)
 
@@ -820,8 +782,7 @@ end
 
     @testset "select_columns! with with_file_column! - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
 
         # Select specific columns AND include file metadata
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
@@ -864,7 +825,7 @@ end
 
     @testset "select_columns! with with_file_column! - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig())
 
         # Select specific column AND include file metadata for incremental scan
         RustyIceberg.select_columns!(scan, ["n"])
@@ -905,8 +866,7 @@ end
 
     @testset "select_columns! with FILE_COLUMN constant" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
 
         # Select columns including FILE_COLUMN constant
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", RustyIceberg.FILE_COLUMN])
@@ -947,8 +907,7 @@ end
 
     @testset "select_columns! with with_pos_column! - Full Scan" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
 
         # Select specific columns AND include pos metadata
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
@@ -994,7 +953,7 @@ end
 
     @testset "select_columns! with with_pos_column! - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
+        scan = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig())
 
         # Select specific column AND include pos metadata for incremental scan
         RustyIceberg.select_columns!(scan, ["n"])
@@ -1084,8 +1043,7 @@ end
 
     @testset "select_columns! with POS_COLUMN constant" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
 
         # Select columns including POS_COLUMN constant
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", RustyIceberg.POS_COLUMN])
@@ -1129,8 +1087,7 @@ end
 
     @testset "with_file_column! and with_pos_column! combined" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
 
         # Select columns and include both file and pos metadata
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
@@ -1183,8 +1140,7 @@ end
         # Use the correct snapshot ID for the customer table
         customer_snapshot_id = Int64(3441867730092225551)
 
-        scan = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
 
         # Set snapshot ID explicitly using builder method
         RustyIceberg.with_snapshot_id!(scan, customer_snapshot_id)
@@ -1235,12 +1191,9 @@ end
         end
     end
 
-    @testset "with_file_prefetch_depth!" begin
+    @testset "file_prefetch_depth via IcebergPerfConfig" begin
         table = RustyIceberg.table_open(customer_path)
-        scan  = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
-
-        @test_nowarn RustyIceberg.with_file_prefetch_depth!(scan, UInt(4))
+        scan  = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024, file_prefetch_depth=4))
         stream = RustyIceberg.scan!(scan)
 
         total_rows = 0
@@ -1261,15 +1214,12 @@ end
         end
 
         @test total_rows > 0
-        println("✅ with_file_prefetch_depth! test passed ($total_rows rows)")
+        println("✅ file_prefetch_depth via IcebergPerfConfig test passed ($total_rows rows)")
     end
 
-    @testset "with_file_prefetch_depth! - Incremental Scan" begin
+    @testset "file_prefetch_depth via IcebergPerfConfig - Incremental Scan" begin
         table = RustyIceberg.table_open(incremental_path)
-        scan  = new_incremental_scan(table, from_snapshot_id, to_snapshot_id)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
-
-        @test_nowarn RustyIceberg.with_file_prefetch_depth!(scan, UInt(4))
+        scan  = new_incremental_scan(table, from_snapshot_id, to_snapshot_id, RustyIceberg.IcebergPerfConfig(batch_size=1024, file_prefetch_depth=4))
         append_stream, delete_stream = RustyIceberg.scan_incremental_nested!(scan)
 
         total_rows = 0
@@ -1297,12 +1247,12 @@ end
         end
 
         @test total_rows > 0
-        println("✅ with_file_prefetch_depth! test passed for incremental scan ($total_rows rows)")
+        println("✅ file_prefetch_depth via IcebergPerfConfig test passed for incremental scan ($total_rows rows)")
     end
 
     @testset "Combined with_snapshot_id! and other builder methods" begin
         table = RustyIceberg.table_open(customer_path)
-        scan = RustyIceberg.new_scan(table)
+        scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=5))
 
         # Use the correct snapshot ID for the customer table
         customer_snapshot_id = Int64(3441867730092225551)
@@ -1310,8 +1260,6 @@ end
         # Combine multiple builder methods including snapshot_id
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name", "c_address"])
         RustyIceberg.with_snapshot_id!(scan, customer_snapshot_id)
-        RustyIceberg.with_batch_size!(scan, UInt(5))
-        RustyIceberg.with_data_file_concurrency_limit!(scan, UInt(2))
 
         stream = RustyIceberg.scan!(scan)
 
@@ -1360,8 +1308,7 @@ end
     @testset "nested_arrow_stream called directly after build!" begin
         # scan_nested! = build! + nested_arrow_stream; exercise the two-step path.
         table = RustyIceberg.table_open(nations_path)
-        scan  = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan  = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         RustyIceberg.build!(scan)
         outer = RustyIceberg.nested_arrow_stream(scan)
         @test outer != C_NULL
@@ -1395,8 +1342,7 @@ end
 
     @testset "Basic iteration — filenames and record counts" begin
         table = RustyIceberg.table_open(nations_path)
-        scan  = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan  = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         outer = RustyIceberg.scan_nested!(scan)
         @test outer != C_NULL
 
@@ -1440,8 +1386,7 @@ end
     @testset "Row counts match flat scan" begin
         # Collect total rows via nested pipeline.
         table_n = RustyIceberg.table_open(customer_path)
-        scan_n  = RustyIceberg.new_scan(table_n)
-        RustyIceberg.with_batch_size!(scan_n, UInt(1024))
+        scan_n  = RustyIceberg.new_scan(table_n, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         outer   = RustyIceberg.scan_nested!(scan_n)
 
         nested_rows = 0
@@ -1469,8 +1414,7 @@ end
 
         # Collect total rows via flat pipeline.
         table_f  = RustyIceberg.table_open(customer_path)
-        scan_f   = RustyIceberg.new_scan(table_f)
-        RustyIceberg.with_batch_size!(scan_f, UInt(1024))
+        scan_f   = RustyIceberg.new_scan(table_f, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         stream_f = RustyIceberg.scan!(scan_f)
 
         flat_rows = 0
@@ -1497,8 +1441,7 @@ end
 
     @testset "Correct data — nations table" begin
         table = RustyIceberg.table_open(nations_path)
-        scan  = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan  = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         outer = RustyIceberg.scan_nested!(scan)
 
         rows = Tuple[]
@@ -1535,11 +1478,10 @@ end
         println("✅ Correct data verified for nations table via nested API")
     end
 
-    @testset "Builder methods — select_columns! and with_batch_size!" begin
+    @testset "Builder methods — select_columns! and batch_size via IcebergPerfConfig" begin
         table = RustyIceberg.table_open(customer_path)
-        scan  = RustyIceberg.new_scan(table)
+        scan  = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=10))
         RustyIceberg.select_columns!(scan, ["c_custkey", "c_name"])
-        RustyIceberg.with_batch_size!(scan, UInt(10))
         outer = RustyIceberg.scan_nested!(scan)
 
         try
@@ -1565,14 +1507,13 @@ end
             RustyIceberg.free_scan!(scan)
             RustyIceberg.free_table(table)
         end
-        println("✅ select_columns! and with_batch_size! work with nested API")
+        println("✅ select_columns! and batch_size via IcebergPerfConfig work with nested API")
     end
 
     @testset "Safe early drop of FileScan" begin
         # Drop a FileScan after reading only the first batch — must not crash or hang.
         table = RustyIceberg.table_open(customer_path)
-        scan  = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1))
+        scan  = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1))
         outer = RustyIceberg.scan_nested!(scan)
 
         try
@@ -1599,8 +1540,7 @@ end
     @testset "print_pipeline_stats and reset_pipeline_stats" begin
         # Run a full scan so the pipeline stats are populated.
         table  = RustyIceberg.table_open(nations_path)
-        scan   = RustyIceberg.new_scan(table)
-        RustyIceberg.with_batch_size!(scan, UInt(1024))
+        scan   = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
         stream = RustyIceberg.scan!(scan)
         try
             batch_ptr = RustyIceberg.next_batch(stream)

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -16,8 +16,7 @@ tbl = read_table_data(table)
 ```
 """
 function read_table_data(table)
-    scan = RustyIceberg.new_scan(table)
-    RustyIceberg.with_batch_size!(scan, UInt(1024))
+    scan = RustyIceberg.new_scan(table, RustyIceberg.IcebergPerfConfig(batch_size=1024))
     stream = RustyIceberg.scan!(scan)
 
     # Collect column data across batches as plain Julia vectors.


### PR DESCRIPTION
[RAI-50776](https://relationalai.atlassian.net/browse/RAI-50776)

Consolidate all Iceberg scan tuning parameters into a single `IcebergPerfConfig` that is the one authoritative home for every default, passed **by value** into `new_scan` / `new_incremental_scan` at construction. Removes the per-knob `with_*!` setters, the `Option`/`0 = auto` hidden defaults, the dead `data_file_concurrency_limit`, and the hard-coded per-file buffer constants — a forgotten knob is now a compile error, not a silent wrong default.

> ⚠️ **Breaking change (ABI + Julia API).** Paired with raicode PR **RelationalAI/raicode#27966**. Must be published + merged in the order below.

## 🔀 How to merge (do these in order)

The dependency chain is raicode → RustyIceberg.jl (Julia, git-rev pinned) → `iceberg_rust_ffi_jll` (the Rust dylib). Because this is an ABI break, the **JLL must be published first** so this PR's `test-julia` CI can resolve `iceberg_rust_ffi_jll = "0.9"` and go green.

1. **Publish the new JLL first** — open a Yggdrasil PR for `iceberg_rust_ffi` at **`v0.9.0`** with the `GitSource` pointing at this branch's pushed commit (`5493fe4`). The Rust crate is fetched by commit SHA, so **this does not require this PR to be merged** — it can (and should) be done now. Pattern: [Yggdrasil#13808](https://github.com/JuliaPackaging/Yggdrasil/pull/13808) (Robert's `0.8.0`), [Yggdrasil#13839](https://github.com/JuliaPackaging/Yggdrasil/pull/13839) (Gerald's bump).
2. **This PR's CI goes green** once `iceberg_rust_ffi_jll 0.9.x` is registered (the `[compat]` here requires `"0.9"`). Until then, `test-julia-*` correctly fails with `Unsatisfiable requirements … iceberg_rust_ffi_jll`. ✅ Existing consumers are unaffected meanwhile: raicode `master` pins RustyIceberg by an exact git-rev in its `Manifest.toml` lockfile, so it keeps resolving the old `0.8.3` + old `iceberg_rust_ffi_jll 0.8.x`.
3. **Merge this PR**, then trigger the `RustyIceberg.jl 0.9.0` release (open the merge commit and comment to kick off the registry/TagBot flow — see this repo's README → *Release*). Version is already bumped to `0.9.0` here.
4. **Then** the raicode side (**RelationalAI/raicode#27966**) can be merged: it re-resolves its `Manifest.toml` to this new rev + `iceberg_rust_ffi_jll 0.9.x` and starts using the new API. See that PR for its own steps.

Prior art for this exact 3-repo dance (RustyIceberg.jl → Yggdrasil → raicode): the Arrow C Data Interface breaking change — [RustyIceberg.jl#100](https://github.com/RelationalAI/RustyIceberg.jl/pull/100) → [Yggdrasil#13808](https://github.com/JuliaPackaging/Yggdrasil/pull/13808) → [raicode#27727](https://github.com/RelationalAI/raicode/pull/27727).

## Summary

- **One config, owned here.** `IcebergPerfConfig` (Julia, `scan_common.jl`) holds every tuning default with the full tuning docstring; raicode re-exports it and no longer defines its own. Knobs: `batch_size`, `manifest_file_concurrency_limit`, `manifest_entry_concurrency_limit`, `file_prefetch_depth`, `serialization_concurrency_limit`, plus the per-file output-buffer limits `max_buffered_bytes_per_task`, `max_prefetch_buffers_of_waiting_file`, `max_prefetch_buffers_of_active_file`.
- **By-value construction.** `new_scan(table, perf)` / `new_incremental_scan(table, from, to, perf)` take the config and apply the manifest/batch knobs to the iceberg-rs builder at construction. Deleted: `with_batch_size!`, `with_file_prefetch_depth!`, `with_serialization_concurrency_limit!`, `with_manifest_*_concurrency_limit!`, and the `with_data_file_concurrency_limit!` no-ops (+ their exports).
- **Per-file buffer limits are now per-scan too** (Robert's review): the former hard-coded `MAX_BUFFERED_BYTES_PER_TASK` / `MAX_PREFETCH_BUFFERS_OF_{WAITING,ACTIVE}_FILE` constants are gone; the values are carried per-scan in a `BufferLimits` struct on the scan and threaded through `create_nested_pipeline` / `spawn_file_task` to size the byte semaphore, the waiting/active slot budgets, and the per-file mpsc capacity. Defaults (100 MiB / 1 / 8) live only in the Julia `IcebergPerfConfig`.
- **Rust FFI:** new `#[repr(C)] IcebergPerfConfigFFI` (8× `u64`, no `Default`) as the by-value wire struct; `batch_size: Option<usize>` → `usize`; removed the dead `file_concurrency` field and every `0 = auto` (`cpu_count`) fallback — values are used verbatim. Dead FFI setters/macros removed.
- **Env-var escape hatch.** `const rust_lib` now honors `ENV["ICEBERG_RUST_FFI_LIB"]` (mirrors RustyObjectStore's `OBJECT_STORE_LIB`) so local/unreleased dylibs load in subprocesses such as ReTestItems workers, which run in a temp test env that does **not** inherit a `LocalPreferences.toml` override.
- **Versions:** `iceberg_rust_ffi` crate + `RustyIceberg.jl` → `0.9.0`; `[compat] iceberg_rust_ffi_jll = "0.9"`.

Organized as two commits: the consolidation, then the per-file buffer-limit knobs (+ the `cargo fmt`/`clippy` fixes from the first CI run).

## Test plan

- [x] `cargo test` — crate compiles; `perf_config_abi_tests` (struct size/align/offsets, 8× u64) passes; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- [x] `test/perf_config_tests.jl` — server-free binary-compat round-trip (`isbits`, `sizeof == 8 × u64`, `iceberg_perf_config_roundtrip` echo with 8 distinct sentinels) verifies the Julia ↔ Rust struct layout agree.
- [x] `test/scan_tests.jl` migrated to the new construction API.
- [x] Verified end-to-end from raicode (iceberg load unit suite, 131377/131377) against this branch via `ENV["ICEBERG_RUST_FFI_LIB"]`.
- [ ] `test-julia-*` CI — green once `iceberg_rust_ffi_jll 0.9.x` is published (step 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RAI-50776]: https://relationalai.atlassian.net/browse/RAI-50776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ