### PR TITLE
Bump object_store_ffi to pick up the flate2 zlib-rs fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustyIceberg"
 uuid = "390bdf5b-b624-43dc-a846-0ef7a3405804"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/iceberg_rust_ffi/Cargo.lock
+++ b/iceberg_rust_ffi/Cargo.lock
@@ -1245,7 +1245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1879,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "iceberg_rust_ffi"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2311,16 +2310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879917b256f6317769b9f374b435805a8697013098aacce5a38ac106cd6a9469"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "link-section"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,8 +2639,8 @@ dependencies = [
 
 [[package]]
 name = "object_store_ffi"
-version = "0.12.3"
-source = "git+https://github.com/RelationalAI/object_store_ffi?rev=79b08071c7a1642532b5891253280861eca9e44e#79b08071c7a1642532b5891253280861eca9e44e"
+version = "0.12.9"
+source = "git+https://github.com/RelationalAI/object_store_ffi?rev=2031546098060f4350831a5d19c22a275f6088ed#2031546098060f4350831a5d19c22a275f6088ed"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/iceberg_rust_ffi/Cargo.lock
+++ b/iceberg_rust_ffi/Cargo.lock
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "object_store_ffi"
 version = "0.12.9"
-source = "git+https://github.com/RelationalAI/object_store_ffi?rev=2031546098060f4350831a5d19c22a275f6088ed#2031546098060f4350831a5d19c22a275f6088ed"
+source = "git+https://github.com/RelationalAI/object_store_ffi?rev=bbbbd2f0ab0d609416014cef0d124efa99a515f3#bbbbd2f0ab0d609416014cef0d124efa99a515f3"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceberg_rust_ffi"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]
@@ -14,7 +14,7 @@ julia = []
 [dependencies]
 iceberg = { git = "https://github.com/RelationalAI/iceberg-rust.git", rev = "1953bcee83b135848c69755b5e8eef101dcd155e", features = ["storage-azdls"] }
 iceberg-catalog-rest = { git = "https://github.com/RelationalAI/iceberg-rust.git", rev = "1953bcee83b135848c69755b5e8eef101dcd155e" }
-object_store_ffi = { git = "https://github.com/RelationalAI/object_store_ffi", rev = "79b08071c7a1642532b5891253280861eca9e44e", default-features = false }
+object_store_ffi = { git = "https://github.com/RelationalAI/object_store_ffi", rev = "2031546098060f4350831a5d19c22a275f6088ed", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 futures = "0.3"
 libc = "0.2"

--- a/iceberg_rust_ffi/Cargo.toml
+++ b/iceberg_rust_ffi/Cargo.toml
@@ -14,7 +14,7 @@ julia = []
 [dependencies]
 iceberg = { git = "https://github.com/RelationalAI/iceberg-rust.git", rev = "1953bcee83b135848c69755b5e8eef101dcd155e", features = ["storage-azdls"] }
 iceberg-catalog-rest = { git = "https://github.com/RelationalAI/iceberg-rust.git", rev = "1953bcee83b135848c69755b5e8eef101dcd155e" }
-object_store_ffi = { git = "https://github.com/RelationalAI/object_store_ffi", rev = "2031546098060f4350831a5d19c22a275f6088ed", default-features = false }
+object_store_ffi = { git = "https://github.com/RelationalAI/object_store_ffi", rev = "bbbbd2f0ab0d609416014cef0d124efa99a515f3", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 futures = "0.3"
 libc = "0.2"


### PR DESCRIPTION
## Summary

- Points at [RelationalAI/object_store_ffi@2031546](https://github.com/RelationalAI/object_store_ffi/commit/2031546098060f4350831a5d19c22a275f6088ed) ([object_store_ffi#48](https://github.com/RelationalAI/object_store_ffi/pull/48), still open as of this PR), which switches `object_store_ffi`'s `flate2` dependency from the `zlib-ng` backend to `zlib-rs` (pure Rust, no C compiler needed).
- `zlib-ng` was failing to cross-compile on BinaryBuilder's `aarch64-apple-darwin` toolchain: `zlib-ng`'s CMake ARMv8 CRC32 feature-detection incorrectly concluded Clang 22 lacks native `__crc32b`/`__crc32h`/`__crc32w` intrinsics, so it included its own polyfill header, which then collided with Clang's own `arm_acle.h` (which already defines them) — `redefinition of '__crc32b'` errors. Found while bumping `iceberg_rust_ffi_jll` in Yggdrasil ([JuliaPackaging/Yggdrasil#14575](https://github.com/JuliaPackaging/Yggdrasil/pull/14575)).
- This also removes a latent issue: `parquet` (via `iceberg-rust`) already uses `flate2`'s `zlib-rs` backend, so both `zlib-ng` and `zlib-rs` were being compiled into the same binary simultaneously — `flate2`'s own docs flag enabling more than one backend at once as producing undefined ordering behavior.
- Bumps `iceberg_rust_ffi`'s own version 0.9.1 → 0.9.2 (its `Cargo.toml` changed) and `Project.toml` to match.

⚠️ This PR's `rev` will need to be updated to the merge commit once `object_store_ffi#48` lands on its `main`, same as the pattern used for the `iceberg-rust` bump in #110.

## Test plan

- [x] `cargo test` (iceberg_rust_ffi) — 40 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --all -- --check` — clean
- [x] `make test-dev` — **27935 passed, 0 failed, 0 errored**, fully green, including the GZIP compression test (exercising the new `zlib-rs` backend path)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>