### PR TITLE
Classify DNS resolution errors as IO_NETWORK

### DIFF
--- a/iceberg_rust_ffi/src/error_codes.rs
+++ b/iceberg_rust_ffi/src/error_codes.rs
@@ -377,6 +377,7 @@ fn classify_message(detail: &str) -> (IcebergErrorCode, String) {
         || lower.contains("connection reset")
         || lower.contains("timed out")
         || lower.contains("network error")
+        || lower.contains("dns error")
     {
         return (IcebergErrorCode::IO_NETWORK, "Network error".into());
     }


### PR DESCRIPTION
## Summary
- A DNS resolution failure (`dns error: proto error: no records found ...` from hickory-resolver) didn't match any substring check in `classify_message()` and fell through to the `INTERNAL` catch-all, even though it's a network-connectivity condition.
- Adds `"dns error"` to the `IO_NETWORK` pattern list so these classify consistently with other connection failures (refused/reset/timed out).

## Test plan
- [ ] `cargo test` in `iceberg_rust_ffi` (existing error-classification tests in `test/error_tests.jl` / Rust unit tests)
- [ ] Manually verify a DNS-unreachable Iceberg REST catalog host now surfaces `IcebergException: IO_NETWORK` instead of `INTERNAL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)